### PR TITLE
feat: route login based on user role

### DIFF
--- a/frontend/src/__tests__/setup/msw.handlers.ts
+++ b/frontend/src/__tests__/setup/msw.handlers.ts
@@ -46,7 +46,8 @@ export const handlers = [
     return HttpResponse.json({
       access_token: 'test-token',
       token_type: 'bearer',
-      user: { id: 1, full_name: 'Test User', email: body.email },
+      role: 'CUSTOMER',
+      user: { id: 1, full_name: 'Test User', email: body.email, role: 'CUSTOMER' },
     });
   }),
 

--- a/frontend/src/pages/Auth/LoginPage.tsx
+++ b/frontend/src/pages/Auth/LoginPage.tsx
@@ -37,8 +37,10 @@ export default function LoginPage() {
     setSubmitting(true);
     setError(null);
     try {
-      await loginWithPassword(email, password);
-      const dest = params.get("from") || "/book";
+      const role = await loginWithPassword(email, password);
+      let dest = "/book";
+      if (role === "DRIVER") dest = "/driver";
+      else if (role && role.toUpperCase().includes("ADMIN")) dest = "/admin";
       navigate(dest, { replace: true });
     } catch (err: unknown) {
       if (err instanceof Response) {

--- a/frontend/src/types/AuthContextType.tsx
+++ b/frontend/src/types/AuthContextType.tsx
@@ -1,5 +1,5 @@
 // Type definitions for the authentication context values.
-export type UserShape = { email?: string; full_name?: string } | null;
+export type UserShape = { email?: string; full_name?: string; role?: string } | null;
 
 export type AuthContextType = {
   accessToken: string | null;
@@ -9,7 +9,9 @@ export type AuthContextType = {
   userName: string | null;
   userID: string | null;
 
-  loginWithPassword: (email: string, password: string) => Promise<void>;
+  role: string | null;
+
+  loginWithPassword: (email: string, password: string) => Promise<string | null>;
   registerWithPassword: (fullName: string, email: string, password: string) => Promise<void>;
 
   loginWithOAuth: () => void;


### PR DESCRIPTION
## Summary
- add role support to AuthContext and persist it for auth redirects
- redirect login by role to driver/admin/customer landing pages
- test role-based navigation paths

## Testing
- `npm run lint`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68a6ffa11fe483318ac0c088dd92484b