### PR TITLE
feat: use backend API for address autocomplete

### DIFF
--- a/frontend/src/hooks/useAddressAutocomplete.test.tsx
+++ b/frontend/src/hooks/useAddressAutocomplete.test.tsx
@@ -1,32 +1,57 @@
 import { renderHook, waitFor } from "@testing-library/react";
-import { describe, expect, test, vi } from "vitest";
+import { afterEach, describe, expect, test, vi } from "vitest";
 import { useAddressAutocomplete } from "./useAddressAutocomplete";
 
-const sample = [
-  {
-    address: {
-      unit: "12",
-      house_number: "34",
-      road: "Main St",
-      suburb: "Springfield",
-      postcode: "1234",
-    },
-  },
-];
-
 describe("useAddressAutocomplete", () => {
-  test("returns formatted suggestions", async () => {
-    vi.stubGlobal("fetch", vi.fn(async () => ({
-      ok: true,
-      json: async () => sample,
-    })));
-
-    const { result } = renderHook(() => useAddressAutocomplete("123", { debounceMs: 0 }));
-
-    await waitFor(() => {
-      expect(result.current.suggestions[0].display).toBe("12/34 Main St Springfield 1234");
-    });
-
+  afterEach(() => {
     vi.unstubAllGlobals();
   });
+
+  test("returns formatted suggestions for airport codes", async () => {
+    const sample = [
+      { name: "JFK", address: { city: "Queens", postcode: "11430" } },
+    ];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({ ok: true, json: async () => sample }))
+    );
+
+    const { result } = renderHook(() =>
+      useAddressAutocomplete("jf", { debounceMs: 0 })
+    );
+
+    await waitFor(() => {
+      expect(result.current.suggestions[0]).toEqual({
+        name: "JFK",
+        address: sample[0].address,
+        display: "JFK, Queens 11430",
+      });
+    });
+  });
+
+  test("returns formatted suggestions for POIs", async () => {
+    const sample = [
+      {
+        name: "Central Park",
+        address: { city: "New York", postcode: "10022" },
+      },
+    ];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({ ok: true, json: async () => sample }))
+    );
+
+    const { result } = renderHook(() =>
+      useAddressAutocomplete("central", { debounceMs: 0 })
+    );
+
+    await waitFor(() => {
+      expect(result.current.suggestions[0]).toEqual({
+        name: "Central Park",
+        address: sample[0].address,
+        display: "Central Park, New York 10022",
+      });
+    });
+  });
 });
+

--- a/frontend/src/hooks/useAddressAutocomplete.ts
+++ b/frontend/src/hooks/useAddressAutocomplete.ts
@@ -1,10 +1,12 @@
 // Hook to fetch address suggestions as the user types.
 import { useEffect, useState } from "react";
 import { CONFIG } from "@/config";
-import { formatAddress } from "@/lib/formatAddress";
+import { formatAddress, type AddressComponents } from "@/lib/formatAddress";
 import * as logger from "@/lib/logger";
 
 export interface AddressSuggestion {
+  name: string;
+  address: AddressComponents;
   display: string;
 }
 
@@ -21,24 +23,25 @@ export function useAddressAutocomplete(query: string, options?: { debounceMs?: n
     const timeout = setTimeout(async () => {
       try {
         setLoading(true);
-        const backend = CONFIG.API_BASE_URL as string | undefined;
-        let url: string;
-        if (backend) {
-          const u = new URL("/geocode/search", backend || window.location.origin);
-          u.searchParams.set("q", query);
-          url = u.toString();
-        } else {
-          url = `https://nominatim.openstreetmap.org/search?format=json&addressdetails=1&limit=5&q=${encodeURIComponent(query)}`;
-        }
+        const base = (CONFIG.API_BASE_URL as string | undefined) || window.location.origin;
+        const u = new URL("/geocode/search", base);
+        u.searchParams.set("q", query);
+        const url = u.toString();
         const res = await fetch(url, { signal: controller.signal });
         if (!res.ok) throw new Error("Autocomplete failed");
         const data = await res.json();
         const list = Array.isArray(data) ? data : data?.results || [];
         setSuggestions(
           list
-            .map((item: Record<string, unknown>) => ({
-              display: formatAddress((item as { address?: Record<string, unknown> }).address || item),
-            }))
+            .map((item: { name?: string; address?: AddressComponents }) => {
+              const name = item.name || "";
+              const address = (item.address || {}) as AddressComponents;
+              return {
+                name,
+                address,
+                display: [name, formatAddress(address)].filter(Boolean).join(", "),
+              };
+            })
             .filter((s: AddressSuggestion) => !!s.display)
         );
       } catch (e) {


### PR DESCRIPTION
## Summary
- always query backend API for address autocomplete suggestions
- include name and address in suggestions and update tests

## Testing
- `npm run lint`
- `cd backend && pytest`
- `cd frontend && CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b10e4240a88331bc09b1b0b9a8b86d