### PR TITLE
test: add backend and frontend coverage

### DIFF
--- a/backend/tests/integration/test_geocode_api.py
+++ b/backend/tests/integration/test_geocode_api.py
@@ -1,0 +1,31 @@
+import pytest
+import httpx
+from httpx import AsyncClient
+from _pytest.monkeypatch import MonkeyPatch
+
+pytestmark = pytest.mark.asyncio
+
+async def test_reverse_geocode_timeout(monkeypatch: MonkeyPatch, client: AsyncClient):
+    from app.api import geocode as geocode_router
+
+    async def fake_reverse(lat: float, lon: float):
+        raise httpx.TimeoutException("timeout")
+
+    monkeypatch.setattr(geocode_router, "reverse_geocode", fake_reverse)
+
+    res = await client.get("/geocode/reverse", params={"lat": 1.0, "lon": 2.0})
+    assert res.status_code == 504
+    assert res.json()["detail"] == "Geocoding service timed out"
+
+
+async def test_geocode_search_http_error(monkeypatch: MonkeyPatch, client: AsyncClient):
+    from app.api import geocode as geocode_router
+
+    async def fake_search(q: str, limit: int = 5):
+        raise httpx.HTTPError("boom")
+
+    monkeypatch.setattr(geocode_router, "search_geocode", fake_search)
+
+    res = await client.get("/geocode/search", params={"q": "Main"})
+    assert res.status_code == 502
+    assert res.json()["detail"] == "Geocoding service error"

--- a/backend/tests/integration/test_route_metrics_api.py
+++ b/backend/tests/integration/test_route_metrics_api.py
@@ -1,0 +1,31 @@
+import pytest
+from httpx import AsyncClient
+from _pytest.monkeypatch import MonkeyPatch
+
+pytestmark = pytest.mark.asyncio
+
+async def test_route_metrics_success(monkeypatch: MonkeyPatch, client: AsyncClient):
+    from app.api import route_metrics as router
+
+    async def fake_get_route_metrics(pickup: str, dropoff: str):
+        assert pickup == "A" and dropoff == "B"
+        return {"km": 1.23, "min": 4.5}
+
+    monkeypatch.setattr(router, "get_route_metrics", fake_get_route_metrics)
+
+    res = await client.get("/route-metrics", params={"pickup": "A", "dropoff": "B"})
+    assert res.status_code == 200
+    assert res.json() == {"km": 1.23, "min": 4.5}
+
+
+async def test_route_metrics_error(monkeypatch: MonkeyPatch, client: AsyncClient):
+    from app.api import route_metrics as router
+
+    async def fake_get_route_metrics(pickup: str, dropoff: str):
+        raise RuntimeError("bad request")
+
+    monkeypatch.setattr(router, "get_route_metrics", fake_get_route_metrics)
+
+    res = await client.get("/route-metrics", params={"pickup": "A", "dropoff": "B"})
+    assert res.status_code == 400
+    assert res.json()["detail"] == "bad request"

--- a/frontend/src/lib/formatAddress.test.ts
+++ b/frontend/src/lib/formatAddress.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { formatAddress } from './formatAddress';
+
+describe('formatAddress', () => {
+  it('joins typical address parts', () => {
+    const addr = {
+      unit: '1',
+      house_number: '23',
+      road: 'Main St',
+      city: 'Springfield',
+      postcode: '12345'
+    };
+    expect(formatAddress(addr)).toBe('1/23 Main St Springfield 12345');
+  });
+
+  it('falls back to alternative fields and omits blanks', () => {
+    const addr = {
+      flat_number: '2',
+      pedestrian: 'Highway',
+      suburb: 'Shelbyville'
+    } as any;
+    expect(formatAddress(addr)).toBe('2 Highway Shelbyville');
+  });
+
+  it('returns empty string for nullish input', () => {
+    // @ts-expect-error testing null input
+    expect(formatAddress(null)).toBe('');
+  });
+});

--- a/frontend/tests/e2e/specs/auth/profile.spec.ts
+++ b/frontend/tests/e2e/specs/auth/profile.spec.ts
@@ -1,0 +1,37 @@
+import { test, expect } from '@playwright/test';
+
+const uniqueEmail = `user+${Date.now()}@example.com`;
+const password = 'pw';
+
+test('user can update profile details', async ({ page }) => {
+  // Register and auto-login
+  await page.goto('/register');
+  await page.getByLabel(/full name/i).fill('E2E User');
+  await page.getByLabel(/email/i).fill(uniqueEmail);
+  await page.getByLabel(/password/i).fill(password);
+  await Promise.all([
+    page.waitForURL('**/book'),
+    page.getByRole('button', { name: /register/i }).click(),
+  ]);
+
+  // Navigate to profile page
+  await page.goto('/profile');
+  await expect(page.getByRole('heading', { name: /my profile/i })).toBeVisible();
+
+  // Fields populated from server
+  await expect(page.getByLabel(/full name/i)).toHaveValue('E2E User');
+  await expect(page.getByLabel(/email/i)).toHaveValue(uniqueEmail);
+
+  // Update full name and default pickup
+  await page.getByLabel(/full name/i).fill('Updated User');
+  await page.getByLabel(/default pickup address/i).fill('456 Ave');
+
+  const [resp] = await Promise.all([
+    page.waitForResponse(r => r.url().endsWith('/users/me') && r.request().method() === 'PATCH'),
+    page.getByRole('button', { name: /save/i }).click(),
+  ]);
+  expect(resp.ok()).toBeTruthy();
+
+  const storedName = await page.evaluate(() => localStorage.getItem('userName'));
+  expect(storedName).toBe('Updated User');
+});


### PR DESCRIPTION
## Summary
- test geocode API error paths
- cover route metrics API happy and error paths
- unit test address formatting helper
- E2E test for updating profile details

## Testing
- `pytest`
- `npm test` *(fails: Unable to find configured text, AdminDashboard assertions)*
- `npm run e2e` *(fails: connect ECONNREFUSED ::1:8000)*

------
https://chatgpt.com/codex/tasks/task_e_68a49d0bc4f88331a326c1ccc017b88b