### PR TITLE
refactor: use generated api clients

### DIFF
--- a/frontend/src/__tests__/DriverDashboard.test.tsx
+++ b/frontend/src/__tests__/DriverDashboard.test.tsx
@@ -2,8 +2,7 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import DriverDashboard from '@/pages/Driver/DriverDashboard';
 import { MemoryRouter } from 'react-router-dom';
 import { vi } from 'vitest';
-
-vi.mock('@/services/tokenStore', () => ({ getAccessToken: () => 'tok' }));
+import { driverBookingsApi } from '@/components/ApiConfig';
 
 describe('DriverDashboard', () => {
   it('loads and confirms booking', async () => {
@@ -16,9 +15,14 @@ describe('DriverDashboard', () => {
         status: 'PENDING'
       }
     ];
-    global.fetch = vi.fn()
-      .mockResolvedValueOnce({ ok: true, json: async () => bookings })
-      .mockResolvedValueOnce({ ok: true, json: async () => ({ status: 'DRIVER_CONFIRMED' }) });
+    vi
+      .spyOn(driverBookingsApi, 'listBookingsApiV1DriverBookingsGet')
+      .mockResolvedValue({ data: bookings } as never);
+    vi
+      .spyOn(driverBookingsApi, 'confirmBookingApiV1DriverBookingsBookingIdConfirmPost')
+      .mockResolvedValue({
+        data: { ...bookings[0], status: 'DRIVER_CONFIRMED' },
+      } as never);
 
     render(
       <MemoryRouter>

--- a/frontend/src/__tests__/useAvailability.test.ts
+++ b/frontend/src/__tests__/useAvailability.test.ts
@@ -1,17 +1,14 @@
 import { renderHook, waitFor } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
-import { renderHook, waitFor } from '@testing-library/react';
 import useAvailability from '@/hooks/useAvailability';
+import { availabilityApi } from '@/components/ApiConfig';
 
 describe('useAvailability', () => {
   it('fetches availability data', async () => {
-    vi.mock('@/config', () => ({ CONFIG: { API_BASE_URL: 'http://api' } }));
     const fake = { slots: [], bookings: [] };
-    const fetchMock = vi.fn(async (url: string) => {
-      expect(url).toBe('http://api/api/v1/availability?month=2025-01');
-      return { ok: true, json: async () => fake } as unknown as Response;
-    });
-    vi.stubGlobal('fetch', fetchMock);
+    vi
+      .spyOn(availabilityApi, 'getAvailabilityApiV1AvailabilityGet')
+      .mockResolvedValue({ data: fake } as never);
     const { result } = renderHook(() => useAvailability('2025-01'));
     await waitFor(() => expect(result.current.data).not.toBeNull());
     expect(result.current.data).toEqual(fake);

--- a/frontend/src/components/ApiConfig.test.ts
+++ b/frontend/src/components/ApiConfig.test.ts
@@ -34,6 +34,9 @@ vi.mock("@/api-client", () => {
     UsersApi: FakeApi,
     SetupApi: FakeApi,
     SettingsApi: FakeApi,
+    CustomerBookingsApi: FakeApi,
+    DriverBookingsApi: FakeApi,
+    AvailabilityApi: FakeApi,
   };
 });
 
@@ -43,7 +46,16 @@ describe("ApiConfig", () => {
   test("constructs clients with basePath and token getter", async () => {
     const mod = await import("./ApiConfig");
     const cfg = mod.default;
-    const { authApi, bookingsApi, usersApi, setupApi, settingsApi } = mod;
+    const {
+      authApi,
+      bookingsApi,
+      usersApi,
+      setupApi,
+      settingsApi,
+      customerBookingsApi,
+      driverBookingsApi,
+      availabilityApi,
+    } = mod;
 
     // config assertions
     const cfgTyped = cfg as Configuration;
@@ -52,7 +64,16 @@ describe("ApiConfig", () => {
     await expect(cfgTyped.accessToken()).resolves.toBe("token-abc");
 
     // clients share same Configuration
-    for (const api of [authApi, bookingsApi, usersApi, setupApi, settingsApi]) {
+    for (const api of [
+      authApi,
+      bookingsApi,
+      usersApi,
+      setupApi,
+      settingsApi,
+      customerBookingsApi,
+      driverBookingsApi,
+      availabilityApi,
+    ]) {
       const client = api as FakeApi;
       expect(client).toBeTruthy();
       expect(client.cfg.basePath).toBe("https://api.example.test");

--- a/frontend/src/components/ApiConfig.ts
+++ b/frontend/src/components/ApiConfig.ts
@@ -1,8 +1,17 @@
 // Shared configuration and API client singletons.
-import { Configuration, AuthApi, BookingsApi, UsersApi, SetupApi, SettingsApi } from "@/api-client";
+import {
+  Configuration,
+  AuthApi,
+  BookingsApi,
+  UsersApi,
+  SetupApi,
+  SettingsApi,
+  CustomerBookingsApi,
+  DriverBookingsApi,
+  AvailabilityApi,
+} from "@/api-client";
 import { CONFIG } from "@/config";
 import { getAccessToken } from "@/services/tokenStore";
-
 
 const configuration = new Configuration({
   basePath: CONFIG.API_BASE_URL,
@@ -10,14 +19,26 @@ const configuration = new Configuration({
 });
 
 // Export **instances** (singletons)
-export const authApi     = new AuthApi(configuration);
+export const authApi = new AuthApi(configuration);
 export const bookingsApi = new BookingsApi(configuration);
-export const usersApi    = new UsersApi(configuration);
-export const setupApi    = new SetupApi(configuration);
+export const usersApi = new UsersApi(configuration);
+export const setupApi = new SetupApi(configuration);
 export const settingsApi = new SettingsApi(configuration);
+export const customerBookingsApi = new CustomerBookingsApi(configuration);
+export const driverBookingsApi = new DriverBookingsApi(configuration);
+export const availabilityApi = new AvailabilityApi(configuration);
 
 // (Keep if you still want the classes too)
-export { AuthApi, BookingsApi, UsersApi, SetupApi, SettingsApi } from "@/api-client";
+export {
+  AuthApi,
+  BookingsApi,
+  UsersApi,
+  SetupApi,
+  SettingsApi,
+  CustomerBookingsApi,
+  DriverBookingsApi,
+  AvailabilityApi,
+} from "@/api-client";
 
 // Optional: token change hook
 // onTokenChange(() => { /* e.g. invalidate caches if needed */ });

--- a/frontend/src/hooks/useAvailability.ts
+++ b/frontend/src/hooks/useAvailability.ts
@@ -1,18 +1,12 @@
 import { useEffect, useState, useCallback } from 'react';
-import { CONFIG } from '@/config';
-
-export interface AvailabilityData {
-  slots: { id: number; start_dt: string; end_dt: string; reason?: string | null }[];
-  bookings: { id: string; pickup_when: string }[];
-}
+import { availabilityApi } from '@/components/ApiConfig';
+import type { AvailabilityResponse as AvailabilityData } from '@/api-client';
 
 export default function useAvailability(month: string) {
   const [data, setData] = useState<AvailabilityData | null>(null);
   const fetchData = useCallback(async () => {
-    const res = await fetch(`${CONFIG.API_BASE_URL}/api/v1/availability?month=${month}`);
-    if (res.ok) {
-      setData(await res.json());
-    }
+    const res = await availabilityApi.getAvailabilityApiV1AvailabilityGet(month);
+    setData(res.data as AvailabilityData);
   }, [month]);
   useEffect(() => {
     void fetchData();

--- a/frontend/src/pages/Booking/RideHistoryPage.test.tsx
+++ b/frontend/src/pages/Booking/RideHistoryPage.test.tsx
@@ -2,9 +2,8 @@ import { render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import RideHistoryPage from './RideHistoryPage';
 import { AuthProvider } from '@/contexts/AuthContext';
-import { server } from '@/__tests__/setup/msw.server';
-import { http, HttpResponse } from 'msw';
-import { apiUrl } from '@/__tests__/setup/msw.handlers';
+import { customerBookingsApi } from '@/components/ApiConfig';
+import { vi } from 'vitest';
 
 test('shows track link for trackable bookings', async () => {
   const bookings = [
@@ -28,11 +27,9 @@ test('shows track link for trackable bookings', async () => {
     },
   ];
 
-  server.use(
-    http.get(apiUrl('/api/v1/customers/me/bookings'), () =>
-      HttpResponse.json(bookings),
-    ),
-  );
+  vi
+    .spyOn(customerBookingsApi, 'listMyBookingsApiV1CustomersMeBookingsGet')
+    .mockResolvedValue({ data: bookings } as never);
 
   render(
     <AuthProvider>

--- a/frontend/src/pages/Booking/RideHistoryPage.tsx
+++ b/frontend/src/pages/Booking/RideHistoryPage.tsx
@@ -12,19 +12,8 @@ import {
   Typography,
 } from '@mui/material';
 
-import { CONFIG } from '@/config';
-import { getAccessToken } from '@/services/tokenStore';
-
-interface Booking {
-  id: string;
-  pickup_address: string;
-  dropoff_address: string;
-  pickup_when: string;
-  status: string;
-  public_code: string;
-  estimated_price_cents: number;
-  final_price_cents?: number;
-}
+import { customerBookingsApi } from '@/components/ApiConfig';
+import type { AppSchemasBookingV2BookingRead as Booking } from '@/api-client';
 
 function RideHistoryPage() {
   const navigate = useNavigate();
@@ -38,15 +27,13 @@ function RideHistoryPage() {
 
     (async () => {
       try {
-        const token = getAccessToken();
-        const res = await fetch(`${CONFIG.API_BASE_URL}/api/v1/customers/me/bookings`, {
-          headers: { Authorization: `Bearer ${token}` }
-        });
-        if (!res.ok) throw new Error('Failed to load bookings');
-        const data = await res.json();
-        if (alive) setBookings(data as Booking[]);
+        const res = await customerBookingsApi.listMyBookingsApiV1CustomersMeBookingsGet();
+        if (alive) setBookings(res.data as Booking[]);
       } catch (e: unknown) {
-        if (alive) setError(e instanceof Error ? e.message : 'Failed to load bookings');
+        if (alive)
+          setError(
+            e instanceof Error ? e.message : 'Failed to load bookings',
+          );
       } finally {
         if (alive) setLoading(false);
       }

--- a/frontend/src/pages/Driver/AvailabilityPage.tsx
+++ b/frontend/src/pages/Driver/AvailabilityPage.tsx
@@ -1,8 +1,7 @@
 import { useState } from 'react';
 import { Stack, TextField, Button, List, ListItem, ListItemText, Typography } from '@mui/material';
 import useAvailability from '@/hooks/useAvailability';
-import { CONFIG } from '@/config';
-import { getAccessToken } from '@/services/tokenStore';
+import { availabilityApi } from '@/components/ApiConfig';
 
 export default function AvailabilityPage() {
   const month = new Date().toISOString().slice(0, 7);
@@ -11,14 +10,9 @@ export default function AvailabilityPage() {
   const [end, setEnd] = useState('');
 
   async function create() {
-    const token = getAccessToken();
-    await fetch(`${CONFIG.API_BASE_URL}/api/v1/availability`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${token}`,
-      },
-      body: JSON.stringify({ start_dt: start, end_dt: end }),
+    await availabilityApi.createSlotApiV1AvailabilityPost({
+      start_dt: start,
+      end_dt: end,
     });
     setStart('');
     setEnd('');


### PR DESCRIPTION
## Summary
- switch pages to shared ApiConfig API clients
- remove manual token usage and adjust hooks
- update tests to mock API client methods

## Testing
- `npm run lint`
- `cd backend && pytest`
- `cd frontend && npm test` *(fails: NavBar.test.tsx and external service tests due to unhandled requests)*

------
https://chatgpt.com/codex/tasks/task_e_68a74ad829648331a6e4a2eb9791ab4a