### PR TITLE
feat: run migrations at startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,12 @@ domain actions, and handled errors are recorded with structured context.
    npm install
    ```
 
+## Database migrations
+
+The backend relies on Alembic migrations for database schema creation and
+updates. When the application starts, migrations are applied up to the latest
+revision, so ensure your migration files are up to date.
+
 ## Running
 
 ### Using Docker


### PR DESCRIPTION
## Summary
- apply Alembic migrations instead of creating tables manually
- document reliance on database migrations

## Testing
- `npm run lint`
- `cd backend && pytest`
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a6ec81905883318f45e2911d35a1ca