### PR TITLE
Refactor price summary to compute after valid inputs

### DIFF
--- a/frontend/src/components/PriceSummary.test.tsx
+++ b/frontend/src/components/PriceSummary.test.tsx
@@ -3,23 +3,55 @@ import React from "react";
 import { PriceSummary } from "./PriceSummary";
 
 describe("PriceSummary", () => {
-  test("shows loader when loading", () => {
-    render(<PriceSummary price={null} loading />);
-    expect(screen.getByRole("progressbar")).toBeInTheDocument();
+  test("renders nothing without valid addresses", () => {
+    const { container } = render(
+      <PriceSummary pickup="" dropoff="" rideTime="" flagfall={0} perKm={1} perMin={1} />
+    );
+    expect(container).toBeEmptyDOMElement();
   });
 
-  test("shows error when provided", () => {
-    render(<PriceSummary price={null} error="Oops" />);
-    expect(screen.getByText("Oops")).toBeInTheDocument();
+  test("renders formatted price when inputs complete", async () => {
+    render(
+      <PriceSummary
+        pickup="A"
+        dropoff="B"
+        rideTime="2025-01-01T10:00"
+        flagfall={0}
+        perKm={2}
+        perMin={1}
+        distanceKm={10}
+        durationMin={5}
+      />
+    );
+    expect(await screen.findByText("$25.00")).toBeInTheDocument();
   });
 
-  test("renders formatted price when available", () => {
-    render(<PriceSummary price={12.345} />);
-    expect(screen.getByText(/\$12\.35/)).toBeInTheDocument();
-  });
-
-  test("renders dash when price is null and no error/loading", () => {
-    render(<PriceSummary price={null} />);
-    expect(screen.getByText("—")).toBeInTheDocument();
+  test("recalculates when distance changes", async () => {
+    const { rerender } = render(
+      <PriceSummary
+        pickup="A"
+        dropoff="B"
+        rideTime="2025-01-01T10:00"
+        flagfall={0}
+        perKm={2}
+        perMin={1}
+        distanceKm={1}
+        durationMin={1}
+      />
+    );
+    expect(await screen.findByText("$3.00")).toBeInTheDocument();
+    rerender(
+      <PriceSummary
+        pickup="A"
+        dropoff="B"
+        rideTime="2025-01-01T10:00"
+        flagfall={0}
+        perKm={2}
+        perMin={1}
+        distanceKm={2}
+        durationMin={1}
+      />
+    );
+    expect(await screen.findByText("$5.00")).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/PriceSummary.tsx
+++ b/frontend/src/components/PriceSummary.tsx
@@ -1,13 +1,36 @@
-// Displays calculated fare or loading/error states.
+// Displays calculated fare or loading/error states based on user input.
+import { useEffect } from "react";
 import { Alert, Box, CircularProgress, Typography } from "@mui/material";
+import { usePriceCalculator, type PriceInputs } from "@/hooks/usePriceCalculator";
 
-export function PriceSummary(props: { price: number | null; loading?: boolean; error?: string | null }) {
-  if (props.loading) return <CircularProgress size={24} />;
-  if (props.error) return <Alert severity="error">{props.error}</Alert>;
+export type PriceSummaryProps = PriceInputs & {
+  onPrice?: (price: number | null) => void;
+};
+
+export function PriceSummary(props: PriceSummaryProps) {
+  const { onPrice, ...inputs } = props;
+  const { price, loading, error, compute } = usePriceCalculator({ ...inputs, auto: false });
+
+  useEffect(() => {
+    if (!inputs.pickup || !inputs.dropoff) return;
+    if (typeof inputs.distanceKm !== "number" || typeof inputs.durationMin !== "number") return;
+    void compute();
+  }, [inputs.pickup, inputs.dropoff, inputs.rideTime, inputs.flagfall, inputs.perKm, inputs.perMin, inputs.distanceKm, inputs.durationMin, compute]);
+
+  useEffect(() => {
+    onPrice?.(price);
+  }, [price, onPrice]);
+
+  if (loading) return <CircularProgress size={24} />;
+  if (error) return <Alert severity="error">{error}</Alert>;
+  if (price === null) return null;
+
   return (
     <Box>
       <Typography variant="h6">Estimated Price</Typography>
-      <Typography variant="h4">{props.price !== null ? `$${props.price.toFixed(2)}` : "—"}</Typography>
+      <Typography variant="h4">{`$${price.toFixed(2)}`}</Typography>
     </Box>
   );
 }
+
+export default PriceSummary;

--- a/frontend/src/hooks/usePriceCalculator.ts
+++ b/frontend/src/hooks/usePriceCalculator.ts
@@ -54,11 +54,14 @@ export function usePriceCalculator(
       }
     }
 
-    // Basic local fare model
-    const km = typeof distanceKm === "number" ? distanceKm : 0;
-    const min = typeof durationMin === "number" ? durationMin : 0;
+    // Ensure we have distance and duration metrics before computing
+    if (typeof distanceKm !== "number" || typeof durationMin !== "number") {
+      setPrice(null);
+      return;
+    }
 
-    const p = Number(flagfall) + Number(perKm) * km + Number(perMin) * min;
+    // Basic local fare model
+    const p = Number(flagfall) + Number(perKm) * distanceKm + Number(perMin) * durationMin;
 
     if (!Number.isFinite(p)) {
       setPrice(null);


### PR DESCRIPTION
## Summary
- compute fare in PriceSummary only after valid pickup/dropoff and route metrics
- ensure price calculator waits for distance and duration before calculating
- integrate updated PriceSummary into booking page

## Testing
- `npm test --prefix frontend -- --run` *(fails: AdminDashboard tests)*
- `npm run lint` *(fails: lint error in DevNotes.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68a4868e4af88331af7d4077118a37e8