### PR TITLE
test: add availability page tests

### DIFF
--- a/frontend/src/pages/Driver/AvailabilityPage.test.tsx
+++ b/frontend/src/pages/Driver/AvailabilityPage.test.tsx
@@ -1,0 +1,57 @@
+import { renderWithProviders } from '@/__tests__/setup/renderWithProviders';
+import AvailabilityPage from './AvailabilityPage';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi } from 'vitest';
+
+let slots: Array<{ id: number; start_dt: string; end_dt: string; reason?: string }>;
+const refreshMock = vi.fn();
+
+vi.mock('@/hooks/useAvailability', () => ({
+  default: () => ({ data: { slots, bookings: [] }, refresh: refreshMock }),
+}));
+
+describe('AvailabilityPage', () => {
+  beforeEach(() => {
+    slots = [];
+    refreshMock.mockClear();
+    vi.stubGlobal('fetch', vi.fn(() => Promise.resolve({ ok: true } as Response)));
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('lists availability slots', () => {
+    slots.push({ id: 1, start_dt: '2024-01-01T10:00', end_dt: '2024-01-01T11:00', reason: 'Busy' });
+
+    renderWithProviders(<AvailabilityPage />);
+
+    expect(screen.getByText('Busy')).toBeInTheDocument();
+  });
+
+  it('creates a slot and refreshes the list', async () => {
+    const { rerender } = renderWithProviders(<AvailabilityPage />);
+
+    await userEvent.type(screen.getByLabelText(/start/i), '2024-01-01T10:00');
+    await userEvent.type(screen.getByLabelText(/end/i), '2024-01-01T11:00');
+    await userEvent.click(screen.getByRole('button', { name: /add/i }));
+
+    expect(fetch).toHaveBeenCalledWith(
+      expect.stringContaining('/api/v1/availability'),
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({
+          start_dt: '2024-01-01T10:00',
+          end_dt: '2024-01-01T11:00',
+        }),
+      }),
+    );
+    expect(refreshMock).toHaveBeenCalled();
+
+    slots.push({ id: 1, start_dt: '2024-01-01T10:00', end_dt: '2024-01-01T11:00', reason: 'Busy' });
+    rerender(<AvailabilityPage />);
+    expect(screen.getByText('Busy')).toBeInTheDocument();
+  });
+});
+


### PR DESCRIPTION
## Summary
- add tests for driver availability page covering slot listing and creation
- mock useAvailability hook to isolate UI logic

## Testing
- `npm run lint`
- `cd backend && pytest`
- `cd ../frontend && npm test` *(fails: 2 failed)*

------
https://chatgpt.com/codex/tasks/task_e_68a74a5b7a888331ae9c22d8861a43ce