### PR TITLE
test: stabilize e2e flows with backend startup

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -39,3 +39,4 @@ python-json-logger
 stripe
 apscheduler
 broadcaster
+websockets


### PR DESCRIPTION
## Summary
- ensure e2e setup installs websockets, mocks external services, and waits for backend readiness
- feed tracking points via WebSocket in driver lifecycle test and loosen completion check
- include websockets in backend requirements

## Testing
- `npm run lint` (fails: Unexpected any and other lint errors)
- `cd backend && pytest`
- `cd frontend && npm test` (cancelled after run)
- `cd frontend && npm run e2e -- --project=api`


------
https://chatgpt.com/codex/tasks/task_e_68a6bcddbb908331ab4aa8ff4256d524