### PR TITLE
feat: display fare breakdown on booking payment step

### DIFF
--- a/frontend/src/components/BookingWizard/PaymentStep.tsx
+++ b/frontend/src/components/BookingWizard/PaymentStep.tsx
@@ -12,6 +12,7 @@ import { useStripeSetupIntent } from '@/hooks/useStripeSetupIntent';
 import { useSettings } from '@/hooks/useSettings';
 import { settingsApi } from '@/components/ApiConfig';
 import { useRouteMetrics } from '@/hooks/useRouteMetrics';
+import FareBreakdown from '@/components/FareBreakdown';
 
 const stripePromise = (async () => {
   try {
@@ -64,6 +65,8 @@ function PaymentInner({ data, onBack }: Props) {
   };
   const getMetrics = useRouteMetrics();
   const [price, setPrice] = useState<number | null>(null);
+  const [distanceKm, setDistanceKm] = useState<number>(0);
+  const [durationMin, setDurationMin] = useState<number>(0);
 
   useEffect(() => {
     let ignore = false;
@@ -78,6 +81,8 @@ function PaymentInner({ data, onBack }: Props) {
           metrics.km * tariff.perKm +
           metrics.min * tariff.perMin;
         setPrice(estimate);
+        setDistanceKm(metrics.km);
+        setDurationMin(metrics.min);
       }
     }
     fetchPrice();
@@ -136,6 +141,14 @@ function PaymentInner({ data, onBack }: Props) {
       {price != null && (
         <Typography>Estimated fare: ${price.toFixed(2)}</Typography>
       )}
+      <FareBreakdown
+        price={price}
+        flagfall={tariff.flagfall}
+        perKm={tariff.perKm}
+        perMin={tariff.perMin}
+        distanceKm={distanceKm}
+        durationMin={durationMin}
+      />
       <Typography variant="body2">
         50% deposit{price != null ? ` ($${(price * 0.5).toFixed(2)})` : ''} charged on
         confirmation


### PR DESCRIPTION
## Summary
- show fare breakdown below estimated fare in booking wizard when dev features enabled
- test fare breakdown visibility toggled by development features

## Testing
- `npm run lint`
- `cd backend && pytest`
- `cd ../frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b0f47b3518833193dcded2d9f7d4bf