### PR TITLE
feat: add authenticated dashboard home page

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -16,6 +16,7 @@ import CircularProgress from "@mui/material/CircularProgress";
 import PageNotFound from '@/pages/PageNotFound';
 import DevNotes from '@/components/DevNotes';
 import { useDevFeatures } from '@/contexts/DevFeaturesContext';
+import HomePage from '@/pages/Dashboard/HomePage';
 
 function App() {
   const { accessToken, loading, userID } = useAuth(); // custom hook to get AuthContext
@@ -29,9 +30,9 @@ function App() {
     <>
     {accessToken && <NavBar />}
     <Routes>
-      <Route path="/" element={ accessToken ? <Navigate to="/book" /> : <Navigate to="/login" /> } />
-      <Route path="/login" element={ !accessToken ? <LoginPage />: <Navigate to="/book" />} />
-      <Route path="/register" element={ !accessToken ? <RegisterPage /> : <Navigate to="/book" />} />
+      <Route path="/" element={ accessToken ? <HomePage /> : <Navigate to="/login" /> } />
+      <Route path="/login" element={ !accessToken ? <LoginPage />: <Navigate to="/" />} />
+      <Route path="/register" element={ !accessToken ? <RegisterPage /> : <Navigate to="/" />} />
 
       {/* Protected user routes */}
       <Route

--- a/frontend/src/pages/Auth/LoginPage.test.tsx
+++ b/frontend/src/pages/Auth/LoginPage.test.tsx
@@ -14,14 +14,14 @@ test('logs in successfully', async () => {
   // stub /admin only (destination), not /login (source)
   renderWithProviders(<LoginPage />, {
     initialPath: '/login',
-    extraRoutes: <Route path="/book" element={<h1>Booking Page</h1>} />
+    extraRoutes: <Route path="/" element={<h1>Home Page</h1>} />
   });
 
   await userEvent.type(label(/email/i), 'test@example.com');
   await userEvent.type(label(/password/i), 'pw');
   await userEvent.click(screen.getByRole('button', { name: /log in/i }));
 
-  expect(await screen.findByRole('heading', { name: /booking page/i })).toBeInTheDocument();
+  expect(await screen.findByRole('heading', { name: /home page/i })).toBeInTheDocument();
 });
 
 test('shows error on bad credentials', async () => {

--- a/frontend/src/pages/Auth/LoginPage.tsx
+++ b/frontend/src/pages/Auth/LoginPage.tsx
@@ -21,7 +21,7 @@ export default function LoginPage() {
       try {
         await finishOAuthIfCallback?.();
         if (/\bcode=/.test(window.location.search)) {
-          const dest = params.get("from") || "/book";
+          const dest = params.get("from") || "/";
           navigate(dest, { replace: true });
         }
       } catch {
@@ -38,7 +38,7 @@ export default function LoginPage() {
     setError(null);
     try {
       await loginWithPassword(email, password);
-      const dest = params.get("from") || "/book";
+      const dest = params.get("from") || "/";
       navigate(dest, { replace: true });
     } catch (err: unknown) {
       if (err instanceof Response) {

--- a/frontend/src/pages/Dashboard/HomePage.test.tsx
+++ b/frontend/src/pages/Dashboard/HomePage.test.tsx
@@ -1,0 +1,32 @@
+import { renderWithProviders } from '@/__tests__/setup/renderWithProviders';
+import { screen } from '@testing-library/react';
+import HomePage from './HomePage';
+
+function seedAuth(id: string) {
+  localStorage.setItem('auth_tokens', JSON.stringify({ access_token: 't', refresh_token: 'r', user: { email: 'x' } }));
+  localStorage.setItem('userID', id);
+  localStorage.setItem('userName', 'Test User');
+}
+
+describe('HomePage', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('shows common tiles for a regular user', () => {
+    seedAuth('2');
+    renderWithProviders(<HomePage />);
+    expect(screen.getByRole('link', { name: /book a ride/i })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /ride history/i })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /driver dashboard/i })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /profile/i })).toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: /admin dashboard/i })).not.toBeInTheDocument();
+  });
+
+  it('shows admin dashboard tile for admin user', () => {
+    seedAuth('1');
+    renderWithProviders(<HomePage />);
+    expect(screen.getByRole('link', { name: /admin dashboard/i })).toBeInTheDocument();
+  });
+});
+

--- a/frontend/src/pages/Dashboard/HomePage.tsx
+++ b/frontend/src/pages/Dashboard/HomePage.tsx
@@ -1,0 +1,42 @@
+import { Grid, Button, Typography } from '@mui/material';
+import { Link } from 'react-router-dom';
+import { useAuth } from '@/contexts/AuthContext';
+
+interface Tile {
+  label: string;
+  path: string;
+}
+
+export default function HomePage() {
+  const { userID } = useAuth();
+
+  const tiles: Tile[] = [
+    { label: 'Book a Ride', path: '/book' },
+    { label: 'Ride History', path: '/history' },
+    { label: 'Driver Dashboard', path: '/driver' },
+    { label: 'Profile', path: '/me' },
+  ];
+
+  if (userID === '1') {
+    tiles.push({ label: 'Admin Dashboard', path: '/admin' });
+  }
+
+  return (
+    <Grid container spacing={2} sx={{ p: 2 }}>
+      {tiles.map((tile) => (
+        <Grid item xs={12} sm={6} md={4} key={tile.path}>
+          <Button
+            component={Link}
+            to={tile.path}
+            variant="contained"
+            fullWidth
+            sx={{ height: 120 }}
+          >
+            <Typography variant="h6">{tile.label}</Typography>
+          </Button>
+        </Grid>
+      ))}
+    </Grid>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add role-aware HomePage dashboard with quick action tiles
- route `/` to new HomePage and redirect to it after login
- cover HomePage and login redirect in tests

## Testing
- `npm run lint`
- `cd backend && pytest` (fails: test_driver_seed)
- `cd frontend && npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68a6ffae4e6083318f5d29f39bdcfc02