### PR TITLE
Ensure AddressField calls onBlur with latest value

### DIFF
--- a/frontend/src/components/AddressField.tsx
+++ b/frontend/src/components/AddressField.tsx
@@ -29,6 +29,7 @@ export function AddressField(props: {
       options={suggestions.map((s) => s.display)}
       inputValue={props.value}
       onInputChange={(_e, val) => props.onChange(val)}
+      onBlur={() => props.onBlur?.(props.value)}
       renderInput={(params) => (
         <TextField
           {...params}


### PR DESCRIPTION
## Summary
- call `onBlur` handler in `AddressField` with the current input value

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68a432870f4c83318f6c145bcca0b425