### PR TITLE
Fix FareBreakdown props and guard with dev features

### DIFF
--- a/frontend/src/components/DevNotes.test.tsx
+++ b/frontend/src/components/DevNotes.test.tsx
@@ -1,7 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import { describe, test, expect, vi } from 'vitest';
 import DevNotes from './DevNotes';
-import { DevFeaturesProvider } from '@/contexts/DevFeaturesContext';
 
 vi.mock('@/config', () => ({
   CONFIG: {

--- a/frontend/src/components/DevNotes.tsx
+++ b/frontend/src/components/DevNotes.tsx
@@ -7,7 +7,6 @@ import ListItem from '@mui/material/ListItem';
 import ListItemText from '@mui/material/ListItemText';
 
 import { CONFIG } from '@/config';
-import { useDevFeatures } from '@/contexts/DevFeaturesContext';
 const DevNotes: React.FC = () => {
   return (
     <Box p={2}>

--- a/frontend/src/components/FareBreakdown.test.tsx
+++ b/frontend/src/components/FareBreakdown.test.tsx
@@ -1,20 +1,25 @@
 import { render, screen } from "@testing-library/react";
 import React from "react";
+import { DevFeaturesProvider } from "@/contexts/DevFeaturesContext";
 import { FareBreakdown } from "./FareBreakdown";
 
 describe("FareBreakdown", () => {
   test("renders breakdown values", () => {
     render(
-      <FareBreakdown
-        flagfall={5}
-        perKm={2}
-        perMin={1}
-        distanceKm={3}
-        durationMin={4}
-      />
+      <DevFeaturesProvider>
+        <FareBreakdown
+          price={null}
+          flagfall={5}
+          perKm={2}
+          perMin={1}
+          distanceKm={3}
+          durationMin={4}
+        />
+      </DevFeaturesProvider>
     );
-    expect(screen.getByText(/flagfall: \$5\.00/)).toBeInTheDocument();
-    expect(screen.getByText(/3\.00 km x \$2\.00/)).toBeInTheDocument();
-    expect(screen.getByText(/4\.00 min x \$1\.00/)).toBeInTheDocument();
+    expect(screen.getByText(/Flagfall: \$5\.00/i)).toBeInTheDocument();
+    expect(screen.getByText(/Distance: \$6\.00/i)).toBeInTheDocument();
+    expect(screen.getByText(/Duration: \$4\.00/i)).toBeInTheDocument();
+    expect(screen.getByText(/Total: \$15\.00/i)).toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/Booking/BookingPage.tsx
+++ b/frontend/src/pages/Booking/BookingPage.tsx
@@ -179,16 +179,9 @@ export default function BookingPage() {
                 durationMin={durationMin}
                 onPrice={setPrice}
               />
-              <FareBreakdown
-                flagfall={tariff.flagfall}
-                perKm={tariff.perKm}
-                perMin={tariff.perMin}
-                distanceKm={distanceKm}
-                durationMin={durationMin}
-              />
               <DevOnly>
                 <FareBreakdown
-                  price={pricing.price}
+                  price={price}
                   flagfall={tariff.flagfall}
                   perKm={tariff.perKm}
                   perMin={tariff.perMin}


### PR DESCRIPTION
## Summary
- only render FareBreakdown on the booking page when dev features are enabled
- drop unused DevFeatures imports from DevNotes and its test to satisfy lint

## Testing
- `npm --prefix frontend run build`
- `npm --prefix frontend test -- --run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a5b253250883319989fb627e6cfc73