### PR TITLE
fix: ensure geocode test compatible with older Python

### DIFF
--- a/backend/tests/unit/services/test_geocode_service.py
+++ b/backend/tests/unit/services/test_geocode_service.py
@@ -23,7 +23,7 @@ async def test_reverse_geocode_parses_label(monkeypatch: MonkeyPatch):
         async def __aexit__(self, *exc_info):
             return None
 
-        async def get(self, url: str, params: dict | None = None, headers: dict | None = None):
+        async def get(self, url, params=None, headers=None):
             assert "reverse" in url
             assert params["point.lat"] == 1.0
             assert params["point.lon"] == 2.0


### PR DESCRIPTION
## Summary
- remove all typing from geocode service unit test dummy client to avoid runtime errors on Python <3.10

## Testing
- `DATABASE_PATH=../data/test.db pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a387e18fc4833186cb8925df47277e