### PR TITLE
feat: add role-based auth and nav

### DIFF
--- a/frontend/src/components/NavBar.tsx
+++ b/frontend/src/components/NavBar.tsx
@@ -13,7 +13,7 @@ import { useAuth } from '@/contexts/AuthContext';
 import { useDevFeatures } from '@/contexts/DevFeaturesContext';
 
 const NavBar: React.FC = () => {
-  const { logout, userName, userID } = useAuth();  // get logout (and maybe user info) from context
+  const { logout, userName, role } = useAuth();  // get logout (and maybe user info) from context
   const { enabled: devEnabled } = useDevFeatures();
   const navigate = useNavigate();
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
@@ -47,6 +47,16 @@ const NavBar: React.FC = () => {
   const navProfile = () => {
     handleMenuClose();
     navigate('/me');
+  };
+
+  const navDriverDashboard = () => {
+    handleMenuClose();
+    navigate('/driver');
+  };
+
+  const navDriverAvailability = () => {
+    handleMenuClose();
+    navigate('/driver/availability');
   };
 
   const navAdmin = () => {
@@ -91,10 +101,14 @@ const NavBar: React.FC = () => {
         >
           <MenuItem onClick={handleLogout}>Logout</MenuItem>
           <MenuItem onClick={navBook}>Book</MenuItem>
-          <MenuItem onClick={navHistory}>History</MenuItem>
+          <MenuItem onClick={navHistory}>Ride History</MenuItem>
           <MenuItem onClick={navProfile}>Profile</MenuItem>
-          {userID == '1' && (
-            <MenuItem onClick={navAdmin}>Administration</MenuItem>
+          {role?.toLowerCase() === 'driver' && [
+            <MenuItem key="driver-dashboard" onClick={navDriverDashboard}>Driver Dashboard</MenuItem>,
+            <MenuItem key="driver-availability" onClick={navDriverAvailability}>Availability</MenuItem>,
+          ]}
+          {role?.toLowerCase() === 'admin' && (
+            <MenuItem onClick={navAdmin}>Admin Dashboard</MenuItem>
           )}
           {devEnabled && <MenuItem onClick={navDevNotes}>Dev Notes</MenuItem>}
         </Menu>

--- a/frontend/src/types/AuthContextType.tsx
+++ b/frontend/src/types/AuthContextType.tsx
@@ -5,9 +5,10 @@ export type AuthContextType = {
   accessToken: string | null;
   user: UserShape | null;
   loading: boolean;
-  
+
   userName: string | null;
   userID: string | null;
+  role: string | null;
 
   loginWithPassword: (email: string, password: string) => Promise<void>;
   registerWithPassword: (fullName: string, email: string, password: string) => Promise<void>;


### PR DESCRIPTION
## Summary
- persist user role in auth context and fetch from `/users/me` when needed
- render NavBar links based on role and handle driver/admin routes
- test NavBar role-based menu visibility

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a6ff9c1ae08331ad44c6af361a39cd