### PR TITLE
feat: add directions hook with caching

### DIFF
--- a/frontend/src/__tests__/useDirections.test.ts
+++ b/frontend/src/__tests__/useDirections.test.ts
@@ -1,0 +1,33 @@
+import { renderHook } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import useDirections from '@/hooks/useDirections';
+
+describe('useDirections', () => {
+  it('fetches and parses distance and duration', async () => {
+    vi.mock('@/config', () => ({ CONFIG: { GOOGLE_MAPS_API_KEY: 'KEY' } }));
+    const fake = {
+      routes: [
+        {
+          legs: [
+            {
+              distance: { value: 1000 },
+              duration: { value: 600 },
+            },
+          ],
+        },
+      ],
+    };
+    const fetchMock = vi.fn(async (url: string) => {
+      expect(url).toBe(
+        'https://maps.googleapis.com/maps/api/directions/json?origin=A&destination=B&mode=driving&key=KEY'
+      );
+      return { ok: true, json: async () => fake } as any;
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    const { result } = renderHook(() => useDirections());
+    const res = await result.current('A', 'B');
+    expect(res).toEqual({ km: 1, min: 10 });
+    await result.current('A', 'B');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/hooks/useDirections.ts
+++ b/frontend/src/hooks/useDirections.ts
@@ -1,0 +1,46 @@
+import { CONFIG } from "@/config";
+import { useCallback, useRef } from "react";
+
+export interface DirectionsMetrics {
+  km: number;
+  min: number;
+}
+
+export function useDirections() {
+  const cache = useRef(new Map<string, DirectionsMetrics>());
+
+  return useCallback(
+    async (pickup: string, dropoff: string): Promise<DirectionsMetrics | null> => {
+      if (!pickup || !dropoff) return null;
+      const key = `${pickup}|${dropoff}`;
+      if (cache.current.has(key)) {
+        return cache.current.get(key)!;
+      }
+      try {
+        const params = new URLSearchParams({
+          origin: pickup,
+          destination: dropoff,
+          mode: "driving",
+          key: CONFIG.GOOGLE_MAPS_API_KEY || "",
+        });
+        const url = `https://maps.googleapis.com/maps/api/directions/json?${params.toString()}`;
+        const res = await fetch(url);
+        if (!res.ok) return null;
+        const data = await res.json();
+        const leg = data?.routes?.[0]?.legs?.[0];
+        const dist = leg?.distance?.value; // meters
+        const dur = leg?.duration?.value; // seconds
+        if (!Number.isFinite(dist) || !Number.isFinite(dur)) return null;
+        const metrics = { km: dist / 1000, min: dur / 60 };
+        cache.current.set(key, metrics);
+        return metrics;
+      } catch (err) {
+        console.error(err);
+        return null;
+      }
+    },
+    []
+  );
+}
+
+export default useDirections;


### PR DESCRIPTION
## Summary
- add `useDirections` hook to request Google Directions and cache results
- test `useDirections` distance and duration parsing with mocked fetch

## Testing
- `npm run lint` *(fails: Unexpected any in unrelated files)*
- `cd backend && pytest`
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a6b1cd8d0c8331a26b8792173db0b0