### PR TITLE
fix: encode route metrics parameters

### DIFF
--- a/frontend/src/hooks/useRouteMetrics.test.tsx
+++ b/frontend/src/hooks/useRouteMetrics.test.tsx
@@ -29,4 +29,15 @@ describe("useRouteMetrics", () => {
     expect(await result.current("A", "B")).toBeNull();
     expect(await result.current("", "B")).toBeNull();
   });
+
+  test("encodes spaces in params", async () => {
+    vi.mock("@/config", () => ({ CONFIG: { API_BASE_URL: "http://api" } }));
+    const fetchMock = vi.fn(async (url: string) => {
+      expect(url).toBe("http://api/route-metrics?pickup=A%20B&dropoff=C%20D");
+      return { ok: true, json: async () => ({ km: 1, min: 2 }) } as any;
+    });
+    vi.stubGlobal("fetch", fetchMock as any);
+    const { result } = renderHook(() => useRouteMetrics());
+    await result.current("A B", "C D");
+  });
 });

--- a/frontend/src/hooks/useRouteMetrics.ts
+++ b/frontend/src/hooks/useRouteMetrics.ts
@@ -9,11 +9,14 @@ export function useRouteMetrics() {
     if (!pickup || !dropoff) return null;
     try {
       const base = CONFIG.API_BASE_URL || "";
-      const url = new URL("/route-metrics", base || window.location.origin);
-      url.searchParams.set("pickup", pickup);
-      url.searchParams.set("dropoff", dropoff);
+      const origin = base || window.location.origin;
+      const url = new URL("/route-metrics", origin);
+      url.search = `pickup=${encodeURIComponent(pickup)}&dropoff=${encodeURIComponent(dropoff)}`;
       const res = await fetch(url.toString());
-      if (!res.ok) return null;
+      if (!res.ok) {
+        console.error("Route metrics request failed", res.status);
+        return null;
+      }
       const data = await res.json();
       const km = Number(data?.km);
       const min = Number(data?.min);


### PR DESCRIPTION
## Summary
- avoid `+` in pickup/dropoff by using `encodeURIComponent`
- log route-metrics HTTP failures for easier debugging
- test that addresses with spaces are encoded correctly

## Testing
- `npm test -- --run`
- `pytest` *(fails: sqlalchemy.exc.OperationalError: database is locked)*

------
https://chatgpt.com/codex/tasks/task_e_68a42c01560083319717098dec791b7b