### PR TITLE
refactor: remove default ApiConfig export

### DIFF
--- a/frontend/src/components/ApiConfig.test.ts
+++ b/frontend/src/components/ApiConfig.test.ts
@@ -42,11 +42,10 @@ vi.mock("@/config", () => ({ CONFIG: { API_BASE_URL: "https://api.example.test" 
 describe("ApiConfig", () => {
   test("constructs clients with basePath and token getter", async () => {
     const mod = await import("./ApiConfig");
-    const cfg = mod.default;
-    const { authApi, bookingsApi, usersApi, setupApi, settingsApi } = mod;
+    const { configuration, authApi, bookingsApi, usersApi, setupApi, settingsApi } = mod;
 
     // config assertions
-    const cfgTyped = cfg as Configuration;
+    const cfgTyped = configuration as Configuration;
     expect(cfgTyped.basePath).toBe("https://api.example.test");
     expect(typeof cfgTyped.accessToken).toBe("function");
     await expect(cfgTyped.accessToken()).resolves.toBe("token-abc");

--- a/frontend/src/components/ApiConfig.ts
+++ b/frontend/src/components/ApiConfig.ts
@@ -4,7 +4,7 @@ import { CONFIG } from "@/config";
 import { getAccessToken } from "@/services/tokenStore";
 
 
-const configuration = new Configuration({
+export const configuration = new Configuration({
   basePath: CONFIG.API_BASE_URL,
   accessToken: async () => getAccessToken() ?? "",
 });
@@ -21,6 +21,3 @@ export { AuthApi, BookingsApi, UsersApi, SetupApi, SettingsApi } from "@/api-cli
 
 // Optional: token change hook
 // onTokenChange(() => { /* e.g. invalidate caches if needed */ });
-
-// (Optional) still export default for legacy imports
-export default configuration;

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -1,6 +1,6 @@
 // React context providing authentication state and helpers.
 import React, { createContext, useCallback, useContext, useEffect, useMemo, useState } from "react";
-import cfg, { AuthApi } from "@/components/ApiConfig";
+import { configuration, AuthApi } from "@/components/ApiConfig";
 import { CONFIG } from "@/config";
 import { setTokens, getRefreshToken } from "../services/tokenStore";
 import { beginLogin, completeLoginFromRedirect, refreshTokens, TokenResponse, OAuthConfig } from "../services/oauth";
@@ -29,7 +29,7 @@ const oauthCfg: OAuthConfig = {
 
 export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const [state, setState] = useState<AuthState>({ accessToken: null, user: null, loading: true, userID: null, userName: null, role: null });
-  const authApi = useMemo(() => new AuthApi(cfg), []);
+  const authApi = useMemo(() => new AuthApi(configuration), []);
   // const [userName, setUserName] = useState<string>('');
   // const [userID, setUserID] = useState<string|null>(null);
 

--- a/frontend/src/pages/Admin/AdminDashboard.tsx
+++ b/frontend/src/pages/Admin/AdminDashboard.tsx
@@ -3,7 +3,7 @@ import { AxiosError } from "axios";
 // Use the SAME shared API client that RegisterPage uses so we hit the correct backend/db
 // Update the path below to exactly match RegisterPage's import if different
 // import { SettingsApi } from "../../api-client/api";
-import config, { SettingsApi } from "@/components/ApiConfig";
+import { configuration, SettingsApi } from "@/components/ApiConfig";
 import type { SettingsPayload } from "@/api-client";
 import { useDevFeatures } from '@/contexts/DevFeaturesContext';
 import {
@@ -39,7 +39,7 @@ export default function AdminDashboard() {
   //   // Replace with your actual token plumbed from context if needed.
   //   accessToken: () => localStorage.getItem("access_token") || "",
   // });
-  const settingsApi = useMemo(() => new SettingsApi(config), []);
+  const settingsApi = useMemo(() => new SettingsApi(configuration), []);
   const { enabled: devEnabled, setEnabled: setDevEnabled, isProd } = useDevFeatures();
 
   // Local UI state

--- a/frontend/src/pages/Auth/RegisterPage.tsx
+++ b/frontend/src/pages/Auth/RegisterPage.tsx
@@ -12,8 +12,8 @@ import {
   Button,
   Alert,
 } from '@mui/material';
-import cfg, { AuthApi } from "@/components/ApiConfig"
-const authApi = new AuthApi(cfg);
+import { configuration, AuthApi } from "@/components/ApiConfig";
+const authApi = new AuthApi(configuration);
 
 function RegisterPage() {
     const [email, setEmail] = useState("");


### PR DESCRIPTION
## Summary
- refactor ApiConfig to export named `configuration` and remove default export
- update components and tests to use named configuration

## Testing
- `npm run lint`
- `cd backend && pytest`
- `cd ../frontend && npm test` *(fails: 3 failed tests, 1 error)*

------
https://chatgpt.com/codex/tasks/task_e_68a74b0af0b483318372b05fd582d7fc