### PR TITLE
feat: expose availability API client

### DIFF
--- a/frontend/src/components/ApiConfig.test.ts
+++ b/frontend/src/components/ApiConfig.test.ts
@@ -44,7 +44,17 @@ vi.mock("@/config", () => ({ CONFIG: { API_BASE_URL: "https://api.example.test" 
 describe("ApiConfig", () => {
   test("constructs clients with basePath and token getter", async () => {
     const mod = await import("./ApiConfig");
-    const { authApi, bookingsApi, driverBookingsApi, usersApi, setupApi, settingsApi } = mod;
+    const {
+      configuration,
+      authApi,
+      bookingsApi,
+      customerBookingsApi,
+      driverBookingsApi,
+      usersApi,
+      setupApi,
+      settingsApi,
+      availabilityApi,
+    } = mod;
 
     // config assertions
     const cfgTyped = configuration as Configuration;
@@ -53,7 +63,16 @@ describe("ApiConfig", () => {
     await expect(cfgTyped.accessToken()).resolves.toBe("token-abc");
 
     // clients share same Configuration
-    for (const api of [authApi, bookingsApi, driverBookingsApi, usersApi, setupApi, settingsApi]) {
+    for (const api of [
+      authApi,
+      bookingsApi,
+      customerBookingsApi,
+      driverBookingsApi,
+      usersApi,
+      setupApi,
+      settingsApi,
+      availabilityApi,
+    ]) {
       const client = api as FakeApi;
       expect(client).toBeTruthy();
       expect(client.cfg.basePath).toBe("https://api.example.test");

--- a/frontend/src/components/ApiConfig.ts
+++ b/frontend/src/components/ApiConfig.ts
@@ -1,5 +1,14 @@
 // Shared configuration and API client singletons.
-import { Configuration, AuthApi, BookingsApi, UsersApi, SetupApi, SettingsApi, DriverBookingsApi } from "@/api-client";
+import {
+  Configuration,
+  AuthApi,
+  BookingsApi,
+  UsersApi,
+  SetupApi,
+  SettingsApi,
+  DriverBookingsApi,
+  AvailabilityApi,
+} from "@/api-client";
 import { CONFIG } from "@/config";
 import { getAccessToken } from "@/services/tokenStore";
 
@@ -12,10 +21,12 @@ export const configuration = new Configuration({
 // Export **instances** (singletons)
 export const authApi = new AuthApi(configuration);
 export const bookingsApi = new BookingsApi(configuration);
+export const customerBookingsApi = new BookingsApi(configuration);
 export const driverBookingsApi = new DriverBookingsApi(configuration);
 export const usersApi = new UsersApi(configuration);
 export const setupApi = new SetupApi(configuration);
 export const settingsApi = new SettingsApi(configuration);
+export const availabilityApi = new AvailabilityApi(configuration);
 
 // (Keep if you still want the classes too)
 export {


### PR DESCRIPTION
## Summary
- add AvailabilityApi singleton and export from ApiConfig
- provide customerBookingsApi alias for tests
- verify ApiConfig test covers new clients

## Testing
- `npm run lint`
- `cd backend && pytest`
- `cd frontend && npm test` *(fails: listMyBookingsApiV1CustomersMeBookingsGet does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68a8a9d55714833185de73fdcd43016e