### PR TITLE
test: add navigation tests for dashboard links

### DIFF
--- a/frontend/src/components/NavBar.test.tsx
+++ b/frontend/src/components/NavBar.test.tsx
@@ -5,6 +5,7 @@ import { AuthProvider } from '@/contexts/AuthContext';
 import { DevFeaturesProvider } from '@/contexts/DevFeaturesContext';
 import NavBar from './NavBar';
 import { render } from '@testing-library/react';
+import type { ReactNode } from 'react';
 
 function seedAuth({ id, name, role }: { id: string; name: string; role: string }) {
   localStorage.setItem('auth_tokens', JSON.stringify({ access_token: 't', refresh_token: 'r', user: { email: 'x' }, role }));
@@ -13,12 +14,13 @@ function seedAuth({ id, name, role }: { id: string; name: string; role: string }
   localStorage.setItem('userRole', role);
 }
 
-function renderWithAuth(initialPath = '/book') {
+function renderWithAuth(initialPath = '/book', extraRoutes?: ReactNode) {
   return render(
     <DevFeaturesProvider>
       <AuthProvider>
         <MemoryRouter initialEntries={[initialPath]}>
           <Routes>
+            {extraRoutes}
             <Route path="/login" element={<h1>Log in</h1>} />
             <Route path="*" element={<NavBar />} />
           </Routes>
@@ -33,7 +35,8 @@ describe('NavBar', () => {
     seedAuth({ id: '1', name: 'Admin User', role: 'ADMIN' });
     renderWithAuth();
 
-    await userEvent.click(screen.getByLabelText(/account/i)); // open menu
+    const accountBtn = await screen.findByLabelText(/account/i);
+    await userEvent.click(accountBtn); // open menu
     expect(await screen.findByRole('menuitem', { name: /admin dashboard/i })).toBeInTheDocument();
   });
 
@@ -41,7 +44,8 @@ describe('NavBar', () => {
     seedAuth({ id: '2', name: 'Driver User', role: 'DRIVER' });
     renderWithAuth();
 
-    await userEvent.click(screen.getByLabelText(/account/i));
+    const accountBtn = await screen.findByLabelText(/account/i);
+    await userEvent.click(accountBtn);
     expect(await screen.findByRole('menuitem', { name: /driver dashboard/i })).toBeInTheDocument();
     expect(await screen.findByRole('menuitem', { name: /availability/i })).toBeInTheDocument();
     expect(screen.queryByRole('menuitem', { name: /admin dashboard/i })).not.toBeInTheDocument();
@@ -51,7 +55,8 @@ describe('NavBar', () => {
     seedAuth({ id: '3', name: 'Regular User', role: 'CUSTOMER' });
     renderWithAuth();
 
-    await userEvent.click(screen.getByLabelText(/account/i));
+    const accountBtn = await screen.findByLabelText(/account/i);
+    await userEvent.click(accountBtn);
     expect(screen.queryByRole('menuitem', { name: /admin dashboard/i })).not.toBeInTheDocument();
     expect(screen.queryByRole('menuitem', { name: /driver dashboard/i })).not.toBeInTheDocument();
   });
@@ -60,7 +65,8 @@ describe('NavBar', () => {
     seedAuth({ id: '1', name: 'Admin User', role: 'ADMIN' });
     renderWithAuth('/book');
 
-    await userEvent.click(screen.getByLabelText(/account/i));
+    const accountBtn = await screen.findByLabelText(/account/i);
+    await userEvent.click(accountBtn);
     await userEvent.click(screen.getByRole('menuitem', { name: /logout/i }));
 
     // We provide a /login route with <h1>Log in</h1>
@@ -69,5 +75,74 @@ describe('NavBar', () => {
     expect(localStorage.getItem('userID')).toBeNull();
     expect(localStorage.getItem('userName')).toBeNull();
     expect(localStorage.getItem('userRole')).toBeNull();
+  });
+
+  test('book menu item navigates to booking wizard', async () => {
+    seedAuth({ id: '3', name: 'Regular User', role: 'CUSTOMER' });
+    renderWithAuth('/home', <Route path="/book" element={<h1>Book</h1>} />);
+
+    const accountBtn = await screen.findByLabelText(/account/i);
+    await userEvent.click(accountBtn);
+    await userEvent.click(screen.getByRole('menuitem', { name: /book/i }));
+    expect(
+      await screen.findByRole('heading', { name: /book/i })
+    ).toBeInTheDocument();
+  });
+
+  test('ride history menu item navigates to history page', async () => {
+    seedAuth({ id: '3', name: 'Regular User', role: 'CUSTOMER' });
+    renderWithAuth('/home', <Route path="/history" element={<h1>History</h1>} />);
+
+    const accountBtn = await screen.findByLabelText(/account/i);
+    await userEvent.click(accountBtn);
+    await userEvent.click(screen.getByRole('menuitem', { name: /ride history/i }));
+    expect(
+      await screen.findByRole('heading', { name: /history/i })
+    ).toBeInTheDocument();
+  });
+
+  test('driver dashboard menu navigates to driver dashboard', async () => {
+    seedAuth({ id: '2', name: 'Driver User', role: 'DRIVER' });
+    renderWithAuth('/book', <Route path="/driver" element={<h1>Driver</h1>} />);
+
+    const accountBtn = await screen.findByLabelText(/account/i);
+    await userEvent.click(accountBtn);
+    await userEvent.click(
+      screen.getByRole('menuitem', { name: /driver dashboard/i })
+    );
+    expect(
+      await screen.findByRole('heading', { name: /driver/i })
+    ).toBeInTheDocument();
+  });
+
+  test('availability menu navigates to driver availability', async () => {
+    seedAuth({ id: '2', name: 'Driver User', role: 'DRIVER' });
+    renderWithAuth(
+      '/book',
+      <Route path="/driver/availability" element={<h1>Availability</h1>} />,
+    );
+
+    const accountBtn = await screen.findByLabelText(/account/i);
+    await userEvent.click(accountBtn);
+    await userEvent.click(
+      screen.getByRole('menuitem', { name: /availability/i })
+    );
+    expect(
+      await screen.findByRole('heading', { name: /availability/i })
+    ).toBeInTheDocument();
+  });
+
+  test('admin menu item navigates to admin dashboard', async () => {
+    seedAuth({ id: '1', name: 'Admin User', role: 'ADMIN' });
+    renderWithAuth('/book', <Route path="/admin" element={<h1>Admin</h1>} />);
+
+    const accountBtn = await screen.findByLabelText(/account/i);
+    await userEvent.click(accountBtn);
+    await userEvent.click(
+      screen.getByRole('menuitem', { name: /admin dashboard/i })
+    );
+    expect(
+      await screen.findByRole('heading', { name: /admin/i })
+    ).toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/Booking/RideHistoryPage.test.tsx
+++ b/frontend/src/pages/Booking/RideHistoryPage.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
 import RideHistoryPage from './RideHistoryPage';
 import { AuthProvider } from '@/contexts/AuthContext';
 import { server } from '@/__tests__/setup/msw.server';
@@ -47,4 +48,41 @@ test('shows track link for trackable bookings', async () => {
   const trackLinks = screen.getAllByRole('link', { name: /track/i });
   expect(trackLinks).toHaveLength(1);
   expect(trackLinks[0]).toHaveAttribute('href', '/t/abc123');
+});
+
+test('track link navigates to tracking page', async () => {
+  const bookings = [
+    {
+      id: '1',
+      pickup_address: 'A',
+      dropoff_address: 'B',
+      pickup_when: new Date().toISOString(),
+      status: 'on_the_way',
+      estimated_price_cents: 1000,
+      public_code: 'abc123',
+    },
+  ];
+
+  server.use(
+    http.get(apiUrl('/api/v1/customers/me/bookings'), () =>
+      HttpResponse.json(bookings),
+    ),
+  );
+
+  render(
+    <AuthProvider>
+      <MemoryRouter initialEntries={['/history']}>
+        <Routes>
+          <Route path="/history" element={<RideHistoryPage />} />
+          <Route path="/t/:code" element={<h1>Tracking</h1>} />
+        </Routes>
+      </MemoryRouter>
+    </AuthProvider>,
+  );
+
+  const link = await screen.findByRole('link', { name: /track/i });
+  await userEvent.click(link);
+  expect(
+    await screen.findByRole('heading', { name: /tracking/i })
+  ).toBeInTheDocument();
 });

--- a/frontend/src/pages/Dashboard/HomePage.test.tsx
+++ b/frontend/src/pages/Dashboard/HomePage.test.tsx
@@ -1,5 +1,7 @@
 import { renderWithProviders } from '@/__tests__/setup/renderWithProviders';
 import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Route } from 'react-router-dom';
 import HomePage from './HomePage';
 
 function seedAuth(id: string) {
@@ -27,6 +29,50 @@ describe('HomePage', () => {
     seedAuth('1');
     renderWithProviders(<HomePage />);
     expect(screen.getByRole('link', { name: /admin dashboard/i })).toBeInTheDocument();
+  });
+
+  it('navigates to booking wizard', async () => {
+    seedAuth('2');
+    renderWithProviders(<HomePage />, {
+      extraRoutes: <Route path="/book" element={<h1>Book</h1>} />,
+    });
+    await userEvent.click(screen.getByRole('link', { name: /book a ride/i }));
+    expect(
+      await screen.findByRole('heading', { name: /book/i })
+    ).toBeInTheDocument();
+  });
+
+  it('navigates to ride history details', async () => {
+    seedAuth('2');
+    renderWithProviders(<HomePage />, {
+      extraRoutes: <Route path="/history" element={<h1>History</h1>} />,
+    });
+    await userEvent.click(screen.getByRole('link', { name: /ride history/i }));
+    expect(
+      await screen.findByRole('heading', { name: /history/i })
+    ).toBeInTheDocument();
+  });
+
+  it('navigates to driver dashboard', async () => {
+    seedAuth('2');
+    renderWithProviders(<HomePage />, {
+      extraRoutes: <Route path="/driver" element={<h1>Driver</h1>} />,
+    });
+    await userEvent.click(screen.getByRole('link', { name: /driver dashboard/i }));
+    expect(
+      await screen.findByRole('heading', { name: /driver/i })
+    ).toBeInTheDocument();
+  });
+
+  it('navigates to admin dashboard for admin user', async () => {
+    seedAuth('1');
+    renderWithProviders(<HomePage />, {
+      extraRoutes: <Route path="/admin" element={<h1>Admin</h1>} />,
+    });
+    await userEvent.click(screen.getByRole('link', { name: /admin dashboard/i }));
+    expect(
+      await screen.findByRole('heading', { name: /admin/i })
+    ).toBeInTheDocument();
   });
 });
 


### PR DESCRIPTION
## Summary
- add navigation tests for Home tiles
- exercise NavBar menu navigation per role
- verify tracking links from ride history reach tracking page

## Testing
- `npm run lint`
- `cd backend && pytest`
- `cd ../frontend && npm test` *(fails: unable to find driver dashboard menu item; external services unhandled)*

------
https://chatgpt.com/codex/tasks/task_e_68a74b3140b08331a6663fd3de9815c2