### PR TITLE
feat: add back navigation on ride details

### DIFF
--- a/frontend/src/pages/Booking/RideDetailsPage.test.tsx
+++ b/frontend/src/pages/Booking/RideDetailsPage.test.tsx
@@ -1,0 +1,43 @@
+import { render } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import RideDetailsPage from './RideDetailsPage';
+import { http, HttpResponse } from 'msw';
+import { server } from '@/__tests__/setup/msw.server';
+import { apiUrl } from '@/__tests__/setup/msw.handlers';
+import { AuthProvider } from '@/contexts/AuthContext';
+
+test('Back button navigates to /history', async () => {
+  const booking = {
+    id: 1,
+    pickup_location: 'A',
+    dropoff_location: 'B',
+    time: new Date().toISOString(),
+    price: 10,
+    status: 'completed',
+  };
+
+  server.use(
+    http.get(apiUrl('/bookings'), () => HttpResponse.json([booking]))
+  );
+
+  render(
+    <AuthProvider>
+      <MemoryRouter initialEntries={['/history/1']}>
+        <Routes>
+          <Route path="/history/:id" element={<RideDetailsPage />} />
+          <Route path="/history" element={<h1>Ride History</h1>} />
+        </Routes>
+      </MemoryRouter>
+    </AuthProvider>,
+  );
+
+  expect(await screen.findByText(/Ride Details/i)).toBeInTheDocument();
+
+  await userEvent.click(screen.getByRole('link', { name: /back/i }));
+
+  expect(
+    await screen.findByRole('heading', { name: /ride history/i })
+  ).toBeInTheDocument();
+});

--- a/frontend/src/pages/Booking/RideDetailsPage.tsx
+++ b/frontend/src/pages/Booking/RideDetailsPage.tsx
@@ -1,11 +1,13 @@
 import { useEffect, useState } from 'react';
-import { useLocation, useParams } from 'react-router-dom';
+import { Link as RouterLink, useLocation, useParams } from 'react-router-dom';
 import {
   Box,
   CircularProgress,
   Stack,
   Typography,
+  IconButton,
 } from '@mui/material';
+import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 
 import { bookingsApi } from '@/components/ApiConfig';
 import type { BookingRead } from '@/api-client';
@@ -76,9 +78,16 @@ function RideDetailsPage() {
 
   return (
     <Box sx={{ p: 2 }}>
-      <Typography variant="h4" gutterBottom>
-        Ride Details
-      </Typography>
+      <Stack direction="row" alignItems="center" spacing={1} sx={{ mb: 2 }}>
+        <IconButton
+          component={RouterLink}
+          to="/history"
+          aria-label="Back to history"
+        >
+          <ArrowBackIcon />
+        </IconButton>
+        <Typography variant="h4">Ride Details</Typography>
+      </Stack>
 
       <Stack spacing={1} sx={{ mb: 2 }}>
         <Typography>


### PR DESCRIPTION
## Summary
- add back arrow linking to history on ride details page
- cover ride details back navigation with unit test

## Testing
- `npm run lint` *(fails: Unexpected any. Specify a different type in ProfilePage.tsx)*
- `npm --prefix frontend test src/pages/Booking/RideDetailsPage.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68a493b7098c8331abd1030d9d7e42b5