### PR TITLE
Refactor map provider into context

### DIFF
--- a/frontend/src/components/MapRoute.test.tsx
+++ b/frontend/src/components/MapRoute.test.tsx
@@ -7,7 +7,7 @@ import { MapProvider } from './MapProvider';
 vi.mock('@react-google-maps/api', () => ({
   GoogleMap: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
   DirectionsRenderer: () => null,
-  LoadScript: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  useJsApiLoader: () => ({ isLoaded: true, loadError: undefined }),
 }));
 
 beforeEach(() => {

--- a/frontend/src/components/MapRoute.tsx
+++ b/frontend/src/components/MapRoute.tsx
@@ -3,6 +3,7 @@ import { useEffect } from 'react';
 import { GoogleMap, DirectionsRenderer } from '@react-google-maps/api';
 import { useRoute } from '@/hooks/useRoute';
 import { useRouteMetrics } from '@/hooks/useRouteMetrics';
+import { useMap } from './MapProvider';
 
 export type Props = {
   pickup: string;
@@ -10,7 +11,7 @@ export type Props = {
   onMetrics?: (km: number, minutes: number) => void;
 };
 
-function Placeholder() {
+function Placeholder({ text = 'map unavailable' }: { text?: string }) {
   return (
     <div
       id="map"
@@ -23,13 +24,14 @@ function Placeholder() {
         background: '#eee',
       }}
     >
-      map unavailable
+      {text}
     </div>
   );
 }
 
 export function MapRoute({ pickup, dropoff, onMetrics }: Props) {
-  const { valid, directions } = useRoute(pickup, dropoff);
+  const { isLoaded, loadError } = useMap();
+  const { valid, directions } = useRoute(pickup, dropoff, isLoaded);
   const getMetrics = useRouteMetrics();
 
   useEffect(() => {
@@ -45,6 +47,8 @@ export function MapRoute({ pickup, dropoff, onMetrics }: Props) {
     };
   }, [pickup, dropoff, onMetrics, getMetrics]);
 
+  if (loadError) return <Placeholder />;
+  if (!isLoaded) return <Placeholder text="loading..." />;
   if (!valid || !directions) return <Placeholder />;
 
   return (

--- a/frontend/src/hooks/useRoute.ts
+++ b/frontend/src/hooks/useRoute.ts
@@ -9,13 +9,17 @@ interface GMaps {
   };
 }
 
-export function useRoute(pickup: string, dropoff: string) {
+export function useRoute(pickup: string, dropoff: string, enabled = true) {
   const [valid, setValid] = useState(false);
   const [directions, setDirections] = useState<google.maps.DirectionsResult | null>(null);
 
   useEffect(() => {
     let cancelled = false;
     setDirections(null);
+    if (!enabled) {
+      setValid(false);
+      return;
+    }
     const g = (window as { google?: GMaps }).google;
     if (!pickup || !dropoff || !g?.maps) {
       setValid(false);
@@ -38,7 +42,7 @@ export function useRoute(pickup: string, dropoff: string) {
     return () => {
       cancelled = true;
     };
-  }, [pickup, dropoff]);
+  }, [pickup, dropoff, enabled]);
 
   return { valid, directions };
 }


### PR DESCRIPTION
## Summary
- expose Google Maps loading status via new MapContext
- update MapRoute to react to loader state and show meaningful fallbacks
- allow useRoute hook to recompute when Google Maps becomes available

## Testing
- `npm test -- --run` *(fails: DevNotes > renders configuration values)*

------
https://chatgpt.com/codex/tasks/task_e_68a4938351808331b42db620feecb829