### PR TITLE
test: add e2e page objects and scenarios

### DIFF
--- a/frontend/tests/e2e/pages/booking/BookingPage.ts
+++ b/frontend/tests/e2e/pages/booking/BookingPage.ts
@@ -1,0 +1,15 @@
+import { expect } from '@playwright/test';
+import type { Page } from '@playwright/test';
+
+export class BookingPage {
+  private page: Page;
+  constructor(page: Page) {
+    this.page = page;
+  }
+
+  async goto() {
+    await this.page.goto('/book');
+    await expect(this.page.getByRole('heading', { name: /make a booking/i })).toBeVisible();
+  }
+}
+

--- a/frontend/tests/e2e/pages/driver/DriverAvailabilityPage.ts
+++ b/frontend/tests/e2e/pages/driver/DriverAvailabilityPage.ts
@@ -1,0 +1,33 @@
+import { expect } from '@playwright/test';
+import type { Page } from '@playwright/test';
+
+export class DriverAvailabilityPage {
+  private page: Page;
+  constructor(page: Page) {
+    this.page = page;
+  }
+
+  async goto() {
+    await this.page.goto('/driver/availability');
+    await expect(this.page.getByRole('heading', { name: /availability/i })).toBeVisible();
+  }
+
+  startField() {
+    return this.page.getByLabel(/start/i);
+  }
+
+  endField() {
+    return this.page.getByLabel(/end/i);
+  }
+
+  addButton() {
+    return this.page.getByRole('button', { name: /add/i });
+  }
+
+  async addSlot(start: string, end: string) {
+    await this.startField().fill(start);
+    await this.endField().fill(end);
+    await this.addButton().click();
+  }
+}
+

--- a/frontend/tests/e2e/pages/profile/ProfilePage.ts
+++ b/frontend/tests/e2e/pages/profile/ProfilePage.ts
@@ -1,0 +1,37 @@
+import { expect } from '@playwright/test';
+import type { Page } from '@playwright/test';
+
+export class ProfilePage {
+  private page: Page;
+  constructor(page: Page) {
+    this.page = page;
+  }
+
+  async goto() {
+    await this.page.goto('/profile');
+    await expect(this.page.getByRole('heading', { name: /my profile/i })).toBeVisible();
+  }
+
+  fullNameField() {
+    return this.page.getByLabel(/full name/i);
+  }
+
+  defaultPickupField() {
+    return this.page.getByLabel(/default pickup address/i);
+  }
+
+  saveButton() {
+    return this.page.getByRole('button', { name: /save/i });
+  }
+
+  async update(data: { fullName?: string; defaultPickup?: string }) {
+    if (data.fullName !== undefined) {
+      await this.fullNameField().fill(data.fullName);
+    }
+    if (data.defaultPickup !== undefined) {
+      await this.defaultPickupField().fill(data.defaultPickup);
+    }
+    await this.saveButton().click();
+  }
+}
+

--- a/frontend/tests/e2e/specs/booking/login-booking-history.spec.ts
+++ b/frontend/tests/e2e/specs/booking/login-booking-history.spec.ts
@@ -1,0 +1,76 @@
+import { test, expect } from '@playwright/test';
+import { BookingPage } from '../../pages/booking/BookingPage';
+
+interface Booking {
+  id: string;
+  pickup_address: string;
+  dropoff_address: string;
+  pickup_when: string;
+  status: string;
+  public_code: string;
+  estimated_price_cents: number;
+}
+
+const token = 'test-token';
+let created: Booking | null = null;
+
+test('user logs in, creates booking, views history', async ({ page, request }) => {
+  await page.route('**/auth/token', async route => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ access_token: token, token_type: 'bearer' })
+    });
+  });
+
+  await page.route('**/api/v1/bookings', async route => {
+    if (route.request().method() === 'POST') {
+      created = {
+        id: '1',
+        pickup_address: 'A St',
+        dropoff_address: 'B St',
+        pickup_when: new Date().toISOString(),
+        status: 'PENDING',
+        public_code: 'abc',
+        estimated_price_cents: 1000
+      };
+      await route.fulfill({
+        status: 201,
+        contentType: 'application/json',
+        body: JSON.stringify({ booking: created })
+      });
+    } else {
+      await route.continue();
+    }
+  });
+
+  await page.route('**/api/v1/customers/me/bookings', async route => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(created ? [created] : [])
+    });
+  });
+
+  await page.goto('/login');
+  await page.getByLabel(/email/i).fill('user@example.com');
+  await page.getByLabel(/password/i).fill('pw');
+  await Promise.all([
+    page.waitForURL('**/book'),
+    page.getByRole('button', { name: /log.?in|sign.?in/i }).click()
+  ]);
+
+  const book = new BookingPage(page);
+  await book.goto();
+
+  await request.post('/api/v1/bookings', {
+    data: {},
+    headers: { Authorization: `Bearer ${token}` }
+  });
+
+  await page.goto('/history');
+  await expect(page.getByRole('heading', { name: /ride history/i })).toBeVisible();
+  await expect(page.getByText('A St')).toBeVisible();
+  await expect(page.getByText('B St')).toBeVisible();
+});
+

--- a/frontend/tests/e2e/specs/driver/availability-management.spec.ts
+++ b/frontend/tests/e2e/specs/driver/availability-management.spec.ts
@@ -1,0 +1,56 @@
+import { test, expect } from '@playwright/test';
+import { DriverAvailabilityPage } from '../../pages/driver/DriverAvailabilityPage';
+
+interface Slot {
+  start_dt?: string;
+  end_dt?: string;
+}
+
+const token = 'driver-token';
+let captured: Slot | null = null;
+
+test('driver manages availability slots', async ({ page }) => {
+  await page.route('**/auth/token', async route => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ access_token: token, token_type: 'bearer' })
+    });
+  });
+
+  await page.route('**/api/v1/availability', async route => {
+    if (route.request().method() === 'GET') {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ slots: [] })
+      });
+    } else {
+      captured = JSON.parse(route.request().postData() || '{}');
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ id: '1', ...captured })
+      });
+    }
+  });
+
+  await page.goto('/login');
+  await page.getByLabel(/email/i).fill('driver@example.com');
+  await page.getByLabel(/password/i).fill('pw');
+  await Promise.all([
+    page.waitForURL('**/book'),
+    page.getByRole('button', { name: /log.?in|sign.?in/i }).click()
+  ]);
+
+  const availability = new DriverAvailabilityPage(page);
+  await availability.goto();
+
+  const start = '2024-01-01T10:00';
+  const end = '2024-01-01T11:00';
+  await availability.addSlot(start, end);
+
+  expect(captured.start_dt).toBe(start);
+  expect(captured.end_dt).toBe(end);
+});
+

--- a/frontend/tests/e2e/specs/profile/update.spec.ts
+++ b/frontend/tests/e2e/specs/profile/update.spec.ts
@@ -1,0 +1,54 @@
+import { test, expect } from '@playwright/test';
+import { ProfilePage } from '../../pages/profile/ProfilePage';
+
+interface ProfileUpdate {
+  full_name?: string;
+  default_pickup_address?: string;
+}
+
+const token = 'profile-token';
+let captured: ProfileUpdate | null = null;
+
+test('user updates profile information', async ({ page }) => {
+  await page.route('**/auth/token', async route => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ access_token: token, token_type: 'bearer' })
+    });
+  });
+
+  await page.route('**/users/me', async route => {
+    if (route.request().method() === 'GET') {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ full_name: 'Test User', email: 'user@example.com', default_pickup_address: '123 Rd' })
+      });
+    } else {
+      captured = JSON.parse(route.request().postData() || '{}');
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ ...captured })
+      });
+    }
+  });
+
+  await page.goto('/login');
+  await page.getByLabel(/email/i).fill('user@example.com');
+  await page.getByLabel(/password/i).fill('pw');
+  await Promise.all([
+    page.waitForURL('**/book'),
+    page.getByRole('button', { name: /log.?in|sign.?in/i }).click()
+  ]);
+
+  const profile = new ProfilePage(page);
+  await profile.goto();
+
+  await profile.update({ fullName: 'Updated User', defaultPickup: '456 Ave' });
+
+  expect(captured.full_name).toBe('Updated User');
+  expect(captured.default_pickup_address).toBe('456 Ave');
+});
+


### PR DESCRIPTION
## Summary
- add BookingPage, ProfilePage and DriverAvailabilityPage objects
- cover login→booking→history, profile update and driver availability flows

## Testing
- `npm run lint`
- `pytest`
- `npm test` (fails: 2 failed files)
- `npx playwright test tests/e2e/specs/booking/login-booking-history.spec.ts tests/e2e/specs/profile/update.spec.ts tests/e2e/specs/driver/availability-management.spec.ts` (no tests found)


------
https://chatgpt.com/codex/tasks/task_e_68a74a667518833185d85a1b80007510