### PR TITLE
feat: enhance route metrics logging

### DIFF
--- a/backend/app/api/route_metrics.py
+++ b/backend/app/api/route_metrics.py
@@ -1,13 +1,11 @@
 """Endpoint exposing distance and duration calculations."""
 
 import logging
-
 from datetime import datetime
 from typing import Union
 
-from fastapi import APIRouter, HTTPException, Query
-
 from app.services.route_metrics_service import get_route_metrics
+from fastapi import APIRouter, HTTPException, Query
 
 logger = logging.getLogger(__name__)
 
@@ -24,10 +22,29 @@ async def api_route_metrics(
 ):
     """Return travel metrics between pickup and dropoff addresses."""
     try:
-        logger.info(
-            "route metrics pickup=%s dropoff=%s ride_time=%s", pickup, dropoff, ride_time
+        logger.debug(
+            "route metrics inputs pickup=%s dropoff=%s ride_time=%s",
+            pickup,
+            dropoff,
+            ride_time,
         )
-        return await get_route_metrics(pickup, dropoff, ride_time)
+        logger.info(
+            "route metrics pickup=%s dropoff=%s ride_time=%s",
+            pickup,
+            dropoff,
+            ride_time,
+        )
+        metrics = await get_route_metrics(pickup, dropoff, ride_time)
+        logger.debug("route metrics result %s", metrics)
+        return metrics
+    except ValueError as e:
+        logger.warning(
+            "route metrics invalid input pickup=%s dropoff=%s ride_time=%s",
+            pickup,
+            dropoff,
+            ride_time,
+        )
+        raise HTTPException(status_code=400, detail=str(e))
     except Exception as e:
         logger.error(
             "route metrics error pickup=%s dropoff=%s ride_time=%s",
@@ -36,4 +53,3 @@ async def api_route_metrics(
             ride_time,
         )
         raise HTTPException(status_code=400, detail=str(e))
-


### PR DESCRIPTION
## Summary
- log route metrics inputs and outputs at debug level
- add warning log for invalid route metrics inputs

## Testing
- `npm run lint` *(fails: 'AddressComponents' is defined but never used)*
- `cd backend && pytest` *(fails: tests/unit/services/test_geocode_service.py::test_search_geocode_returns_airport)*
- `cd ../frontend && npm test` *(fails: src/hooks/useAddressAutocomplete.test.tsx > returns formatted suggestions for airport codes; returns formatted suggestions for POIs)*

------
https://chatgpt.com/codex/tasks/task_e_68b11fac9fec83319d8efdb0c43e5ec6