### PR TITLE
feat: add debug and info logs to AddressField

### DIFF
--- a/frontend/src/components/AddressField.tsx
+++ b/frontend/src/components/AddressField.tsx
@@ -1,6 +1,8 @@
 // Text field with autocomplete and optional geolocation button.
+import { useEffect } from "react";
 import { TextField, InputAdornment, IconButton, CircularProgress, Autocomplete } from "@mui/material";
 import MyLocationIcon from "@mui/icons-material/MyLocation";
+import * as logger from "@/lib/logger";
 import { AddressSuggestion } from "@/hooks/useAddressAutocomplete";
 
 export function AddressField(props: {
@@ -15,9 +17,23 @@ export function AddressField(props: {
   suggestions: AddressSuggestion[];
   loading?: boolean;
 }) {
+  useEffect(() => {
+    if (props.errorText) {
+      logger.warn("components/AddressField", "Error text", props.errorText);
+    }
+  }, [props.errorText]);
+
   const adornment = props.onUseLocation ? (
     <InputAdornment position="end">
-      <IconButton onClick={props.onUseLocation} edge="end" aria-label="Use my location" disabled={props.locating}>
+      <IconButton
+        onClick={() => {
+          logger.debug("components/AddressField", "Use location clicked");
+          props.onUseLocation?.();
+        }}
+        edge="end"
+        aria-label="Use my location"
+        disabled={props.locating}
+      >
         {props.locating ? <CircularProgress size={18} /> : <MyLocationIcon />}
       </IconButton>
     </InputAdornment>
@@ -34,8 +50,24 @@ export function AddressField(props: {
         </li>
       )}
       inputValue={props.value}
-      onInputChange={(_e, val) => props.onChange(val)}
-      onBlur={() => props.onBlur?.(props.value)}
+      onInputChange={(_e, val) => {
+        logger.debug("components/AddressField", "Input change", val);
+        props.onChange(val);
+      }}
+      onBlur={() => {
+        logger.debug("components/AddressField", "Blur", props.value);
+        props.onBlur?.(props.value);
+      }}
+      onChange={(_e, val) => {
+        if (val) {
+          logger.info("components/AddressField", "Suggestion selected", val);
+          if (typeof val === "string") {
+            props.onChange(val);
+          } else {
+            props.onChange(val.address);
+          }
+        }
+      }}
       renderInput={(params) => (
         <TextField
           {...params}

--- a/frontend/src/hooks/useAddressAutocomplete.ts
+++ b/frontend/src/hooks/useAddressAutocomplete.ts
@@ -1,7 +1,7 @@
 // Hook to fetch address suggestions as the user types.
 import { useEffect, useState } from "react";
 import { CONFIG } from "@/config";
-import { formatAddress, type AddressComponents } from "@/lib/formatAddress";
+import { formatAddress } from "@/lib/formatAddress";
 import * as logger from "@/lib/logger";
 
 export interface AddressSuggestion {


### PR DESCRIPTION
## Summary
- log input, blur and location events with logger.debug
- report selected suggestions and error text
- remove unused import in address autocomplete hook

## Testing
- `npm run lint`
- `pytest` (failed: tests/unit/services/test_geocode_service.py::test_search_geocode_returns_airport)
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b11fccad4483319c1caf68d00473ed