### PR TITLE
fix: handle FCM HTTP errors via AsyncClient

### DIFF
--- a/backend/tests/unit/services/test_notifications.py
+++ b/backend/tests/unit/services/test_notifications.py
@@ -30,6 +30,10 @@ async def test_send_fcm_uses_async_client(monkeypatch: MonkeyPatch):
         def json(self):
             return self._data
 
+        def raise_for_status(self):
+            if self.status_code >= 400:
+                raise httpx.HTTPStatusError("error", request=None, response=None)
+
     class DummyClient:
         def __init__(self, *args, **kwargs):
             self.calls = []


### PR DESCRIPTION
## Summary
- handle FCM messaging in `_send_fcm` using `httpx.AsyncClient` with unified error handling
- update tests to mock AsyncClient and support `raise_for_status`

## Testing
- `npm run lint`
- `cd backend && pytest --sw-reset`
- `cd frontend && npm test` *(fails: 2 failed | 6 passed | 1 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68a733dd0eb48331b02d7dc450b6c4a2