### PR TITLE
feat: add customer bookings api client

### DIFF
--- a/frontend/src/api-client/api.ts
+++ b/frontend/src/api-client/api.ts
@@ -758,6 +758,12 @@ export interface UserRead {
      * @memberof UserRead
      */
     'id': number;
+    /**
+     * 
+     * @type {string}
+     * @memberof UserRead
+     */
+    'fcm_token'?: string | null;
 }
 /**
  * Optional fields for updating a user.
@@ -789,6 +795,12 @@ export interface UserUpdate {
      * @memberof UserUpdate
      */
     'default_pickup_address'?: string | null;
+    /**
+     * 
+     * @type {string}
+     * @memberof UserUpdate
+     */
+    'fcm_token'?: string | null;
 }
 /**
  * 
@@ -1527,6 +1539,103 @@ export class BookingsApi extends BaseAPI {
      */
     public createBookingEndpointApiV1BookingsPost(bookingCreateRequest: BookingCreateRequest, options?: RawAxiosRequestConfig) {
         return BookingsApiFp(this.configuration).createBookingEndpointApiV1BookingsPost(bookingCreateRequest, options).then((request) => request(this.axios, this.basePath));
+    }
+}
+
+
+
+/**
+ * CustomerBookingsApi - axios parameter creator
+ * @export
+ */
+export const CustomerBookingsApiAxiosParamCreator = function (configuration?: Configuration) {
+    return {
+        /**
+         * 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        listMyBookingsApiV1CustomersMeBookingsGet: async (options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+            const localVarPath = `/api/v1/customers/me/bookings`;
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+
+    
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+    }
+};
+
+/**
+ * CustomerBookingsApi - functional programming interface
+ * @export
+ */
+export const CustomerBookingsApiFp = function(configuration?: Configuration) {
+    const localVarAxiosParamCreator = CustomerBookingsApiAxiosParamCreator(configuration)
+    return {
+        /**
+         * 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async listMyBookingsApiV1CustomersMeBookingsGet(options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<BookingRead>>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.listMyBookingsApiV1CustomersMeBookingsGet(options);
+            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+            const localVarOperationServerBasePath = operationServerMap['CustomerBookingsApi.listMyBookingsApiV1CustomersMeBookingsGet']?.[localVarOperationServerIndex]?.url;
+            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
+        },
+    }
+};
+
+/**
+ * CustomerBookingsApi - factory interface
+ * @export
+ */
+export const CustomerBookingsApiFactory = function (configuration?: Configuration, basePath?: string, axios?: AxiosInstance) {
+    const localVarFp = CustomerBookingsApiFp(configuration)
+    return {
+        /**
+         * 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        listMyBookingsApiV1CustomersMeBookingsGet(options?: RawAxiosRequestConfig): AxiosPromise<Array<BookingRead>> {
+            return localVarFp.listMyBookingsApiV1CustomersMeBookingsGet(options).then((request) => request(axios, basePath));
+        },
+    };
+};
+
+/**
+ * CustomerBookingsApi - object-oriented interface
+ * @export
+ * @class CustomerBookingsApi
+ * @extends {BaseAPI}
+ */
+export class CustomerBookingsApi extends BaseAPI {
+    /**
+     * 
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof CustomerBookingsApi
+     */
+    public listMyBookingsApiV1CustomersMeBookingsGet(options?: RawAxiosRequestConfig) {
+        return CustomerBookingsApiFp(this.configuration).listMyBookingsApiV1CustomersMeBookingsGet(options).then((request) => request(this.axios, this.basePath));
     }
 }
 

--- a/frontend/src/components/ApiConfig.test.ts
+++ b/frontend/src/components/ApiConfig.test.ts
@@ -31,6 +31,7 @@ vi.mock("@/api-client", () => {
     Configuration,
     AuthApi: FakeApi,
     BookingsApi: FakeApi,
+    CustomerBookingsApi: FakeApi,
     DriverBookingsApi: FakeApi,
     UsersApi: FakeApi,
     SetupApi: FakeApi,
@@ -44,7 +45,16 @@ vi.mock("@/config", () => ({ CONFIG: { API_BASE_URL: "https://api.example.test" 
 describe("ApiConfig", () => {
   test("constructs clients with basePath and token getter", async () => {
     const mod = await import("./ApiConfig");
-    const { authApi, bookingsApi, driverBookingsApi, usersApi, setupApi, settingsApi } = mod;
+    const {
+      configuration,
+      authApi,
+      bookingsApi,
+      customerBookingsApi,
+      driverBookingsApi,
+      usersApi,
+      setupApi,
+      settingsApi,
+    } = mod;
 
     // config assertions
     const cfgTyped = configuration as Configuration;
@@ -53,7 +63,15 @@ describe("ApiConfig", () => {
     await expect(cfgTyped.accessToken()).resolves.toBe("token-abc");
 
     // clients share same Configuration
-    for (const api of [authApi, bookingsApi, driverBookingsApi, usersApi, setupApi, settingsApi]) {
+    for (const api of [
+      authApi,
+      bookingsApi,
+      customerBookingsApi,
+      driverBookingsApi,
+      usersApi,
+      setupApi,
+      settingsApi,
+    ]) {
       const client = api as FakeApi;
       expect(client).toBeTruthy();
       expect(client.cfg.basePath).toBe("https://api.example.test");

--- a/frontend/src/components/ApiConfig.ts
+++ b/frontend/src/components/ApiConfig.ts
@@ -1,5 +1,14 @@
 // Shared configuration and API client singletons.
-import { Configuration, AuthApi, BookingsApi, UsersApi, SetupApi, SettingsApi, DriverBookingsApi } from "@/api-client";
+import {
+  Configuration,
+  AuthApi,
+  BookingsApi,
+  CustomerBookingsApi,
+  UsersApi,
+  SetupApi,
+  SettingsApi,
+  DriverBookingsApi,
+} from "@/api-client";
 import { CONFIG } from "@/config";
 import { getAccessToken } from "@/services/tokenStore";
 
@@ -12,6 +21,7 @@ export const configuration = new Configuration({
 // Export **instances** (singletons)
 export const authApi = new AuthApi(configuration);
 export const bookingsApi = new BookingsApi(configuration);
+export const customerBookingsApi = new CustomerBookingsApi(configuration);
 export const driverBookingsApi = new DriverBookingsApi(configuration);
 export const usersApi = new UsersApi(configuration);
 export const setupApi = new SetupApi(configuration);
@@ -21,6 +31,7 @@ export const settingsApi = new SettingsApi(configuration);
 export {
   AuthApi,
   BookingsApi,
+  CustomerBookingsApi,
   DriverBookingsApi,
   UsersApi,
   SetupApi,


### PR DESCRIPTION
## Summary
- add generated CustomerBookingsApi with listMyBookings API
- export customerBookingsApi singleton and update tests

## Testing
- `npm run lint`
- `cd backend && pytest`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a8a9f7e93c8331b9a0fa3f53e22f41