### PR TITLE
fix: handle undefined price in payment step

### DIFF
--- a/frontend/src/components/BookingWizard/PaymentStep.tsx
+++ b/frontend/src/components/BookingWizard/PaymentStep.tsx
@@ -102,11 +102,11 @@ function PaymentInner({ data, onBack }: Props) {
       <TextField label="Name" value={name} onChange={(e) => setName(e.target.value)} />
       <TextField label="Email" value={email} onChange={(e) => setEmail(e.target.value)} />
       <TextField label="Phone" value={phone} onChange={(e) => setPhone(e.target.value)} />
-      {price !== null && (
+      {price != null && (
         <Typography>Estimated fare: ${price.toFixed(2)}</Typography>
       )}
       <Typography variant="body2">
-        50% deposit{price !== null ? ` ($${(price * 0.5).toFixed(2)})` : ''} charged on
+        50% deposit{price != null ? ` ($${(price * 0.5).toFixed(2)})` : ''} charged on
         confirmation
       </Typography>
       <CardElement />


### PR DESCRIPTION
## Summary
- prevent crash when fare estimate is undefined by checking for nullish values before formatting

## Testing
- `npm run lint`
- `cd backend && pytest`
- `cd ../frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae1758b14c833190ef9a42cf7ae670