### PR TITLE
fix: handle HTTPException separately in logging middleware

### DIFF
--- a/backend/app/core/logging.py
+++ b/backend/app/core/logging.py
@@ -7,6 +7,7 @@ from typing import Callable, Optional
 from uuid import uuid4
 
 import graypy
+from fastapi import HTTPException
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
 from starlette.responses import Response
@@ -95,6 +96,15 @@ class RequestLoggingMiddleware(BaseHTTPMiddleware):
         start = time()
         try:
             response = await call_next(request)
+        except HTTPException as exc:
+            logger.warning(
+                "%s %s status=%s detail=%s",
+                request.method,
+                request.url.path,
+                exc.status_code,
+                exc.detail,
+            )
+            raise
         except Exception:
             logger.exception("%s %s unhandled error", request.method, request.url.path)
             raise

--- a/backend/tests/unit/core/test_request_logging_middleware.py
+++ b/backend/tests/unit/core/test_request_logging_middleware.py
@@ -1,0 +1,49 @@
+import logging
+
+import pytest
+from fastapi import HTTPException
+from starlette.requests import Request
+
+from app.core.logging import RequestLoggingMiddleware
+
+pytestmark = pytest.mark.asyncio
+
+
+async def dummy_app(scope, receive, send) -> None:
+    pass
+
+
+async def test_dispatch_logs_http_exception(caplog: pytest.LogCaptureFixture) -> None:
+    middleware = RequestLoggingMiddleware(dummy_app)
+    request = Request({"type": "http", "method": "GET", "path": "/fail", "headers": []})
+
+    async def call_next(_: Request):
+        raise HTTPException(status_code=418, detail="teapot")
+
+    with caplog.at_level(logging.WARNING, logger="app.request"):
+        with pytest.raises(HTTPException):
+            await middleware.dispatch(request, call_next)  # type: ignore[arg-type]
+
+    records = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert records
+    message = records[0].getMessage()
+    assert "status=418" in message
+    assert "detail=teapot" in message
+
+
+async def test_dispatch_logs_unexpected_exception(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    middleware = RequestLoggingMiddleware(dummy_app)
+    request = Request({"type": "http", "method": "GET", "path": "/boom", "headers": []})
+
+    async def call_next(_: Request):
+        raise ValueError("boom")
+
+    with caplog.at_level(logging.ERROR, logger="app.request"):
+        with pytest.raises(ValueError):
+            await middleware.dispatch(request, call_next)  # type: ignore[arg-type]
+
+    records = [r for r in caplog.records if r.levelno == logging.ERROR]
+    assert records
+    assert "unhandled error" in records[0].getMessage()


### PR DESCRIPTION
## Summary
- handle HTTPException separately in RequestLoggingMiddleware
- add tests for HTTP and unexpected exceptions

## Testing
- `npm run lint` (fails: unused vars in frontend)
- `cd backend && pytest`
- `cd ../frontend && npm test` (fails: multiple failing suites)


------
https://chatgpt.com/codex/tasks/task_e_68a84713fd9c8331b22576992d07fa34