### PR TITLE
Handle MapRoute errors and memoize metrics hook

### DIFF
--- a/frontend/src/components/MapRoute.tsx
+++ b/frontend/src/components/MapRoute.tsx
@@ -13,16 +13,16 @@ type Props = {
    * Optional API key to override the default from configuration.
    * Primarily used in tests or when the key is provided dynamically
    * (e.g. fetched from backend settings).
-   */
+  */
   apiKey?: string;
   onMetrics?: (km: number, minutes: number) => void;
-  apiKey?: string;
 };
 
 export function MapRoute({ pickup, dropoff, onMetrics, apiKey }: Props) {
   const getMetrics = useRouteMetrics();
   const mapRef = useRef<HTMLDivElement>(null);
   const resolvedKey = apiKey ?? CONFIG.GOOGLE_MAPS_API_KEY;
+  const [failed, setFailed] = useState(false);
 
   // Compute distance & duration via backend proxy (Distance Matrix)
   useEffect(() => {
@@ -81,11 +81,13 @@ export function MapRoute({ pickup, dropoff, onMetrics, apiKey }: Props) {
         } catch (err) {
           console.error(err);
           if (mapRef.current) mapRef.current.textContent = "Map failed to load";
+          setFailed(true);
         }
       })
       .catch((err) => {
         console.error(err);
         if (mapRef.current) mapRef.current.textContent = "Map failed to load";
+        setFailed(true);
       });
 
     return () => {

--- a/frontend/src/hooks/useRouteMetrics.ts
+++ b/frontend/src/hooks/useRouteMetrics.ts
@@ -3,7 +3,7 @@ import { CONFIG } from "@/config";
 import { useCallback } from "react";
 
 export function useRouteMetrics() {
-  return async function getMetrics(
+  return useCallback(async function getMetrics(
     pickup: string,
     dropoff: string
   ): Promise<{ km: number; min: number } | null> {
@@ -27,5 +27,5 @@ export function useRouteMetrics() {
       console.error(err);
       return null;
     }
-  };
+  }, []);
 }


### PR DESCRIPTION
## Summary
- Handle Google Maps script failures in MapRoute with a fallback message
- Memoize useRouteMetrics hook to avoid unnecessary re-fetches

## Testing
- `npm test`
- `npm run e2e` *(fails: connect ECONNREFUSED ::1:8000)*

------
https://chatgpt.com/codex/tasks/task_e_68a441c72c3483319eda19e0ce39fe5b