### PR TITLE
feat: add home navigation to navbar

### DIFF
--- a/frontend/src/components/NavBar.test.tsx
+++ b/frontend/src/components/NavBar.test.tsx
@@ -11,6 +11,7 @@ function seedAuth({ id, name, role }: { id: string; name: string; role: string }
   localStorage.setItem('userID', id);
   localStorage.setItem('userName', name);
   localStorage.setItem('userRole', role);
+  localStorage.setItem('role', role);
 }
 
 function renderWithAuth(initialPath = '/book') {
@@ -29,6 +30,14 @@ function renderWithAuth(initialPath = '/book') {
 }
 
 describe('NavBar', () => {
+  test('shows Home menu item', async () => {
+    seedAuth({ id: '0', name: 'Regular User', role: 'CUSTOMER' });
+    renderWithAuth();
+
+    await userEvent.click(screen.getByLabelText(/account/i));
+    expect(await screen.findByRole('menuitem', { name: /home/i })).toBeInTheDocument();
+  });
+
   test('shows Admin Dashboard when role is ADMIN', async () => {
     seedAuth({ id: '1', name: 'Admin User', role: 'ADMIN' });
     renderWithAuth();

--- a/frontend/src/components/NavBar.tsx
+++ b/frontend/src/components/NavBar.tsx
@@ -34,6 +34,11 @@ const NavBar: React.FC = () => {
     navigate('/login');  // navigate to login page after logout
   };
 
+  const navHome = () => {
+    handleMenuClose();
+    navigate('/');
+  };
+
   const navBook = () => {
     handleMenuClose();
     navigate('/book');
@@ -100,6 +105,7 @@ const NavBar: React.FC = () => {
           transformOrigin={{ vertical: 'top', horizontal: 'right' }}
         >
           <MenuItem onClick={handleLogout}>Logout</MenuItem>
+          <MenuItem onClick={navHome}>Home</MenuItem>
           <MenuItem onClick={navBook}>Book</MenuItem>
           <MenuItem onClick={navHistory}>Ride History</MenuItem>
           <MenuItem onClick={navProfile}>Profile</MenuItem>


### PR DESCRIPTION
## Summary
- add Home navigation handler and menu item to NavBar
- test NavBar links including new Home link

## Testing
- `npm run lint`
- `cd backend && pytest`
- `CI=true npx vitest run src/components/NavBar.test.tsx`
- `CI=true npm test` *(fails: TypeError: g.maps.DirectionsService is not a constructor)*

------
https://chatgpt.com/codex/tasks/task_e_68a74a51adf483318619079dbdd11158