### PR TITLE
feat: add status tabs and chip component

### DIFF
--- a/frontend/src/__tests__/DriverDashboard.test.tsx
+++ b/frontend/src/__tests__/DriverDashboard.test.tsx
@@ -7,7 +7,15 @@ vi.mock('@/services/tokenStore', () => ({ getAccessToken: () => 'tok' }));
 
 describe('DriverDashboard', () => {
   it('loads and confirms booking', async () => {
-    const bookings = [{ id: '1', pickup_address: 'A', dropoff_address: 'B', pickup_when: new Date().toISOString(), status: 'PENDING' }];
+    const bookings = [
+      {
+        id: '1',
+        pickup_address: 'A',
+        dropoff_address: 'B',
+        pickup_when: new Date().toISOString(),
+        status: 'PENDING'
+      }
+    ];
     global.fetch = vi.fn()
       .mockResolvedValueOnce({ ok: true, json: async () => bookings })
       .mockResolvedValueOnce({ ok: true, json: async () => ({ status: 'DRIVER_CONFIRMED' }) });
@@ -19,6 +27,7 @@ describe('DriverDashboard', () => {
     );
     expect(await screen.findByText('A → B')).toBeInTheDocument();
     fireEvent.click(screen.getByText('Confirm'));
+    fireEvent.click(screen.getByRole('tab', { name: /driver confirmed/i }));
     await waitFor(() => expect(screen.getByText('Leave now')).toBeInTheDocument());
   });
 });

--- a/frontend/src/components/StatusChip.test.tsx
+++ b/frontend/src/components/StatusChip.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen } from '@testing-library/react';
+import { capitalize } from '@mui/material/utils';
+import StatusChip from './StatusChip';
+import {
+  bookingStatusLabels,
+  bookingStatusColors,
+  type BookingStatus
+} from '@/types/BookingStatus';
+
+describe('StatusChip', () => {
+  const statuses = Object.keys(bookingStatusColors) as BookingStatus[];
+
+  it('has mapping for all statuses', () => {
+    expect(statuses.length).toBeGreaterThan(0);
+    statuses.forEach(status => {
+      expect(bookingStatusColors[status]).toBeDefined();
+    });
+  });
+
+  statuses.forEach(status => {
+    it(`renders ${status} with correct label and color`, () => {
+      render(<StatusChip status={status} />);
+      const chipLabel = screen.getByText(bookingStatusLabels[status]);
+      const chip = chipLabel.parentElement;
+      expect(chipLabel).toBeInTheDocument();
+      expect(chip).toHaveClass(
+        `MuiChip-color${capitalize(bookingStatusColors[status])}`
+      );
+    });
+  });
+});

--- a/frontend/src/components/StatusChip.tsx
+++ b/frontend/src/components/StatusChip.tsx
@@ -1,0 +1,20 @@
+import { Chip, type ChipProps } from '@mui/material';
+import {
+  bookingStatusLabels,
+  bookingStatusColors,
+  type BookingStatus
+} from '@/types/BookingStatus';
+
+interface StatusChipProps extends Omit<ChipProps, 'label' | 'color'> {
+  status: BookingStatus;
+}
+
+export default function StatusChip({ status, ...props }: StatusChipProps) {
+  return (
+    <Chip
+      label={bookingStatusLabels[status]}
+      color={bookingStatusColors[status]}
+      {...props}
+    />
+  );
+}

--- a/frontend/src/pages/Driver/DriverDashboard.tsx
+++ b/frontend/src/pages/Driver/DriverDashboard.tsx
@@ -1,21 +1,42 @@
 import { useEffect, useState } from 'react';
-import { Button, List, ListItem, ListItemText, Stack, Typography } from '@mui/material';
+import {
+  Button,
+  List,
+  ListItem,
+  ListItemText,
+  Stack,
+  Typography,
+  Tabs,
+  Tab
+} from '@mui/material';
 import { Link } from 'react-router-dom';
 import { CONFIG } from '@/config';
 import { getAccessToken } from '@/services/tokenStore';
+import { bookingStatusLabels, type BookingStatus } from '@/types/BookingStatus';
+import StatusChip from '@/components/StatusChip';
 
 interface Booking {
   id: string;
   pickup_address: string;
   dropoff_address: string;
   pickup_when: string;
-  status: string;
+  status: BookingStatus;
   leave_at?: string;
   final_price_cents?: number;
 }
 
 export default function DriverDashboard() {
   const [bookings, setBookings] = useState<Booking[]>([]);
+  const statuses: BookingStatus[] = [
+    'PENDING',
+    'DRIVER_CONFIRMED',
+    'ON_THE_WAY',
+    'ARRIVED_PICKUP',
+    'IN_PROGRESS',
+    'ARRIVED_DROPOFF',
+    'COMPLETED'
+  ];
+  const [tab, setTab] = useState<BookingStatus>('PENDING');
 
   useEffect(() => {
     (async () => {
@@ -31,19 +52,34 @@ export default function DriverDashboard() {
 
   async function update(
     id: string,
-    action: 'confirm' | 'decline' | 'leave' | 'arrive-pickup' | 'start-trip' | 'arrive-dropoff' | 'complete'
+    action:
+      | 'confirm'
+      | 'decline'
+      | 'leave'
+      | 'arrive-pickup'
+      | 'start-trip'
+      | 'arrive-dropoff'
+      | 'complete'
   ) {
     const token = getAccessToken();
-    const res = await fetch(`${CONFIG.API_BASE_URL}/api/v1/driver/bookings/${id}/${action}`, {
-      method: 'POST',
-      headers: { Authorization: `Bearer ${token}` }
-    });
+    const res = await fetch(
+      `${CONFIG.API_BASE_URL}/api/v1/driver/bookings/${id}/${action}`,
+      {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${token}` }
+      }
+    );
     if (res.ok) {
       const data = await res.json();
       setBookings(b =>
         b.map(item =>
           item.id === id
-            ? { ...item, status: data.status, final_price_cents: data.final_price_cents ?? item.final_price_cents }
+            ? {
+                ...item,
+                status: data.status,
+                final_price_cents:
+                  data.final_price_cents ?? item.final_price_cents
+              }
             : item
         )
       );
@@ -62,46 +98,101 @@ export default function DriverDashboard() {
       <Button component={Link} to="/driver/availability" variant="outlined">
         Manage availability
       </Button>
-      <List>
-        {bookings.map(b => (
-          <ListItem key={b.id} divider>
-            <ListItemText primary={`${b.pickup_address} → ${b.dropoff_address}`} secondary={new Date(b.pickup_when).toLocaleString()} />
-            {b.status === 'PENDING' && (
-              <>
-                <Button variant="contained" color="success" onClick={() => update(b.id, 'confirm')} sx={{ mr: 1 }}>Confirm</Button>
-                <Button variant="outlined" color="error" onClick={() => update(b.id, 'decline')}>Decline</Button>
-              </>
-            )}
-            {b.status === 'DRIVER_CONFIRMED' && (
-              <Button
-                variant="contained"
-                onClick={async () => {
-                  await update(b.id, 'leave');
-                }}
-                disabled={b.leave_at ? new Date(b.leave_at).getTime() > now : true}
-              >
-                Leave now
-              </Button>
-            )}
-            {b.status === 'ON_THE_WAY' && (
-              <Button variant="contained" onClick={() => update(b.id, 'arrive-pickup')}>Arrived pickup</Button>
-            )}
-            {b.status === 'ARRIVED_PICKUP' && (
-              <Button variant="contained" onClick={() => update(b.id, 'start-trip')}>Start trip</Button>
-            )}
-            {b.status === 'IN_PROGRESS' && (
-              <Button variant="contained" onClick={() => update(b.id, 'arrive-dropoff')}>Arrived dropoff</Button>
-            )}
-            {b.status === 'ARRIVED_DROPOFF' && (
-              <Button variant="contained" onClick={() => update(b.id, 'complete')}>Complete</Button>
-            )}
-            {b.status === 'COMPLETED' && b.final_price_cents !== undefined && (
-              <Typography>${(b.final_price_cents / 100).toFixed(2)}</Typography>
-            )}
-          </ListItem>
+      <Tabs
+        value={tab}
+        onChange={(_e, v) => setTab(v)}
+        variant="scrollable"
+        scrollButtons="auto"
+      >
+        {statuses.map(s => (
+          <Tab key={s} label={bookingStatusLabels[s]} value={s} />
         ))}
-        {bookings.length === 0 && <Typography>No bookings</Typography>}
-      </List>
+      </Tabs>
+      {statuses.map(s => {
+        const list = bookings.filter(b => b.status === s);
+        return (
+          <List key={s} hidden={tab !== s}>
+            {list.map(b => (
+              <ListItem key={b.id} divider>
+                <ListItemText
+                  primary={`${b.pickup_address} → ${b.dropoff_address}`}
+                  secondary={new Date(b.pickup_when).toLocaleString()}
+                />
+                <StatusChip status={b.status} sx={{ mr: 1 }} />
+                {b.status === 'PENDING' && (
+                  <>
+                    <Button
+                      variant="contained"
+                      color="success"
+                      onClick={() => update(b.id, 'confirm')}
+                      sx={{ mr: 1 }}
+                    >
+                      Confirm
+                    </Button>
+                    <Button
+                      variant="outlined"
+                      color="error"
+                      onClick={() => update(b.id, 'decline')}
+                    >
+                      Decline
+                    </Button>
+                  </>
+                )}
+                {b.status === 'DRIVER_CONFIRMED' && (
+                  <Button
+                    variant="contained"
+                    onClick={async () => {
+                      await update(b.id, 'leave');
+                    }}
+                    disabled={b.leave_at ? new Date(b.leave_at).getTime() > now : true}
+                  >
+                    Leave now
+                  </Button>
+                )}
+                {b.status === 'ON_THE_WAY' && (
+                  <Button
+                    variant="contained"
+                    onClick={() => update(b.id, 'arrive-pickup')}
+                  >
+                    Arrived pickup
+                  </Button>
+                )}
+                {b.status === 'ARRIVED_PICKUP' && (
+                  <Button
+                    variant="contained"
+                    onClick={() => update(b.id, 'start-trip')}
+                  >
+                    Start trip
+                  </Button>
+                )}
+                {b.status === 'IN_PROGRESS' && (
+                  <Button
+                    variant="contained"
+                    onClick={() => update(b.id, 'arrive-dropoff')}
+                  >
+                    Arrived dropoff
+                  </Button>
+                )}
+                {b.status === 'ARRIVED_DROPOFF' && (
+                  <Button
+                    variant="contained"
+                    onClick={() => update(b.id, 'complete')}
+                  >
+                    Complete
+                  </Button>
+                )}
+                {b.status === 'COMPLETED' &&
+                  b.final_price_cents !== undefined && (
+                    <Typography>
+                      ${(b.final_price_cents / 100).toFixed(2)}
+                    </Typography>
+                  )}
+              </ListItem>
+            ))}
+            {list.length === 0 && <Typography>No bookings</Typography>}
+          </List>
+        );
+      })}
     </Stack>
   );
 }

--- a/frontend/src/types/BookingStatus.ts
+++ b/frontend/src/types/BookingStatus.ts
@@ -1,0 +1,36 @@
+import { type ChipProps } from '@mui/material';
+
+export type BookingStatus =
+  | 'PENDING'
+  | 'DRIVER_CONFIRMED'
+  | 'DECLINED'
+  | 'ON_THE_WAY'
+  | 'ARRIVED_PICKUP'
+  | 'IN_PROGRESS'
+  | 'ARRIVED_DROPOFF'
+  | 'COMPLETED'
+  | 'CANCELLED';
+
+export const bookingStatusLabels: Record<BookingStatus, string> = {
+  PENDING: 'Pending',
+  DRIVER_CONFIRMED: 'Driver confirmed',
+  DECLINED: 'Declined',
+  ON_THE_WAY: 'On the way',
+  ARRIVED_PICKUP: 'Arrived pickup',
+  IN_PROGRESS: 'In progress',
+  ARRIVED_DROPOFF: 'Arrived dropoff',
+  COMPLETED: 'Completed',
+  CANCELLED: 'Cancelled'
+};
+
+export const bookingStatusColors: Record<BookingStatus, ChipProps['color']> = {
+  PENDING: 'warning',
+  DRIVER_CONFIRMED: 'info',
+  DECLINED: 'error',
+  ON_THE_WAY: 'info',
+  ARRIVED_PICKUP: 'info',
+  IN_PROGRESS: 'primary',
+  ARRIVED_DROPOFF: 'info',
+  COMPLETED: 'success',
+  CANCELLED: 'error'
+};


### PR DESCRIPTION
## Summary
- group driver bookings by status with tabbed lists
- add reusable StatusChip with label/color mappings
- test status chip mapping

## Testing
- `npm run lint` *(fails: Unexpected any in BookingWizard files)*
- `cd backend && pytest`
- `cd frontend && npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68a6b1c8f53c8331a71fbd34088ea88f