### PR TITLE
fix: respect custom logging configuration

### DIFF
--- a/backend/app/__main__.py
+++ b/backend/app/__main__.py
@@ -1,0 +1,22 @@
+"""Run the FastAPI application with uvicorn."""
+
+import uvicorn
+from app.core.config import get_settings
+from app.main import app
+
+
+def main() -> None:
+    """Entrypoint for ``python -m app``."""
+    settings = get_settings()
+    # Pass ``log_config=None`` so uvicorn doesn't override our logging setup.
+    uvicorn.run(
+        app,
+        host="0.0.0.0",
+        port=8000,
+        log_level=settings.log_level.lower(),
+        log_config=None,
+    )
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    main()


### PR DESCRIPTION
## Summary
- ensure root logger level persists after `dictConfig`
- run `uvicorn` with `log_config=None` so defaults aren't re-applied

## Testing
- `npm run lint`
- `cd backend && pytest` *(fails: Expected ValueError for invalid token, etc.)*
- `cd ../frontend && npm test` *(fails: TypeError: g.maps.DirectionsService is not a constructor, etc.)*
- `LOG_LEVEL=DEBUG python -m app` *(debug logs visible)*

------
https://chatgpt.com/codex/tasks/task_e_68a71afdc5bc8331b8af8406a8887eb2