### PR TITLE
feat: add address autocomplete for booking

### DIFF
--- a/frontend/src/components/AddressField.tsx
+++ b/frontend/src/components/AddressField.tsx
@@ -1,6 +1,7 @@
 // src/pages/Booking/components/AddressField.tsx
-import { TextField, InputAdornment, IconButton, CircularProgress } from "@mui/material";
+import { TextField, InputAdornment, IconButton, CircularProgress, Autocomplete } from "@mui/material";
 import MyLocationIcon from "@mui/icons-material/MyLocation";
+import { useAddressAutocomplete } from "@/hooks/useAddressAutocomplete";
 
 export function AddressField(props: {
   id: string;
@@ -19,16 +20,34 @@ export function AddressField(props: {
     </InputAdornment>
   ) : undefined;
 
+  const { suggestions, loading } = useAddressAutocomplete(props.value);
+
   return (
-    <TextField
-      id={props.id}
-      label={props.label}
-      value={props.value}
-      onChange={(e) => props.onChange(e.target.value)}
-      fullWidth
-      error={!!props.errorText}
-      helperText={props.errorText}
-      InputProps={{ endAdornment: adornment }}
+    <Autocomplete
+      freeSolo
+      options={suggestions.map((s) => s.display)}
+      inputValue={props.value}
+      onInputChange={(_e, val) => props.onChange(val)}
+      renderInput={(params) => (
+        <TextField
+          {...params}
+          id={props.id}
+          label={props.label}
+          fullWidth
+          error={!!props.errorText}
+          helperText={props.errorText}
+          InputProps={{
+            ...params.InputProps,
+            endAdornment: (
+              <>
+                {loading && <CircularProgress size={18} />}
+                {adornment}
+                {params.InputProps.endAdornment}
+              </>
+            ),
+          }}
+        />
+      )}
     />
   );
 }

--- a/frontend/src/hooks/useAddressAutocomplete.test.tsx
+++ b/frontend/src/hooks/useAddressAutocomplete.test.tsx
@@ -1,0 +1,32 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { describe, expect, test, vi } from "vitest";
+import { useAddressAutocomplete } from "./useAddressAutocomplete";
+
+const sample = [
+  {
+    address: {
+      unit: "12",
+      house_number: "34",
+      road: "Main St",
+      suburb: "Springfield",
+      postcode: "1234",
+    },
+  },
+];
+
+describe("useAddressAutocomplete", () => {
+  test("returns formatted suggestions", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => ({
+      ok: true,
+      json: async () => sample,
+    }) as any));
+
+    const { result } = renderHook(() => useAddressAutocomplete("123", { debounceMs: 0 }));
+
+    await waitFor(() => {
+      expect(result.current.suggestions[0].display).toBe("12/34 Main St Springfield 1234");
+    });
+
+    vi.unstubAllGlobals();
+  });
+});

--- a/frontend/src/hooks/useAddressAutocomplete.ts
+++ b/frontend/src/hooks/useAddressAutocomplete.ts
@@ -1,0 +1,58 @@
+import { useEffect, useState } from "react";
+import { CONFIG } from "@/config";
+import { formatAddress } from "@/lib/formatAddress";
+
+export interface AddressSuggestion {
+  display: string;
+}
+
+export function useAddressAutocomplete(query: string, options?: { debounceMs?: number }) {
+  const [suggestions, setSuggestions] = useState<AddressSuggestion[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!query) {
+      setSuggestions([]);
+      return;
+    }
+    const controller = new AbortController();
+    const timeout = setTimeout(async () => {
+      try {
+        setLoading(true);
+        const backend = CONFIG.API_BASE_URL as string | undefined;
+        let url: string;
+        if (backend) {
+          const u = new URL("/geocode/search", backend || window.location.origin);
+          u.searchParams.set("q", query);
+          url = u.toString();
+        } else {
+          url = `https://nominatim.openstreetmap.org/search?format=json&addressdetails=1&limit=5&q=${encodeURIComponent(query)}`;
+        }
+        const res = await fetch(url, { signal: controller.signal });
+        if (!res.ok) throw new Error("Autocomplete failed");
+        const data = await res.json();
+        const list = Array.isArray(data) ? data : data?.results || [];
+        setSuggestions(
+          list
+            .map((item: any) => ({ display: formatAddress(item.address || item) }))
+            .filter((s: AddressSuggestion) => !!s.display)
+        );
+      } catch (e) {
+        if (!controller.signal.aborted) {
+          console.warn(e);
+          setSuggestions([]);
+        }
+      } finally {
+        if (!controller.signal.aborted) setLoading(false);
+      }
+    }, options?.debounceMs ?? 300);
+
+    return () => {
+      clearTimeout(timeout);
+      controller.abort();
+    };
+  }, [query, options?.debounceMs]);
+
+  return { suggestions, loading };
+}
+

--- a/frontend/src/lib/formatAddress.ts
+++ b/frontend/src/lib/formatAddress.ts
@@ -1,0 +1,11 @@
+export function formatAddress(addr: any): string {
+  if (!addr) return "";
+  const unit = addr.unit || addr.flat_number || "";
+  const number = addr.house_number || "";
+  const street = addr.road || addr.pedestrian || addr.path || addr.street || "";
+  const suburb = addr.suburb || addr.neighbourhood || addr.town || addr.city || "";
+  const postcode = addr.postcode || "";
+
+  const unitNumber = [unit, number].filter(Boolean).join("/");
+  return [unitNumber, street, suburb, postcode].filter(Boolean).join(" ").trim();
+}

--- a/frontend/src/lib/geocoding.ts
+++ b/frontend/src/lib/geocoding.ts
@@ -1,6 +1,7 @@
 // src/lib/geocoding.ts
 // Reverse geocode helper. Prefer your backend proxy if available; fall back to Nominatim in dev.
 import { CONFIG } from "@/config";
+import { formatAddress } from "@/lib/formatAddress";
 
 export async function reverseGeocode(lat: number, lon: number): Promise<string> {
     
@@ -25,5 +26,5 @@ export async function reverseGeocode(lat: number, lon: number): Promise<string> 
   );
   if (!res.ok) throw new Error(`Reverse geocode failed: ${res.status}`);
   const json = await res.json();
-  return json.display_name ?? `${lat.toFixed(5)}, ${lon.toFixed(5)}`;
+  return formatAddress(json.address) || json.display_name || `${lat.toFixed(5)}, ${lon.toFixed(5)}`;
 }


### PR DESCRIPTION
## Summary
- add `useAddressAutocomplete` hook to fetch and format address suggestions
- enhance `AddressField` with MUI Autocomplete and suggestions
- unify reverse geocode formatting

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any, React Hook "use" is called...)*


------
https://chatgpt.com/codex/tasks/task_e_68a3f53dcfe88331b99f78bbdc1c9397