### PR TITLE
feat: add driver availability tile

### DIFF
--- a/frontend/src/pages/Dashboard/HomePage.test.tsx
+++ b/frontend/src/pages/Dashboard/HomePage.test.tsx
@@ -2,10 +2,14 @@ import { renderWithProviders } from '@/__tests__/setup/renderWithProviders';
 import { screen } from '@testing-library/react';
 import HomePage from './HomePage';
 
-function seedAuth(id: string) {
-  localStorage.setItem('auth_tokens', JSON.stringify({ access_token: 't', refresh_token: 'r', user: { email: 'x' } }));
+function seedAuth(id: string, role = 'CUSTOMER') {
+  localStorage.setItem(
+    'auth_tokens',
+    JSON.stringify({ access_token: 't', refresh_token: 'r', user: { email: 'x', role }, role })
+  );
   localStorage.setItem('userID', id);
   localStorage.setItem('userName', 'Test User');
+  localStorage.setItem('role', role);
 }
 
 describe('HomePage', () => {
@@ -27,6 +31,15 @@ describe('HomePage', () => {
     seedAuth('1');
     renderWithProviders(<HomePage />);
     expect(screen.getByRole('link', { name: /admin dashboard/i })).toBeInTheDocument();
+  });
+
+  it('shows availability tile for driver', () => {
+    seedAuth('2', 'DRIVER');
+    renderWithProviders(<HomePage />);
+    const availabilityLink = screen.getByRole('link', { name: /availability/i });
+    expect(availabilityLink).toBeInTheDocument();
+    // ensure layout includes the extra tile
+    expect(screen.getAllByRole('link')).toHaveLength(5);
   });
 });
 

--- a/frontend/src/pages/Dashboard/HomePage.tsx
+++ b/frontend/src/pages/Dashboard/HomePage.tsx
@@ -8,7 +8,7 @@ interface Tile {
 }
 
 export default function HomePage() {
-  const { userID } = useAuth();
+  const { userID, role } = useAuth();
 
   const tiles: Tile[] = [
     { label: 'Book a Ride', path: '/book' },
@@ -16,6 +16,10 @@ export default function HomePage() {
     { label: 'Driver Dashboard', path: '/driver' },
     { label: 'Profile', path: '/me' },
   ];
+
+  if (role?.toLowerCase() === 'driver') {
+    tiles.splice(3, 0, { label: 'Availability', path: '/driver/availability' });
+  }
 
   if (userID === '1') {
     tiles.push({ label: 'Admin Dashboard', path: '/admin' });


### PR DESCRIPTION
## Summary
- add Availability dashboard tile when logged in as a driver
- test that driver dashboards render the extra tile

## Testing
- `npm run lint`
- `cd backend && pytest`
- `cd frontend && npm test` *(fails: NavBar admin menu, external services, etc.)*
- `npx vitest run src/pages/Dashboard/HomePage.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68a74a548c3c8331bf088dd7a7a40f51