### PR TITLE
feat: add geocode search endpoint

### DIFF
--- a/backend/app/api/geocode.py
+++ b/backend/app/api/geocode.py
@@ -1,8 +1,8 @@
 # app/api/geocode.py
 from fastapi import APIRouter, Query
 
-from app.schemas.geocode import GeocodeResponse
-from app.services.geocode_service import reverse_geocode
+from app.schemas.geocode import GeocodeResponse, GeocodeSearchResponse
+from app.services.geocode_service import reverse_geocode, search_geocode
 
 router = APIRouter(prefix="/geocode", tags=["geocode"])
 
@@ -11,3 +11,16 @@ router = APIRouter(prefix="/geocode", tags=["geocode"])
 async def api_reverse_geocode(lat: float = Query(...), lon: float = Query(...)) -> GeocodeResponse:
     address = await reverse_geocode(lat, lon)
     return GeocodeResponse(address=address)
+
+
+@router.get(
+    "/search",
+    response_model=GeocodeSearchResponse,
+    response_model_exclude_none=True,
+)
+async def api_geocode_search(
+    q: str = Query(..., min_length=1),
+    limit: int = Query(5, ge=1, le=20),
+) -> GeocodeSearchResponse:
+    results = await search_geocode(q, limit)
+    return GeocodeSearchResponse(results=results)

--- a/backend/app/schemas/geocode.py
+++ b/backend/app/schemas/geocode.py
@@ -1,6 +1,24 @@
 # app/schemas/geocode.py
+from typing import List, Optional
+
 from pydantic import BaseModel
 
 
 class GeocodeResponse(BaseModel):
     address: str
+
+
+class AddressComponents(BaseModel):
+    house_number: Optional[str] = None
+    road: Optional[str] = None
+    suburb: Optional[str] = None
+    city: Optional[str] = None
+    postcode: Optional[str] = None
+
+
+class GeocodeSearchResult(BaseModel):
+    address: AddressComponents
+
+
+class GeocodeSearchResponse(BaseModel):
+    results: List[GeocodeSearchResult]

--- a/backend/app/services/geocode_service.py
+++ b/backend/app/services/geocode_service.py
@@ -52,3 +52,58 @@ async def reverse_geocode(lat: float, lon: float) -> str:
     )
 
     return address or f"{lat:.5f}, {lon:.5f}"
+
+
+async def search_geocode(query: str, limit: int = 5) -> list[dict]:
+    """Search for addresses matching free-form text.
+
+    This function proxies to the OpenRouteService forward geocoding endpoint
+    and returns a simplified list of address components suitable for the
+    frontend autocomplete feature. It requires an API key configured via
+    settings.  The caller is expected to handle any exceptions raised by
+    network failures or non-2xx responses.
+
+    Parameters
+    ----------
+    query: str
+        Free-form search text.
+    limit: int, optional
+        Maximum number of suggestions to return (default 5).
+
+    Returns
+    -------
+    list[dict]
+        A list of dictionaries each containing an ``address`` key mapping to
+        address components (``house_number``, ``road``, ``suburb``, ``city``,
+        ``postcode``) when available.
+    """
+
+    settings = get_settings()
+    api_key = settings.ors_api_key
+
+    url = "https://api.openrouteservice.org/geocode/search"
+    params = {
+        "api_key": api_key,
+        "text": query,
+        "size": limit,
+    }
+    headers = {"Accept": "application/json"}
+
+    async with httpx.AsyncClient() as client:
+        res = await client.get(url, params=params, headers=headers)
+        res.raise_for_status()
+        data = res.json()
+
+    results: list[dict] = []
+    for feature in data.get("features", []):
+        props = feature.get("properties", {})
+        address = {
+            "house_number": props.get("housenumber"),
+            "road": props.get("street"),
+            "suburb": props.get("neighbourhood"),
+            "city": props.get("locality"),
+            "postcode": props.get("postalcode"),
+        }
+        results.append({"address": {k: v for k, v in address.items() if v}})
+
+    return results

--- a/backend/tests/unit/api/test_geocode_router.py
+++ b/backend/tests/unit/api/test_geocode_router.py
@@ -19,3 +19,18 @@ async def test_reverse_geocode_endpoint(monkeypatch: MonkeyPatch, client: AsyncC
     res = await client.get("/geocode/reverse?lat=1.0&lon=2.0")
     assert res.status_code == 200
     assert res.json() == {"address": "123 Fake St"}
+
+
+async def test_geocode_search_endpoint(monkeypatch: MonkeyPatch, client: AsyncClient):
+    from app.api import geocode as geocode_router
+
+    async def fake_search(q: str, limit: int = 5):  # type: ignore
+        assert q == "Main St"
+        assert limit == 5
+        return [{"address": {"road": "Main St"}}]
+
+    monkeypatch.setattr(geocode_router, "search_geocode", fake_search)
+
+    res = await client.get("/geocode/search?q=Main%20St")
+    assert res.status_code == 200
+    assert res.json() == {"results": [{"address": {"road": "Main St"}}]}

--- a/backend/tests/unit/services/test_geocode_service.py
+++ b/backend/tests/unit/services/test_geocode_service.py
@@ -36,3 +36,53 @@ async def test_reverse_geocode_parses_label(monkeypatch: MonkeyPatch):
 
     addr = await geocode_service.reverse_geocode(1.0, 2.0)
     assert addr == "123 Fake St"
+
+
+async def test_search_geocode_parses_results(monkeypatch: MonkeyPatch):
+    class DummyResp:
+        status_code = 200
+
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self) -> dict:
+            return {
+                "features": [
+                    {
+                        "properties": {
+                            "housenumber": "10",
+                            "street": "Main St",
+                            "locality": "Springfield",
+                            "postalcode": "12345",
+                        }
+                    }
+                ]
+            }
+
+    class DummyClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc_info):
+            return None
+
+        async def get(self, url, params=None, headers=None):  # type: ignore[override]
+            assert "search" in url
+            assert params["text"] == "Main"
+            assert params["size"] == 5
+            return DummyResp()
+
+    monkeypatch.setattr(geocode_service, "httpx", type("X", (), {"AsyncClient": DummyClient}))
+    monkeypatch.setattr(geocode_service, "get_settings", lambda: type("S", (), {"ors_api_key": "KEY"})())
+
+    results = await geocode_service.search_geocode("Main")
+    assert results == [
+        {
+            "address": {
+                "house_number": "10",
+                "road": "Main St",
+                "city": "Springfield",
+                "postcode": "12345",
+            }
+        }
+    ]


### PR DESCRIPTION
## Summary
- add `/geocode/search` endpoint backed by OpenRouteService forward geocoding
- include schemas and service for address suggestions
- cover geocode search with unit tests

## Testing
- `DATABASE_PATH=.pytest.db pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a431dc633c833184c405b3ed06394a