### PR TITLE
feat: add structured backend logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,13 @@ The application relies on several external services. Set these variables in a `.
 | `JWT_SECRET_KEY` | Secret used to sign access tokens. |
 | `VITE_API_BASE_URL` | (frontend) Base URL of the backend API. |
 | `VITE_GOOGLE_MAPS_API_KEY` | (frontend) Google Maps key for map rendering. |
+| `LOG_LEVEL` | (backend) Logging verbosity (`DEBUG`, `INFO`, etc.). Defaults to `INFO`. |
+
+## Logging
+
+The backend uses Python's standard logging. Set the `LOG_LEVEL` environment
+variable to control verbosity and view structured messages in Docker logs. Each
+HTTP request is logged with its method, path, status code, and processing time.
 
 ## Setup
 

--- a/backend/app/api/bookings.py
+++ b/backend/app/api/bookings.py
@@ -1,6 +1,7 @@
 # app/api/bookings.py
 """Booking management API endpoints."""
 
+import logging
 from fastapi import APIRouter, Depends, status
 from sqlalchemy.ext.asyncio import AsyncSession
 from typing import List
@@ -9,6 +10,8 @@ from app.schemas.booking import BookingCreate, BookingRead, BookingUpdate
 from app.services.booking_service import create_booking, list_bookings, update_booking_status, delete_booking
 from app.dependencies import get_db, get_current_user
 from app.models.user import User  # optional for type hints
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(
     prefix="/bookings",
@@ -20,6 +23,7 @@ router = APIRouter(
 @router.post("", response_model=BookingRead, status_code=status.HTTP_201_CREATED)
 async def api_create_booking(data: BookingCreate, db: AsyncSession = Depends(get_db), user: User = Depends(get_current_user)) -> BookingRead:
     """Create a new booking for the current user."""
+    logger.info("user %s creating booking", user.id)
     booking = await create_booking(db=db, data=data, user_id=user.id)
     return booking
 
@@ -27,6 +31,7 @@ async def api_create_booking(data: BookingCreate, db: AsyncSession = Depends(get
 @router.get("", response_model=List[BookingRead])
 async def api_list_bookings(skip: int = 0, limit: int = 100, db: AsyncSession = Depends(get_db), user: User  = Depends(get_current_user)):
     """List bookings for the authenticated user."""
+    logger.info("user %s listing bookings", user.id)
     bookings = await list_bookings(db, user.id, skip, limit)
     return bookings
 
@@ -34,6 +39,7 @@ async def api_list_bookings(skip: int = 0, limit: int = 100, db: AsyncSession = 
 @router.patch("/{booking_id}/status", response_model=BookingRead)
 async def api_update_status(booking_id: int, data: BookingUpdate, db: AsyncSession = Depends(get_db), user: User  = Depends(get_current_user)):
     """Update the status of an existing booking."""
+    logger.info("user %s updating booking %s", user.id, booking_id)
     booking_status = await update_booking_status(db, booking_id, data)
     return booking_status
 
@@ -41,4 +47,5 @@ async def api_update_status(booking_id: int, data: BookingUpdate, db: AsyncSessi
 @router.delete("/{booking_id}", status_code=status.HTTP_204_NO_CONTENT)
 async def api_delete_booking(booking_id: int, db: AsyncSession = Depends(get_db), user: User  = Depends(get_current_user)):
     """Remove a booking from the system."""
+    logger.info("user %s deleting booking %s", user.id, booking_id)
     await delete_booking(db, booking_id)

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -83,6 +83,7 @@ class Settings(BaseSettings):
     api_prefix: str = os.getenv("API_PREFIX","undefined")
     env: str = _ENV
     debug: bool = os.getenv("DEBUG", "false").lower() in {"1", "true", "yes", "on"}
+    log_level: str = os.getenv("LOG_LEVEL", "INFO")
 
     # CORS (allow multiple origins via comma-separated list)
     allow_origins: str = os.getenv("CORS_ALLOW_ORIGINS", "undefined")

--- a/backend/app/core/logging.py
+++ b/backend/app/core/logging.py
@@ -1,0 +1,57 @@
+import logging
+from logging.config import dictConfig
+from typing import Callable
+
+from app.core.config import get_settings
+from time import time
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import Response
+
+
+def setup_logging() -> None:
+    """Configure application-wide logging."""
+    settings = get_settings()
+    log_level = settings.log_level.upper()
+    logging_config = {
+        "version": 1,
+        "disable_existing_loggers": False,
+        "formatters": {
+            "default": {
+                "format": "%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+                "datefmt": "%Y-%m-%d %H:%M:%S",
+            }
+        },
+        "handlers": {
+            "default": {
+                "class": "logging.StreamHandler",
+                "formatter": "default",
+                "stream": "ext://sys.stdout",
+            }
+        },
+        "root": {"level": log_level, "handlers": ["default"]},
+    }
+    dictConfig(logging_config)
+
+    # ensure uvicorn uses our configuration
+    for logger_name in ("uvicorn", "uvicorn.error", "uvicorn.access"):
+        logging.getLogger(logger_name).handlers = []
+        logging.getLogger(logger_name).propagate = True
+
+
+class RequestLoggingMiddleware(BaseHTTPMiddleware):
+    """Log basic request information for each HTTP request."""
+
+    async def dispatch(self, request: Request, call_next: Callable[[Request], Response]) -> Response:  # type: ignore[override]
+        logger = logging.getLogger("app.request")
+        start = time()
+        response = await call_next(request)
+        process_time = (time() - start) * 1000
+        logger.info(
+            "%s %s status=%s duration=%.2fms",
+            request.method,
+            request.url.path,
+            response.status_code,
+            process_time,
+        )
+        return response

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,11 +1,14 @@
 """Application entry point and API router configuration."""
 
+import logging
+from contextlib import asynccontextmanager
+
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import RedirectResponse
-from contextlib import asynccontextmanager
 
 from app.core.config import get_settings
+from app.core.logging import RequestLoggingMiddleware, setup_logging
 from app.db.database import database
 
 from app.api import (
@@ -19,7 +22,9 @@ from app.api import (
     users as users_router,
 
 )
+setup_logging()
 settings = get_settings()
+logger = logging.getLogger(__name__)
 
 def get_app() -> FastAPI:
     """For pytest: returns the singleton `app`."""
@@ -41,6 +46,8 @@ app = FastAPI(
     swagger_ui_parameters={"persistAuthorization": True},
     lifespan=lifespan,
 )
+app.add_middleware(RequestLoggingMiddleware)
+logger.info("Application startup complete", extra={"env": settings.env})
 
 if not settings.env == "production":
     # Global CORS configuration


### PR DESCRIPTION
## Summary
- configure global logging via LOG_LEVEL
- log every HTTP request and booking operation
- document logging options in README

## Testing
- `cd backend && pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a473feb3288331a9b6bea2f391752e