### PR TITLE
Update FareBreakdown test for new breakdown text

### DIFF
--- a/frontend/src/components/FareBreakdown.test.tsx
+++ b/frontend/src/components/FareBreakdown.test.tsx
@@ -18,8 +18,20 @@ describe("FareBreakdown", () => {
       </DevFeaturesProvider>
     );
     expect(screen.getByText(/Flagfall: \$5\.00/i)).toBeInTheDocument();
-    expect(screen.getByText(/Distance: \$6\.00/i)).toBeInTheDocument();
-    expect(screen.getByText(/Duration: \$4\.00/i)).toBeInTheDocument();
-    expect(screen.getByText(/Total: \$15\.00/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /Distance: 3 km @ \$2 per km = \$6\.00/i,
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /Duration: 4 minutes @ \$1 per minute = \$4\.00/i,
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /Total: \$5 \+ \$6\.00 \+ \$4\.00 = \$15\.00/i,
+      ),
+    ).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- adjust FareBreakdown test expectations for detailed distance, duration, and total strings

## Testing
- `npm test -- --run`
- `npm run lint` *(fails: Unexpected any in formatAddress.test.ts and React hook dependency warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68a5cead59c88331990c019c3aaf3439