### PR TITLE
feat: display routes with Google Maps

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# Limo Booking App
+
+## Google Maps API Setup
+
+1. Create a Google Cloud project and enable the **Maps JavaScript**, **Distance Matrix**, and **Directions** APIs.
+2. Generate an API key and restrict it to your domains/IPs as appropriate.
+3. Expose the key to the backend as `GOOGLE_MAPS_API_KEY` (e.g. in your `.env` file or docker-compose). The backend uses this key to proxy requests to the Distance Matrix API.
+4. Store the same key in the application settings via the Admin dashboard or setup process so the frontend can render maps.
+5. Restart the backend after changing environment variables.
+
+With the key configured, the booking page displays a routed map and pricing uses accurate distance and duration metrics.

--- a/frontend/src/components/MapRoute.test.tsx
+++ b/frontend/src/components/MapRoute.test.tsx
@@ -1,12 +1,27 @@
 import { render, waitFor } from "@testing-library/react";
 import React from "react";
-import { afterEach, describe, expect, test, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { MapRoute } from "./MapRoute";
+
+beforeEach(() => {
+  (globalThis as any).google = {
+    maps: {
+      Map: vi.fn(),
+      DirectionsService: vi.fn(() => ({
+        route: vi.fn(() => Promise.resolve({ routes: [{ legs: [{ distance: { value: 1000 }, duration: { value: 600 } }] }] }))
+      })),
+      DirectionsRenderer: vi.fn(() => ({ setMap: vi.fn(), setDirections: vi.fn() })),
+      TravelMode: { DRIVING: "DRIVING" },
+    },
+  } as any;
+});
 
 afterEach(() => {
   vi.unstubAllGlobals();
   vi.resetModules();
   vi.clearAllMocks();
+  // @ts-ignore
+  delete (globalThis as any).google;
 });
 
 describe("MapRoute", () => {
@@ -15,7 +30,7 @@ describe("MapRoute", () => {
     const fetchMock = vi.fn(async () => ({ ok: true, json: async () => ({ km: 10, min: 15 }) })) as any;
     vi.stubGlobal("fetch", fetchMock);
     const onMetrics = vi.fn();
-    render(<MapRoute pickup="A" dropoff="B" onMetrics={onMetrics} />);
+    render(<MapRoute pickup="A" dropoff="B" apiKey="KEY" onMetrics={onMetrics} />);
     await waitFor(() => expect(onMetrics).toHaveBeenCalledWith(10, 15));
   });
 
@@ -24,11 +39,11 @@ describe("MapRoute", () => {
     const fetchMock = vi.fn(async () => ({ ok: true, json: async () => ({ km: 10, min: 15 }) })) as any;
     vi.stubGlobal("fetch", fetchMock);
     const onMetrics = vi.fn();
-    const { rerender } = render(<MapRoute pickup="" dropoff="B" onMetrics={onMetrics} />);
+    const { rerender } = render(<MapRoute pickup="" dropoff="B" apiKey="KEY" onMetrics={onMetrics} />);
     await new Promise((r) => setTimeout(r, 20));
     expect(onMetrics).not.toHaveBeenCalled();
 
-    rerender(<MapRoute pickup="A" dropoff="" onMetrics={onMetrics} />);
+    rerender(<MapRoute pickup="A" dropoff="" apiKey="KEY" onMetrics={onMetrics} />);
     await new Promise((r) => setTimeout(r, 20));
     expect(onMetrics).not.toHaveBeenCalled();
   });

--- a/frontend/src/components/MapRoute.tsx
+++ b/frontend/src/components/MapRoute.tsx
@@ -1,16 +1,22 @@
 // src/pages/Booking/components/MapRoute.tsx
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { useRouteMetrics } from "@/hooks/useRouteMetrics";
+
+// Google Maps JavaScript API exposes a global `google` object
+declare const google: any;
 
 type Props = {
   pickup: string;
   dropoff: string;
+  apiKey?: string;
   onMetrics?: (km: number, minutes: number) => void;
 };
 
-export function MapRoute({ pickup, dropoff, onMetrics }: Props) {
+export function MapRoute({ pickup, dropoff, apiKey, onMetrics }: Props) {
   const getMetrics = useRouteMetrics();
+  const mapRef = useRef<HTMLDivElement>(null);
 
+  // Compute distance & duration via backend proxy (Distance Matrix)
   useEffect(() => {
     let cancelled = false;
     async function compute() {
@@ -24,5 +30,51 @@ export function MapRoute({ pickup, dropoff, onMetrics }: Props) {
     };
   }, [pickup, dropoff, onMetrics, getMetrics]);
 
-  return <div id="map" />;
+  // Load Google Maps script & render route using Directions API
+  useEffect(() => {
+    if (!pickup || !dropoff || !apiKey || !mapRef.current) return;
+    let cancelled = false;
+
+    function loadScript(): Promise<typeof google> {
+      const w = window as any;
+      if (w.google?.maps) return Promise.resolve(w.google);
+      return new Promise((resolve, reject) => {
+        const script = document.createElement("script");
+        script.src = `https://maps.googleapis.com/maps/api/js?key=${apiKey}`;
+        script.async = true;
+        script.onload = () => resolve(w.google);
+        script.onerror = reject;
+        document.head.appendChild(script);
+      });
+    }
+
+    loadScript()
+      .then(() => {
+        if (cancelled || !mapRef.current) return;
+        const map = new google.maps.Map(mapRef.current, {
+          zoom: 7,
+          center: { lat: 0, lng: 0 },
+        });
+        const service = new google.maps.DirectionsService();
+        const renderer = new google.maps.DirectionsRenderer();
+        renderer.setMap(map);
+        service
+          .route({
+            origin: pickup,
+            destination: dropoff,
+            travelMode: google.maps.TravelMode.DRIVING,
+          })
+          .then((result) => {
+            if (!cancelled) renderer.setDirections(result);
+          })
+          .catch((err) => console.error(err));
+      })
+      .catch((err) => console.error(err));
+
+    return () => {
+      cancelled = true;
+    };
+  }, [pickup, dropoff, apiKey]);
+
+  return <div id="map" ref={mapRef} style={{ width: "100%", height: 300 }} />;
 }

--- a/frontend/src/hooks/useSettings.test.tsx
+++ b/frontend/src/hooks/useSettings.test.tsx
@@ -3,7 +3,7 @@ import { describe, expect, test, vi } from "vitest";
 import { useSettings } from "./useSettings";
 
 class FakeSettingsApi {
-  apiGetSettingsSettingsGet = vi.fn(async () => ({ data: { flagfall: 3, per_km_rate: 2, per_minute_rate: 1, account_mode: false } }));
+  apiGetSettingsSettingsGet = vi.fn(async () => ({ data: { flagfall: 3, per_km_rate: 2, per_minute_rate: 1, account_mode: false, google_maps_api_key: "KEY" } }));
 }
 
 describe("useSettings", () => {
@@ -14,7 +14,7 @@ describe("useSettings", () => {
     expect(result.current.loading).toBe(true);
     await waitFor(() => expect(result.current.loading).toBe(false));
     expect(api.apiGetSettingsSettingsGet).toHaveBeenCalled();
-    expect(result.current.data).toEqual({ flagfall: 3, per_km_rate: 2, per_minute_rate: 1, account_mode: false });
+    expect(result.current.data).toEqual({ flagfall: 3, per_km_rate: 2, per_minute_rate: 1, account_mode: false, google_maps_api_key: "KEY" });
     expect(result.current.error).toBeNull();
   });
 

--- a/frontend/src/hooks/useSettings.ts
+++ b/frontend/src/hooks/useSettings.ts
@@ -9,6 +9,7 @@ export type AppSettings = {
   per_km_rate: number;
   per_minute_rate: number;
   account_mode: boolean;
+  google_maps_api_key: string;
 };
 
 export function useSettings(api: SettingsApi) {

--- a/frontend/src/pages/Booking/BookingPage.tsx
+++ b/frontend/src/pages/Booking/BookingPage.tsx
@@ -144,6 +144,7 @@ export default function BookingPage() {
                 <MapRoute
                   pickup={pickupValue}
                   dropoff={dropoff}
+                  apiKey={settings?.google_maps_api_key}
                   onMetrics={(km, min) => {
                     setDistanceKm(km);
                     setDurationMin(min);


### PR DESCRIPTION
## Summary
- render mapped routes via Google Maps Directions API
- expose `google_maps_api_key` through settings and booking page
- document Google Maps API key setup

## Testing
- `pytest` *(fails: sqlite3.OperationalError)*
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a3f71889ac8331b4ca0ae92cc2b8d7