### PR TITLE
feat: add setup onboarding page

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,6 @@
 // Main application component setting up routes.
 import { Routes, Route, Navigate } from 'react-router-dom';
+import { useEffect, useState } from 'react';
 import LoginPage from '@/pages/Auth/LoginPage';
 import BookingWizardPage from '@/pages/Booking/BookingWizardPage';
 import AdminDashboard from '@/pages/Admin/AdminDashboard';
@@ -10,6 +11,7 @@ import RideHistoryPage from '@/pages/Booking/RideHistoryPage';
 import RideDetailsPage from '@/pages/Booking/RideDetailsPage';
 import RegisterPage from "@/pages/Auth/RegisterPage";
 import ProfilePage from '@/pages/Profile/ProfilePage';
+import SetupPage from '@/pages/Setup/SetupPage';
 import { useAuth } from "@/contexts/AuthContext";
 import NavBar from '@/components/NavBar';
 import CircularProgress from "@mui/material/CircularProgress";
@@ -17,6 +19,28 @@ import PageNotFound from '@/pages/PageNotFound';
 import DevNotes from '@/components/DevNotes';
 import { useDevFeatures } from '@/contexts/DevFeaturesContext';
 import HomePage from '@/pages/Dashboard/HomePage';
+import { setupApi } from '@/components/ApiConfig';
+
+function SetupRoute() {
+  const [configured, setConfigured] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const { data } = await setupApi.setupStatusSetupGet();
+        setConfigured(data !== null);
+      } catch {
+        setConfigured(false);
+      }
+    })();
+  }, []);
+
+  if (configured === null) {
+    return <CircularProgress size="large" title='Loading' />;
+  }
+
+  return configured ? <Navigate to="/login" /> : <SetupPage />;
+}
 
 function App() {
   const { accessToken, loading, userID } = useAuth(); // custom hook to get AuthContext
@@ -33,6 +57,7 @@ function App() {
       <Route path="/" element={ accessToken ? <HomePage /> : <Navigate to="/login" /> } />
       <Route path="/login" element={ !accessToken ? <LoginPage />: <Navigate to="/" />} />
       <Route path="/register" element={ !accessToken ? <RegisterPage /> : <Navigate to="/" />} />
+      <Route path="/setup" element={<SetupRoute />} />
 
       {/* Protected user routes */}
       <Route

--- a/frontend/src/pages/Setup/SetupPage.test.tsx
+++ b/frontend/src/pages/Setup/SetupPage.test.tsx
@@ -1,0 +1,49 @@
+import { renderWithProviders } from '@/__tests__/setup/renderWithProviders';
+import { Route } from 'react-router-dom';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { http, HttpResponse } from 'msw';
+import { server } from '@/__tests__/setup/msw.server';
+import { apiUrl } from '@/__tests__/setup/msw.handlers';
+import App from '@/App';
+
+const label = (re: RegExp | string) => screen.getByLabelText(re, { selector: 'input' });
+
+test('submits setup form and navigates to /login', async () => {
+  server.use(
+    http.get(apiUrl('/setup'), () => HttpResponse.json(null)),
+    http.post(apiUrl('/setup'), () => HttpResponse.json({ message: 'Setup complete' }))
+  );
+
+  renderWithProviders(<App />, {
+    initialPath: '/setup',
+    extraRoutes: <Route path="/login" element={<h1>Log in</h1>} />,
+  });
+
+  await screen.findByRole('heading', { name: /initial setup/i });
+  await userEvent.type(label(/full name/i), 'Admin User');
+  await userEvent.type(label(/email/i), 'admin@example.com');
+  await userEvent.type(label(/password/i), 'pw');
+  await userEvent.type(label(/flagfall/i), '5');
+  await userEvent.type(label(/per km rate/i), '2');
+  await userEvent.type(label(/per minute rate/i), '1');
+  await userEvent.click(screen.getByRole('button', { name: /complete setup/i }));
+
+  expect(await screen.findByRole('heading', { name: /log in/i })).toBeInTheDocument();
+});
+
+test('redirects to /login if already configured', async () => {
+  server.use(
+    http.get(apiUrl('/setup'), () =>
+      HttpResponse.json({ account_mode: true, flagfall: 1, per_km_rate: 2, per_minute_rate: 3 })
+    )
+  );
+
+  renderWithProviders(<App />, {
+    initialPath: '/setup',
+    extraRoutes: <Route path="/login" element={<h1>Log in</h1>} />,
+  });
+
+  expect(await screen.findByRole('heading', { name: /log in/i })).toBeInTheDocument();
+});
+

--- a/frontend/src/pages/Setup/SetupPage.tsx
+++ b/frontend/src/pages/Setup/SetupPage.tsx
@@ -1,0 +1,117 @@
+import { useState, ChangeEvent } from "react";
+import { useNavigate } from "react-router-dom";
+import { Container, Box, Typography, TextField, Button, Alert, Switch, FormControlLabel } from "@mui/material";
+import { setupApi } from "@/components/ApiConfig";
+import { type SetupPayload } from "@/api-client";
+
+export default function SetupPage() {
+  const navigate = useNavigate();
+  const [fullName, setFullName] = useState("");
+  const [adminEmail, setAdminEmail] = useState("");
+  const [adminPassword, setAdminPassword] = useState("");
+  const [accountMode, setAccountMode] = useState(false);
+  const [flagfall, setFlagfall] = useState("");
+  const [perKmRate, setPerKmRate] = useState("");
+  const [perMinuteRate, setPerMinuteRate] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const onChange = (setter: (v: string) => void) => (e: ChangeEvent<HTMLInputElement>) => setter(e.currentTarget.value);
+
+  const onSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setSubmitting(true);
+    setError(null);
+    try {
+      const payload: SetupPayload = {
+        admin_email: adminEmail,
+        full_name: fullName,
+        admin_password: adminPassword,
+        settings: {
+          account_mode: accountMode,
+          flagfall: parseFloat(flagfall),
+          per_km_rate: parseFloat(perKmRate),
+          per_minute_rate: parseFloat(perMinuteRate),
+        },
+      };
+      const resp: unknown = await setupApi.setupSetupPost(payload);
+      const redirect = (resp as { redirectTo?: string })?.redirectTo;
+      navigate(redirect === "admin" ? "/admin" : "/login", { replace: true });
+    } catch (err: unknown) {
+      if (err instanceof Response) {
+        const data = await err.json().catch(() => ({}));
+        setError(data.detail ?? "Setup failed");
+      } else {
+        setError("Setup failed");
+      }
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Container maxWidth="sm">
+      <Box component="form" onSubmit={onSubmit} sx={{ mt: 6 }}>
+        <Typography variant="h4" component="h1">Initial Setup</Typography>
+
+        {error && <Alert severity="error" role="alert">{error}</Alert>}
+
+        <TextField
+          label="Full Name"
+          margin="normal"
+          fullWidth
+          value={fullName}
+          onChange={onChange(setFullName)}
+        />
+        <TextField
+          label="Email"
+          type="email"
+          margin="normal"
+          fullWidth
+          value={adminEmail}
+          onChange={onChange(setAdminEmail)}
+        />
+        <TextField
+          label="Password"
+          type="password"
+          margin="normal"
+          fullWidth
+          value={adminPassword}
+          onChange={onChange(setAdminPassword)}
+        />
+        <FormControlLabel
+          control={<Switch checked={accountMode} onChange={(_, v) => setAccountMode(v)} />}
+          label="Account Mode"
+        />
+        <TextField
+          label="Flagfall"
+          type="number"
+          margin="normal"
+          fullWidth
+          value={flagfall}
+          onChange={onChange(setFlagfall)}
+        />
+        <TextField
+          label="Per KM Rate"
+          type="number"
+          margin="normal"
+          fullWidth
+          value={perKmRate}
+          onChange={onChange(setPerKmRate)}
+        />
+        <TextField
+          label="Per Minute Rate"
+          type="number"
+          margin="normal"
+          fullWidth
+          value={perMinuteRate}
+          onChange={onChange(setPerMinuteRate)}
+        />
+        <Button type="submit" variant="contained" fullWidth sx={{ mt: 2 }} disabled={submitting}>
+          Complete Setup
+        </Button>
+      </Box>
+    </Container>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add SetupPage with admin and pricing form
- redirect /setup to login if already configured
- test setup form flow and existing configuration

## Testing
- `npm run lint`
- `pytest`
- `npm test` *(fails: TypeError: g.maps.DirectionsService is not a constructor)*
- `npm test -- src/pages/Setup/SetupPage.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68a74acbd1fc8331879aafc1e3c70532