### PR TITLE
fix: mock external APIs for e2e tests

### DIFF
--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -30,6 +30,15 @@ export default defineConfig({
       testDir: 'tests/e2e/specs/admin',      // your admin specs
       use: { storageState: path.join(process.cwd(), 'storage', 'admin.json') }, // start signed IN
     },
+    {
+      name: 'api',
+      testDir: 'tests/e2e/specs',
+      testMatch: ['booking/wizard.spec.ts', 'driver/lifecycle.spec.ts'],
+      use: {
+        baseURL: process.env.API_BASE_URL ?? 'http://localhost:8000',
+        storageState: undefined,
+      },
+    },
   ],
 
 });


### PR DESCRIPTION
## Summary
- mock Stripe client when running tests
- bypass Google Directions API with local haversine fallback
- add Playwright api project to run booking wizard and driver lifecycle specs
- seed default admin config for booking creation

## Testing
- `npm run lint` *(fails: Unexpected any...)*
- `cd backend && pytest`
- `cd frontend && npm test`
- `npx playwright test --project=api --reporter=line`


------
https://chatgpt.com/codex/tasks/task_e_68a6b5bb78bc83319b8d38b659cf1228