### PR TITLE
test: cover geocode fallback cases

### DIFF
--- a/backend/tests/unit/services/test_geocode_service.py
+++ b/backend/tests/unit/services/test_geocode_service.py
@@ -86,3 +86,61 @@ async def test_search_geocode_parses_results(monkeypatch: MonkeyPatch):
             }
         }
     ]
+
+
+@pytest.mark.xfail(reason="reverse_geocode fails on empty response", raises=IndexError)
+async def test_reverse_geocode_falls_back_to_coordinates(monkeypatch: MonkeyPatch):
+    class DummyResp:
+        status_code = 200
+
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self) -> dict:
+            # Response with no features should fall back to "lat, lon"
+            return {"features": []}
+
+    class DummyClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc_info):
+            return None
+
+        async def get(self, url, params=None, headers=None):  # type: ignore[override]
+            return DummyResp()
+
+    monkeypatch.setattr(geocode_service, "httpx", type("X", (), {"AsyncClient": DummyClient}))
+    monkeypatch.setattr(geocode_service, "get_settings", lambda: type("S", (), {"ors_api_key": "KEY"})())
+
+    # Expected behaviour: gracefully fall back to formatted coordinates
+    addr = await geocode_service.reverse_geocode(1.0, 2.0)
+    assert addr == "1.00000, 2.00000"
+
+
+async def test_search_geocode_returns_empty_when_no_features(monkeypatch: MonkeyPatch):
+    class DummyResp:
+        status_code = 200
+
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self) -> dict:
+            # Empty list of features from provider
+            return {"features": []}
+
+    class DummyClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc_info):
+            return None
+
+        async def get(self, url, params=None, headers=None):  # type: ignore[override]
+            return DummyResp()
+
+    monkeypatch.setattr(geocode_service, "httpx", type("X", (), {"AsyncClient": DummyClient}))
+    monkeypatch.setattr(geocode_service, "get_settings", lambda: type("S", (), {"ors_api_key": "KEY"})())
+
+    results = await geocode_service.search_geocode("Nowhere")
+    assert results == []


### PR DESCRIPTION
## Summary
- add tests for geocode service when provider returns empty data
- document current bug where reverse_geocode crashes on empty features

## Testing
- `pytest`
- `npm test` *(fails: ReferenceError in MapRoute component)*

------
https://chatgpt.com/codex/tasks/task_e_68a43ff650f08331befa500c52ad6a28