### PR TITLE
fix: compute fare estimate in PaymentStep

### DIFF
--- a/frontend/src/components/BookingWizard/PaymentStep.test.tsx
+++ b/frontend/src/components/BookingWizard/PaymentStep.test.tsx
@@ -18,7 +18,7 @@ vi.mock('@/hooks/useSettings', () => ({
   useSettings: () => ({ data: {} }),
 }));
 vi.mock('@/hooks/useDirections', () => ({
-  useDirections: () => ({ price: null }),
+  useDirections: () => async () => null,
 }));
 vi.mock('@stripe/react-stripe-js', () => ({
   Elements: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,

--- a/frontend/src/pages/Booking/BookingWizardPage.test.tsx
+++ b/frontend/src/pages/Booking/BookingWizardPage.test.tsx
@@ -29,7 +29,7 @@ vi.mock('@/hooks/useSettings', () => ({
   useSettings: () => ({ data: { flagfall: 0, per_km_rate: 0, per_minute_rate: 0 } }),
 }));
 vi.mock('@/hooks/useDirections', () => ({
-  useDirections: () => ({ price: 100 }),
+  useDirections: () => async () => ({ km: 0, min: 0 }),
 }));
 vi.mock('@/hooks/useAddressAutocomplete', () => ({
   useAddressAutocomplete: () => ({ suggestions: [], loading: false }),


### PR DESCRIPTION
## Summary
- compute fare estimate using route metrics to avoid undefined `toFixed`
- adjust tests for updated `useDirections` API

## Testing
- `npm run lint`
- `cd backend && pytest -q`
- `cd frontend && npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68b062d1d8ac8331883cedc561aeea28