### PR TITLE
fix: handle missing routes in Google Directions API

### DIFF
--- a/backend/app/services/routing.py
+++ b/backend/app/services/routing.py
@@ -53,7 +53,14 @@ async def estimate_route(
                 if resp.status_code < 500:
                     resp.raise_for_status()
                     data = resp.json()
-                    leg = data["routes"][0]["legs"][0]
+                    routes = data.get("routes") or []
+                    if (
+                        data.get("status") != "OK"
+                        or not routes
+                        or not routes[0].get("legs")
+                    ):
+                        raise ValueError("no route found")
+                    leg = routes[0]["legs"][0]
                     distance_km = leg["distance"]["value"] / 1000.0
                     duration_min = leg["duration"]["value"] / 60.0
                     return distance_km, duration_min

--- a/backend/tests/unit/services/test_routing.py
+++ b/backend/tests/unit/services/test_routing.py
@@ -1,7 +1,6 @@
 import httpx
 import pytest
 from _pytest.monkeypatch import MonkeyPatch
-
 from app.services import routing
 
 pytestmark = pytest.mark.asyncio
@@ -39,6 +38,7 @@ async def test_estimate_route_retries_then_succeeds(monkeypatch: MonkeyPatch):
             return DummyResp(
                 200,
                 {
+                    "status": "OK",
                     "routes": [
                         {
                             "legs": [
@@ -48,7 +48,7 @@ async def test_estimate_route_retries_then_succeeds(monkeypatch: MonkeyPatch):
                                 }
                             ]
                         }
-                    ]
+                    ],
                 },
             )
 

--- a/backend/tests/unit/services/test_routing_no_route.py
+++ b/backend/tests/unit/services/test_routing_no_route.py
@@ -1,0 +1,37 @@
+import httpx
+import pytest
+from _pytest.monkeypatch import MonkeyPatch
+from app.services import routing
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_estimate_route_no_route(monkeypatch: MonkeyPatch):
+    class DummyResp:
+        status_code = 200
+
+        def json(self):
+            return {"status": "ZERO_RESULTS", "routes": []}
+
+        def raise_for_status(self) -> None:  # pragma: no cover - no HTTP errors
+            return None
+
+    class DummyClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc_info):
+            return None
+
+        async def get(self, url, params=None, timeout=None):  # type: ignore[override]
+            return DummyResp()
+
+    monkeypatch.setattr(
+        routing,
+        "settings",
+        type("S", (), {"env": "prod", "google_maps_api_key": "x"})(),
+    )
+    monkeypatch.setattr(routing.httpx, "AsyncClient", DummyClient)
+
+    with pytest.raises(ValueError, match="no route"):
+        await routing.estimate_route(1, 2, 3, 4)


### PR DESCRIPTION
## Summary
- raise a `ValueError` when Google Directions API returns no usable routes
- test successful route estimation and missing route case

## Testing
- `npm run lint`
- `cd backend && pytest`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b0fa476d9c8331a7134ba75ea4d2a3