### PR TITLE
fix: send ISO pickup timestamp

### DIFF
--- a/frontend/src/__tests__/useStripeSetupIntent.test.ts
+++ b/frontend/src/__tests__/useStripeSetupIntent.test.ts
@@ -8,7 +8,8 @@ describe('useStripeSetupIntent', () => {
       booking: { id: '1', status: 'PENDING', public_code: 'ABC', estimated_price_cents: 1000, deposit_required_cents: 500 },
       stripe: { setup_intent_client_secret: 'sec' },
     };
-    global.fetch = vi.fn().mockResolvedValue({ ok: true, json: async () => fakeResp }) as unknown as typeof fetch;
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => fakeResp });
+    global.fetch = fetchMock as unknown as typeof fetch;
     const { result } = renderHook(() => useStripeSetupIntent());
     const data = await result.current.createBooking({
       pickup_when: '2025-01-01T00:00:00Z',
@@ -17,6 +18,8 @@ describe('useStripeSetupIntent', () => {
       passengers: 1,
       customer: { name: 'x', email: 'y@example.com' },
     });
+    const [, opts] = fetchMock.mock.calls[0];
+    expect(JSON.parse(opts.body as string).pickup_when).toBe('2025-01-01T00:00:00Z');
     expect(data.clientSecret).toBe('sec');
   });
 });

--- a/frontend/src/components/BookingWizard/PaymentStep.test.tsx
+++ b/frontend/src/components/BookingWizard/PaymentStep.test.tsx
@@ -47,7 +47,9 @@ test('shows tracking link after booking', async () => {
   );
 
   await userEvent.click(screen.getByRole('button', { name: /submit/i }));
-
+  expect(mockCreateBooking).toHaveBeenCalledWith(
+    expect.objectContaining({ pickup_when: '2025-01-01T00:00:00Z' }),
+  );
   const link = await screen.findByRole('link', { name: /track this ride/i });
   expect(link).toHaveAttribute('href', '/t/ABC123');
 });

--- a/frontend/src/components/BookingWizard/SelectTimeStep.test.tsx
+++ b/frontend/src/components/BookingWizard/SelectTimeStep.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi, expect, test } from 'vitest';
+import SelectTimeStep from './SelectTimeStep';
+
+vi.mock('@/hooks/useAvailability', () => ({
+  default: () => ({ data: { slots: [], bookings: [] } }),
+}));
+
+test('passes ISO string to onNext', async () => {
+  const onNext = vi.fn();
+  render(<SelectTimeStep data={{}} onNext={onNext} />);
+  const input = screen.getByLabelText(/pickup time/i);
+  const value = '2025-01-01T10:00';
+  await userEvent.clear(input);
+  await userEvent.type(input, value);
+  await userEvent.click(screen.getByRole('button', { name: /next/i }));
+  expect(onNext).toHaveBeenCalledWith({
+    pickup_when: new Date(value).toISOString(),
+  });
+});

--- a/frontend/src/components/BookingWizard/SelectTimeStep.tsx
+++ b/frontend/src/components/BookingWizard/SelectTimeStep.tsx
@@ -35,7 +35,11 @@ export default function SelectTimeStep({ data, onNext }: Props) {
         InputLabelProps={{ shrink: true }}
       />
       {blocked && <Typography color="error">Time unavailable</Typography>}
-      <Button variant="contained" onClick={() => onNext({ pickup_when: when })} disabled={!when || blocked}>
+      <Button
+        variant="contained"
+        onClick={() => onNext({ pickup_when: new Date(when).toISOString() })}
+        disabled={!when || blocked}
+      >
         Next
       </Button>
     </Stack>

--- a/frontend/src/pages/Booking/BookingWizardPage.test.tsx
+++ b/frontend/src/pages/Booking/BookingWizardPage.test.tsx
@@ -67,7 +67,7 @@ test('advances through steps and aggregates form data', async () => {
   await userEvent.click(screen.getByRole('button', { name: /submit/i }));
 
   expect(createBooking).toHaveBeenCalledWith({
-    pickup_when: '2025-01-01T10:00',
+    pickup_when: new Date('2025-01-01T10:00').toISOString(),
     pickup: { address: '123 A St', lat: 0, lng: 0 },
     dropoff: { address: '456 B St', lat: 0, lng: 0 },
     passengers: 2,


### PR DESCRIPTION
## Summary
- convert pickup time to ISO string when advancing from Select Time step
- test that booking wizard and Stripe setup receive unchanged ISO strings
- verify `useStripeSetupIntent` sends ISO timestamp to backend

## Testing
- `npm run lint`
- `cd backend && pytest`
- `cd ../frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b0eff167408331a0ddaf0991a6612a