### PR TITLE
Add ride history and detail pages

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,6 +3,7 @@ import LoginPage from '@/pages/Auth/LoginPage';
 import BookingPage from '@/pages/Booking/BookingPage';
 import AdminDashboard from '@/pages/Admin/AdminDashboard';
 import RideHistoryPage from '@/pages/Booking/RideHistoryPage';
+import RideDetailsPage from '@/pages/Booking/RideDetailsPage';
 import RegisterPage from "@/pages/Auth/RegisterPage";
 import { useAuth } from "@/contexts/AuthContext"
 import NavBar from '@/components/NavBar';
@@ -31,9 +32,13 @@ function App() {
         path="/book" 
         element={ accessToken ? <BookingPage /> : <Navigate to="/login" /> } 
       />
-      <Route 
-        path="/history" 
-        element={ accessToken ? <RideHistoryPage /> : <Navigate to="/login" /> } 
+      <Route
+        path="/history"
+        element={ accessToken ? <RideHistoryPage /> : <Navigate to="/login" /> }
+      />
+      <Route
+        path="/history/:id"
+        element={ accessToken ? <RideDetailsPage /> : <Navigate to="/login" /> }
       />
 
       {/* Protected admin/driver route */}

--- a/frontend/src/pages/Booking/RideDetailsPage.tsx
+++ b/frontend/src/pages/Booking/RideDetailsPage.tsx
@@ -1,0 +1,106 @@
+import { useEffect, useState } from 'react';
+import { useLocation, useParams } from 'react-router-dom';
+import {
+  Box,
+  CircularProgress,
+  Stack,
+  Typography,
+} from '@mui/material';
+
+import { bookingsApi } from '@/components/ApiConfig';
+import type { BookingRead } from '@/api-client';
+import { MapRoute } from '@/components/MapRoute';
+
+function RideDetailsPage() {
+  const { id } = useParams<{ id: string }>();
+  const location = useLocation();
+
+  const [booking, setBooking] = useState<BookingRead | null>(
+    (location.state as BookingRead) || null,
+  );
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (booking || !id) return;
+
+    let alive = true;
+    setLoading(true);
+    (async () => {
+      try {
+        const res = await bookingsApi.apiListBookingsBookingsGet();
+        const found = (res.data as BookingRead[]).find((b) => b.id === Number(id));
+        if (alive) {
+          if (found) {
+            setBooking(found);
+          } else {
+            setError('Ride not found');
+          }
+        }
+      } catch (e: any) {
+        if (alive) setError(e?.message ?? 'Failed to load ride');
+      } finally {
+        if (alive) setLoading(false);
+      }
+    })();
+
+    return () => {
+      alive = false;
+    };
+  }, [booking, id]);
+
+  if (loading) {
+    return (
+      <Box sx={{ p: 2 }}>
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  if (error) {
+    return (
+      <Box sx={{ p: 2 }}>
+        <Typography color="error">{error}</Typography>
+      </Box>
+    );
+  }
+
+  if (!booking) {
+    return (
+      <Box sx={{ p: 2 }}>
+        <Typography>Ride not found.</Typography>
+      </Box>
+    );
+  }
+
+  return (
+    <Box sx={{ p: 2 }}>
+      <Typography variant="h4" gutterBottom>
+        Ride Details
+      </Typography>
+
+      <Stack spacing={1} sx={{ mb: 2 }}>
+        <Typography>
+          <strong>Pickup:</strong> {booking.pickup_location}
+        </Typography>
+        <Typography>
+          <strong>Destination:</strong> {booking.dropoff_location}
+        </Typography>
+        <Typography>
+          <strong>Ride Time:</strong> {new Date(booking.time).toLocaleString()}
+        </Typography>
+        <Typography>
+          <strong>Price:</strong> ${booking.price}
+        </Typography>
+        <Typography>
+          <strong>Status:</strong> {booking.status}
+        </Typography>
+      </Stack>
+
+      <MapRoute pickup={booking.pickup_location} dropoff={booking.dropoff_location} />
+    </Box>
+  );
+}
+
+export default RideDetailsPage;
+

--- a/frontend/src/pages/Booking/RideHistoryPage.tsx
+++ b/frontend/src/pages/Booking/RideHistoryPage.tsx
@@ -1,11 +1,101 @@
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import {
+  Box,
+  CircularProgress,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  Typography,
+} from '@mui/material';
 
-
+import { bookingsApi } from '@/components/ApiConfig';
+import type { BookingRead } from '@/api-client';
 
 function RideHistoryPage() {
+  const navigate = useNavigate();
 
-    return <h1>Ride History Page</h1>;
+  const [bookings, setBookings] = useState<BookingRead[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let alive = true;
+
+    (async () => {
+      try {
+        const res = await bookingsApi.apiListBookingsBookingsGet();
+        if (alive) setBookings(res.data as BookingRead[]);
+      } catch (e: any) {
+        if (alive) setError(e?.message ?? 'Failed to load bookings');
+      } finally {
+        if (alive) setLoading(false);
+      }
+    })();
+
+    return () => {
+      alive = false;
+    };
+  }, []);
+
+  if (loading) {
+    return (
+      <Box sx={{ p: 2 }}>
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  if (error) {
+    return (
+      <Box sx={{ p: 2 }}>
+        <Typography color="error">{error}</Typography>
+      </Box>
+    );
+  }
+
+  return (
+    <Box sx={{ p: 2 }}>
+      <Typography variant="h4" gutterBottom>
+        Ride History
+      </Typography>
+
+      {bookings.length === 0 ? (
+        <Typography>No rides found.</Typography>
+      ) : (
+        <Table>
+          <TableHead>
+            <TableRow>
+              <TableCell>Pickup</TableCell>
+              <TableCell>Destination</TableCell>
+              <TableCell>Ride Time</TableCell>
+              <TableCell>Price</TableCell>
+              <TableCell>Status</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {bookings.map((b) => (
+              <TableRow
+                key={b.id}
+                hover
+                sx={{ cursor: 'pointer' }}
+                onClick={() => navigate(`/history/${b.id}`, { state: b })}
+              >
+                <TableCell>{b.pickup_location}</TableCell>
+                <TableCell>{b.dropoff_location}</TableCell>
+                <TableCell>{new Date(b.time).toLocaleString()}</TableCell>
+                <TableCell>${b.price}</TableCell>
+                <TableCell>{b.status}</TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      )}
+    </Box>
+  );
 }
 
+export default RideHistoryPage;
 
-
-export default RideHistoryPage


### PR DESCRIPTION
## Summary
- implement ride history table for current user bookings
- add ride detail page with Google Maps route
- register history detail routing in app

## Testing
- `cd frontend && npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68a42a5a5a008331ae019b8fa4146c8b