### PR TITLE
Add fare breakdown component to booking page

### DIFF
--- a/frontend/src/components/FareBreakdown.test.tsx
+++ b/frontend/src/components/FareBreakdown.test.tsx
@@ -1,0 +1,20 @@
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import { FareBreakdown } from "./FareBreakdown";
+
+describe("FareBreakdown", () => {
+  test("renders breakdown values", () => {
+    render(
+      <FareBreakdown
+        flagfall={5}
+        perKm={2}
+        perMin={1}
+        distanceKm={3}
+        durationMin={4}
+      />
+    );
+    expect(screen.getByText(/flagfall: \$5\.00/)).toBeInTheDocument();
+    expect(screen.getByText(/3\.00 km x \$2\.00/)).toBeInTheDocument();
+    expect(screen.getByText(/4\.00 min x \$1\.00/)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/FareBreakdown.tsx
+++ b/frontend/src/components/FareBreakdown.tsx
@@ -1,0 +1,33 @@
+import { Box, Typography } from "@mui/material";
+
+export interface FareBreakdownProps {
+  flagfall: number;
+  perKm: number;
+  perMin: number;
+  distanceKm?: number;
+  durationMin?: number;
+}
+
+export function FareBreakdown({
+  flagfall,
+  perKm,
+  perMin,
+  distanceKm,
+  durationMin,
+}: FareBreakdownProps) {
+  const dist = distanceKm ?? 0;
+  const dur = durationMin ?? 0;
+
+  return (
+    <Box mt={2}>
+      <Typography variant="subtitle1">Fare Breakdown</Typography>
+      <Typography>flagfall: ${flagfall.toFixed(2)}</Typography>
+      <Typography>
+        {dist.toFixed(2)} km x ${perKm.toFixed(2)}
+      </Typography>
+      <Typography>
+        {dur.toFixed(2)} min x ${perMin.toFixed(2)}
+      </Typography>
+    </Box>
+  );
+}

--- a/frontend/src/pages/Booking/BookingPage.tsx
+++ b/frontend/src/pages/Booking/BookingPage.tsx
@@ -18,6 +18,7 @@ import { minFutureDateTime } from "@/lib/datetime";
 import { AddressField } from "@/components/AddressField";
 import { DateTimeField } from "@/components/DateTimeField";
 import { PriceSummary } from "@/components/PriceSummary";
+import { FareBreakdown } from "@/components/FareBreakdown";
 import { MapRoute } from "@/components/MapRoute";
 import { MapProvider } from "@/components/MapProvider";
 
@@ -186,6 +187,13 @@ export default function BookingPage() {
                 price={pricing.price}
                 loading={pricing.loading || settingsLoading}
                 error={pricing.error}
+              />
+              <FareBreakdown
+                flagfall={tariff.flagfall}
+                perKm={tariff.perKm}
+                perMin={tariff.perMin}
+                distanceKm={distanceKm}
+                durationMin={durationMin}
               />
             </CardContent>
           </Card>


### PR DESCRIPTION
## Summary
- show fare breakdown component on booking page for development
- include tests for new FareBreakdown component

## Testing
- `npm test --prefix frontend -- --run` (fails: DevNotes.test.tsx, AdminDashboard.test.tsx)
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a47d41ee308331a043867284b67b86