### PR TITLE
refactor: use push subscription utility

### DIFF
--- a/frontend/src/pages/Profile/ProfilePage.tsx
+++ b/frontend/src/pages/Profile/ProfilePage.tsx
@@ -1,11 +1,11 @@
 import { useEffect, useState } from 'react';
-import { Box, Button, TextField, Typography, Tooltip, FormControlLabel, Switch } from '@mui/material';
+import { Box, Button, TextField, Typography, Tooltip } from '@mui/material';
 import { AddressField } from '@/components/AddressField';
 import { useAuth } from '@/contexts/AuthContext';
 import PushToggle from '@/components/PushToggle';
 import { CONFIG } from '@/config';
 
-  const ProfilePage = () => {
+const ProfilePage = () => {
   const { ensureFreshToken } = useAuth();
   const [fullName, setFullName] = useState('');
   const [email, setEmail] = useState('');
@@ -14,9 +14,6 @@ import { CONFIG } from '@/config';
   const [oldPasswordValid, setOldPasswordValid] = useState(false);
   const [newPassword, setNewPassword] = useState('');
   const [confirmPassword, setConfirmPassword] = useState('');
-  const [notificationsEnabled, setNotificationsEnabled] = useState(
-    typeof Notification !== 'undefined' && Notification.permission === 'granted'
-  );
 
   useEffect(() => {
     const load = async () => {
@@ -89,13 +86,6 @@ import { CONFIG } from '@/config';
     setConfirmPassword('');
   };
 
-  const handleNotificationsChange = async (_e: React.ChangeEvent<HTMLInputElement>, checked: boolean) => {
-    setNotificationsEnabled(checked);
-    if (checked) {
-      await initPush();
-    }
-  };
-
   return (
     <Box component="form" onSubmit={handleSubmit} sx={{ p: 2, maxWidth: 400, m: '0 auto' }}>
       <Typography variant="h5" gutterBottom>
@@ -132,11 +122,6 @@ import { CONFIG } from '@/config';
         margin="normal"
         fullWidth
         disabled={!newPassword || !oldPasswordValid}
-      />
-      <FormControlLabel
-        control={<Switch checked={notificationsEnabled} onChange={handleNotificationsChange} />}
-        label="Enable notifications"
-        sx={{ mt: 2 }}
       />
       <Tooltip title={newPassword === confirmPassword ? '' : 'new password and confirm password must match'} disableHoverListener={newPassword === confirmPassword}>
         <span>


### PR DESCRIPTION
## Summary
- replace deprecated `initPush` with `subscribePush` and rename helper to `maybeSubscribePush`
- drop unused notification toggle in profile page and rely on `PushToggle`

## Testing
- `npm run lint`
- `cd backend && pytest`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68adfb0d96f88331974b310f70fb9420