### PR TITLE
test: destructure configuration in ApiConfig test

### DIFF
--- a/frontend/src/components/ApiConfig.test.ts
+++ b/frontend/src/components/ApiConfig.test.ts
@@ -43,8 +43,15 @@ vi.mock("@/config", () => ({ CONFIG: { API_BASE_URL: "https://api.example.test" 
 
 describe("ApiConfig", () => {
   test("constructs clients with basePath and token getter", async () => {
-    const mod = await import("./ApiConfig");
-    const { authApi, bookingsApi, driverBookingsApi, usersApi, setupApi, settingsApi } = mod;
+    const {
+      configuration,
+      authApi,
+      bookingsApi,
+      driverBookingsApi,
+      usersApi,
+      setupApi,
+      settingsApi,
+    } = await import("./ApiConfig");
 
     // config assertions
     const cfgTyped = configuration as Configuration;


### PR DESCRIPTION
## Summary
- Destructure configuration when dynamically importing ApiConfig to use exported configuration

## Testing
- `npm run lint`
- `cd backend && pytest` *(fails: Expected ValueError for invalid token)*
- `cd frontend && npm test` *(fails: Cannot convert undefined or null to object)*

------
https://chatgpt.com/codex/tasks/task_e_68a8a9df68ac833183061c5f212fc654