### PR TITLE
fix: allow first user to access admin and driver dashboards

### DIFF
--- a/frontend/src/__tests__/AccessControl.test.tsx
+++ b/frontend/src/__tests__/AccessControl.test.tsx
@@ -39,23 +39,23 @@ function renderWithAuth(value: Partial<AuthContextType>, initial: string) {
 }
 
 describe('route access control', () => {
-  it('allows admin to access admin dashboard', () => {
-    renderWithAuth({ accessToken: 'tok', role: 'admin' }, '/admin');
+  it('allows first user to access admin dashboard', () => {
+    renderWithAuth({ accessToken: 'tok', userID: '1' }, '/admin');
     expect(screen.getByText('Admin Page')).toBeInTheDocument();
   });
 
-  it('redirects non-admin from admin dashboard', async () => {
-    renderWithAuth({ accessToken: 'tok', role: 'driver' }, '/admin');
+  it('redirects other users from admin dashboard', async () => {
+    renderWithAuth({ accessToken: 'tok', userID: '2' }, '/admin');
     await waitFor(() => expect(screen.getByText('Login Page')).toBeInTheDocument());
   });
 
-  it('allows driver to access driver dashboard', () => {
-    renderWithAuth({ accessToken: 'tok', role: 'driver' }, '/driver');
+  it('allows first user to access driver dashboard', () => {
+    renderWithAuth({ accessToken: 'tok', userID: '1' }, '/driver');
     expect(screen.getByText('Driver Page')).toBeInTheDocument();
   });
 
-  it('redirects non-driver from driver dashboard', async () => {
-    renderWithAuth({ accessToken: 'tok', role: 'admin' }, '/driver');
+  it('redirects other users from driver dashboard', async () => {
+    renderWithAuth({ accessToken: 'tok', userID: '2' }, '/driver');
     await waitFor(() => expect(screen.getByText('Login Page')).toBeInTheDocument());
   });
 });

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -314,19 +314,20 @@ export const RequireRole: React.FC<{ role: string; children: React.ReactNode }> 
   role,
   children,
 }) => {
-  const { accessToken, loading, role: userRole } = useAuth();
+  const { accessToken, loading, role: userRole, userID } = useAuth();
   const navigate = useNavigate();
   const location = useLocation();
 
   useEffect(() => {
     if (!loading) {
       const from = encodeURIComponent(location.pathname + location.search);
-      if (!accessToken || userRole !== role) {
+      const allowed = accessToken && (userRole === role || userID === '1');
+      if (!allowed) {
         navigate(`/login?from=${from}`, { replace: true });
       }
     }
-  }, [loading, accessToken, userRole, role, location, navigate]);
+  }, [loading, accessToken, userRole, userID, role, location, navigate]);
 
-  if (loading || !accessToken || userRole !== role) return null;
+  if (loading || !accessToken || (userRole !== role && userID !== '1')) return null;
   return <>{children}</>;
 };

--- a/frontend/src/pages/Dashboard/HomePage.test.tsx
+++ b/frontend/src/pages/Dashboard/HomePage.test.tsx
@@ -24,8 +24,8 @@ describe('HomePage', () => {
     renderWithProviders(<HomePage />);
     expect(screen.getByRole('link', { name: /book a ride/i })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /ride history/i })).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: /driver dashboard/i })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /profile/i })).toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: /driver dashboard/i })).not.toBeInTheDocument();
     expect(screen.queryByRole('link', { name: /admin dashboard/i })).not.toBeInTheDocument();
   });
 
@@ -57,8 +57,8 @@ describe('HomePage', () => {
     ).toBeInTheDocument();
   });
 
-  it('navigates to driver dashboard', async () => {
-    seedAuth('2');
+  it('navigates to driver dashboard for first user', async () => {
+    seedAuth('1');
     renderWithProviders(<HomePage />, {
       extraRoutes: <Route path="/driver" element={<h1>Driver</h1>} />,
     });

--- a/frontend/src/pages/Dashboard/HomePage.tsx
+++ b/frontend/src/pages/Dashboard/HomePage.tsx
@@ -8,20 +8,17 @@ interface Tile {
 }
 
 export default function HomePage() {
-  const { userID, role } = useAuth();
+  const { userID } = useAuth();
 
   const tiles: Tile[] = [
     { label: 'Book a Ride', path: '/book' },
     { label: 'Ride History', path: '/history' },
-    { label: 'Driver Dashboard', path: '/driver' },
     { label: 'Profile', path: '/me' },
   ];
 
-  if (role?.toLowerCase() === 'driver') {
-    tiles.splice(3, 0, { label: 'Availability', path: '/driver/availability' });
-  }
-
   if (userID === '1') {
+    tiles.splice(2, 0, { label: 'Driver Dashboard', path: '/driver' });
+    tiles.splice(3, 0, { label: 'Availability', path: '/driver/availability' });
     tiles.push({ label: 'Admin Dashboard', path: '/admin' });
   }
 


### PR DESCRIPTION
## Summary
- guard admin and driver routes by checking user ID
- show driver/admin dashboard tiles only for first user
- update unit tests for new access rules

## Testing
- `npm run lint`
- `cd backend && pytest`
- `cd frontend && npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68ae124faa108331a25a7fbd3b568f25