### PR TITLE
docs: expand project setup and environment details

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,75 @@
 # Limo Booking App
 
+A full-stack application for scheduling limousine rides. The backend is built with FastAPI and the frontend uses React, TypeScript and Vite.
+
+## Project structure
+
+- `backend/` – FastAPI service and REST API (see `backend/README.md` for auto-generated API docs).
+- `frontend/` – React application for customers and administrators.
+
+## Prerequisites
+
+- Python 3.11+
+- Node.js 18+
+
+## Environment variables
+
+The application relies on several external services. Set these variables in a `.env` file or your environment:
+
+| Variable | Purpose |
+| --- | --- |
+| `GOOGLE_MAPS_API_KEY` | Distance and duration metrics via Google Distance Matrix. |
+| `ORS_API_KEY` | Geocoding via the OpenRouteService API. |
+| `JWT_SECRET_KEY` | Secret used to sign access tokens. |
+| `VITE_API_BASE_URL` | (frontend) Base URL of the backend API. |
+| `VITE_GOOGLE_MAPS_API_KEY` | (frontend) Google Maps key for map rendering. |
+
+## Setup
+
+1. Install backend dependencies:
+   ```bash
+   cd backend
+   pip install -r requirements.txt
+   ```
+2. Install frontend dependencies:
+   ```bash
+   cd ../frontend
+   npm install
+   ```
+
+## Running
+
+### Using Docker
+
+From the repository root run:
+
+```bash
+docker-compose up --build
+```
+
+This starts both backend and frontend services.
+
+### Local development
+
+Run the backend:
+
+```bash
+cd backend
+uvicorn app.main:app --reload
+```
+
+Run the frontend:
+
+```bash
+cd frontend
+npm run dev
+```
+
+## Testing
+
+- Backend: `cd backend && pytest`
+- Frontend: `cd frontend && npm test`
+
 ## Google Maps API Setup
 
 1. Create a Google Cloud project and enable the **Maps JavaScript**, **Distance Matrix**, and **Directions** APIs.

--- a/backend/README.md
+++ b/backend/README.md
@@ -23,9 +23,12 @@ headingLevel: 2
 
 ## Configuration
 
-Set required environment variables before running the backend. For route metrics
-support, create a Google Maps API key and expose it as `GOOGLE_MAPS_API_KEY`
-in the appropriate `.env.*` file or your deployment environment.
+Set required environment variables before running the backend:
+
+- `GOOGLE_MAPS_API_KEY` – used for distance and duration metrics via Google Distance Matrix.
+- `ORS_API_KEY` – used for geocoding with the OpenRouteService API.
+
+Expose these in the appropriate `.env.*` files or your deployment environment.
 
 > Scroll down for code samples, example requests and responses. Select a language for code samples from the tabs above or the mobile navigation menu.
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,69 +1,35 @@
-# React + TypeScript + Vite
+# Frontend
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+React + TypeScript single-page application for the Limo Booking App.
 
-Currently, two official plugins are available:
+## Setup
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Babel](https://babeljs.io/) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
+Install dependencies:
 
-## Expanding the ESLint configuration
-
-If you are developing a production application, we recommend updating the configuration to enable type-aware lint rules:
-
-```js
-export default tseslint.config([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
-
-      // Remove tseslint.configs.recommended and replace with this
-      ...tseslint.configs.recommendedTypeChecked,
-      // Alternatively, use this for stricter rules
-      ...tseslint.configs.strictTypeChecked,
-      // Optionally, add this for stylistic rules
-      ...tseslint.configs.stylisticTypeChecked,
-
-      // Other configs...
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
+```bash
+npm install
 ```
 
-You can also install [eslint-plugin-react-x](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x) and [eslint-plugin-react-dom](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-dom) for React-specific lint rules:
+Create a `.env` file or export the following variables:
 
-```js
-// eslint.config.js
-import reactX from 'eslint-plugin-react-x'
-import reactDom from 'eslint-plugin-react-dom'
+- `VITE_API_BASE_URL` – URL of the backend API (e.g. `http://localhost:8000`).
+- `VITE_GOOGLE_MAPS_API_KEY` – Google Maps key for rendering maps.
 
-export default tseslint.config([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
-      // Enable lint rules for React
-      reactX.configs['recommended-typescript'],
-      // Enable lint rules for React DOM
-      reactDom.configs.recommended,
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
+## Development
+
+Start the development server:
+
+```bash
+npm run dev
 ```
+
+## Testing
+
+Run unit tests with:
+
+```bash
+npm test
+```
+
+Additional scripts for coverage or end-to-end tests are available in `package.json`.
+


### PR DESCRIPTION
## Summary
- expand top-level README with project overview, environment variables and run instructions
- document required API keys in backend docs
- add project-specific setup and test notes to frontend README

## Testing
- `cd backend && pip install -r requirements.txt`
- `cd backend && pytest`
- `cd frontend && npm test -- --run` *(fails: ReferenceError in MapRoute tests)*

------
https://chatgpt.com/codex/tasks/task_e_68a440e9cc1c833190d14b26d7a4f9f3