### PR TITLE
fix: allow public access to settings

### DIFF
--- a/backend/app/api/settings.py
+++ b/backend/app/api/settings.py
@@ -6,25 +6,21 @@ import logging
 from fastapi import APIRouter, Depends, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.dependencies import get_current_user, get_db  # ensure admin check here
+from app.dependencies import get_current_user, get_db
 from app.schemas.setup import SettingsPayload
 from app.schemas.user import UserRead
 from app.services.settings_service import get_settings, update_settings
 
 logger = logging.getLogger(__name__)
 
-router = APIRouter(
-    prefix="/settings", tags=["settings"], dependencies=[Depends(get_current_user)]
-)
+router = APIRouter(prefix="/settings", tags=["settings"])
 
 
 @router.get("", response_model=SettingsPayload)
-async def api_get_settings(
-    db: AsyncSession = Depends(get_db), user: UserRead = Depends(get_current_user)
-):
+async def api_get_settings(db: AsyncSession = Depends(get_db)):
     """Return current pricing and configuration."""
-    logger.info("fetching settings", extra={"user_id": user.id})
-    return await get_settings(db, user)
+    logger.info("fetching settings")
+    return await get_settings(db)
 
 
 @router.put("", response_model=SettingsPayload, status_code=status.HTTP_200_OK)

--- a/backend/app/services/settings_service.py
+++ b/backend/app/services/settings_service.py
@@ -6,7 +6,7 @@ from fastapi import Depends, HTTPException
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.dependencies import get_current_user, get_db
+from app.dependencies import get_db
 from app.models.settings import AdminConfig
 from app.schemas.setup import SettingsPayload
 from app.schemas.user import UserRead
@@ -20,15 +20,11 @@ def ensure_admin(user: UserRead):
         raise HTTPException(status_code=403, detail="Admin only")
 
 
-async def get_settings(
-    db: AsyncSession = Depends(get_db), user: UserRead = Depends(get_current_user)
-) -> SettingsPayload:
-    """Fetch pricing configuration from the database."""
-    ensure_admin(user)
-    logger.info(
-        "retrieving settings",
-        extra={"user_id": getattr(user, "id", "unknown")},
-    )
+async def get_settings(db: AsyncSession = Depends(get_db)) -> SettingsPayload:
+    """Fetch pricing configuration from the database.
+
+    This endpoint is now public, so no user check occurs here."""
+    logger.info("retrieving settings")
     row = await db.get(AdminConfig, 1)
     if not row:
         raise HTTPException(status_code=404, detail="No settings yet")

--- a/backend/tests/integration/test_settings_api.py
+++ b/backend/tests/integration/test_settings_api.py
@@ -28,11 +28,7 @@ async def _ensure_admin_id1(async_session: AsyncSession) -> User:
 
 
 @pytest.mark.asyncio
-async def test_settings_requires_auth(client: AsyncClient):
-    # GET without a bearer token should be unauthorized
-    resp = await client.get("/settings")
-    assert resp.status_code in (401, 403)
-
+async def test_settings_put_requires_auth(client: AsyncClient):
     # PUT without a bearer token should be unauthorized
     resp2 = await client.put(
         "/settings",
@@ -66,12 +62,8 @@ async def test_get_settings_after_setup(
     # Allow 400 if setup was already completed by a previous test run
     assert setup_resp.status_code in (200, 201, 400)
 
-    # Authenticate explicitly as id=1 (matches ensure_admin rule)
-    u1 = await _ensure_admin_id1(async_session)
-    token = create_jwt_token(u1.id)
-    headers = {"Authorization": f"Bearer {token}"}
-
-    resp = await client.get("/settings", headers=headers)
+    # GET should succeed without authentication
+    resp = await client.get("/settings")
     assert resp.status_code == 200
     data = resp.json()
     assert data == {
@@ -120,7 +112,7 @@ async def test_put_settings_updates_values(
     data = put_resp.json()
     assert data == new_values.model_dump()
 
-    # Subsequent GET reflects new values
-    get_resp = await client.get("/settings", headers=headers)
+    # Subsequent GET reflects new values without auth
+    get_resp = await client.get("/settings")
     assert get_resp.status_code == 200
     assert get_resp.json() == new_values.model_dump()

--- a/backend/tests/unit/services/test_settings_service.py
+++ b/backend/tests/unit/services/test_settings_service.py
@@ -1,6 +1,5 @@
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
-from _pytest.monkeypatch import MonkeyPatch
 from fastapi import HTTPException
 from sqlalchemy import text
 
@@ -10,23 +9,17 @@ from app.schemas.user import UserRead
 
 pytestmark = pytest.mark.asyncio
 
-async def test_get_settings_404_when_missing(monkeypatch: MonkeyPatch, async_session: AsyncSession):
-    """Service currently raises 404 when no settings row exists."""
+async def test_get_settings_404_when_missing(async_session: AsyncSession):
+    """Service raises 404 when no settings row exists."""
     await async_session.execute(text("DELETE FROM admin_config"))
     await async_session.commit()
-
-    # Bypass admin check inside the service
-    monkeypatch.setattr(settings_service, "ensure_admin", lambda *_args, **_kwargs: None) # type: ignore
 
     with pytest.raises(HTTPException) as exc:
         await settings_service.get_settings(async_session)
     assert exc.value.status_code == 404
 
 
-async def test_update_then_get_returns_values(monkeypatch: MonkeyPatch, async_session: AsyncSession):
-    # Bypass admin check inside the service
-    monkeypatch.setattr(settings_service, "ensure_admin", lambda *_args, **_kwargs: None) # type: ignore
-
+async def test_update_then_get_returns_values(async_session: AsyncSession):
     user: UserRead = UserRead(
         email="test@na.com",
         full_name="bloke",


### PR DESCRIPTION
## Summary
- allow unauthenticated clients to fetch /settings
- update tests for public settings endpoint

## Testing
- `npm run lint`
- `cd backend && pytest`
- `cd ../frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b065e8ea2083319e68ccdc3348bf61