### PR TITLE
feat: add health check endpoint

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -9,6 +9,8 @@ RUN pip install --no-cache-dir -r requirements.txt
 FROM python:3.11-slim
 WORKDIR /app
 RUN useradd -u 1000 -m appuser
+# Install curl for healthcheck
+RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/*
 # Install gunicorn and uvicorn
 RUN pip install --no-cache-dir gunicorn uvicorn[standard]
 
@@ -27,6 +29,9 @@ USER appuser
 # RUN chown 1000:1000 /data
 # Expose API port
 EXPOSE 8000
+
+HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
+    CMD curl -f http://localhost:8000/health || exit 1
 
 COPY --chmod=755 docker-entrypoint.sh /entrypoint.sh
 # RUN chown -R 10001:10001 /entrypoint.sh

--- a/backend/app/api/health.py
+++ b/backend/app/api/health.py
@@ -1,0 +1,22 @@
+"""Health check endpoint."""
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db.database import get_async_session
+
+router = APIRouter(tags=["health"])
+
+
+@router.get("/health", status_code=status.HTTP_200_OK)
+async def health(db: AsyncSession = Depends(get_async_session)):
+    """Return 200 if database connection succeeds, 503 otherwise."""
+    try:
+        await db.execute(text("SELECT 1"))
+        return {"status": "ok"}
+    except Exception as exc:  # noqa: BLE001
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Service unavailable",
+        ) from exc

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -20,6 +20,7 @@ from fastapi.responses import JSONResponse, RedirectResponse
 
 from app.api import auth as auth_router
 from app.api import geocode as geocode_router
+from app.api import health as health_router
 from app.api import route_metrics as route_metrics_router
 from app.api import settings as settings_router
 from app.api import setup as setup_router
@@ -78,6 +79,7 @@ app.include_router(auth_router.router)
 app.include_router(geocode_router.router)
 app.include_router(setup_router.router)
 app.include_router(settings_router.router)
+app.include_router(health_router.router)
 app.include_router(route_metrics_router.router)
 app.include_router(users_router.router)
 app.include_router(bookings_v1_router.router)


### PR DESCRIPTION
## Summary
- add FastAPI /health endpoint to verify database connectivity
- wire health router into application startup
- include Docker HEALTHCHECK for service readiness

## Testing
- `npm run lint`
- `cd backend && pytest`
- `cd ../frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b1056b8f708331997387f3cc2f2653