### PR TITLE
feat: enhance geocoding logging

### DIFF
--- a/frontend/src/lib/geocoding.ts
+++ b/frontend/src/lib/geocoding.ts
@@ -4,19 +4,29 @@ import { formatAddress } from "@/lib/formatAddress";
 import * as logger from "@/lib/logger";
 
 export async function reverseGeocode(lat: number, lon: number): Promise<string> {
-    
-    const backend = CONFIG.API_BASE_URL as string | undefined;
+  const backend = CONFIG.API_BASE_URL as string | undefined;
+  logger.debug("lib/geocoding", "reverseGeocode request", { lat, lon, backend });
+
+  if (!backend) {
+    logger.warn("lib/geocoding", "No backend configured, using Nominatim fallback");
+  }
 
   try {
     if (backend) {
       const res = await fetch(`${backend}/geocode/reverse?lat=${lat}&lon=${lon}`);
       if (!res.ok) throw new Error(`Backend reverse geocode failed: ${res.status}`);
       const data = await res.json();
-      return data?.address ?? `${lat.toFixed(5)}, ${lon.toFixed(5)}`;
+      const address = data?.address ?? `${lat.toFixed(5)}, ${lon.toFixed(5)}`;
+      logger.info("lib/geocoding", "Reverse geocode success via backend", { address });
+      return address;
     }
   } catch (e) {
     // continue to dev fallback
-    logger.warn("lib/geocoding", "Backend reverseGeocode error, falling back to Nominatim", e);
+    logger.warn(
+      "lib/geocoding",
+      "Backend reverseGeocode error, falling back to Nominatim",
+      e
+    );
   }
 
   // Dev-only fallback (rate limited; do not ship to prod without a proxy)
@@ -24,7 +34,18 @@ export async function reverseGeocode(lat: number, lon: number): Promise<string> 
     `https://nominatim.openstreetmap.org/reverse?lat=${lat}&lon=${lon}&format=json&addressdetails=1`,
     { headers: { "Accept": "application/json" } }
   );
-  if (!res.ok) throw new Error(`Reverse geocode failed: ${res.status}`);
+  if (!res.ok) {
+    logger.error(
+      "lib/geocoding",
+      `Nominatim reverseGeocode failed: ${res.status}`
+    );
+    throw new Error(`Reverse geocode failed: ${res.status}`);
+  }
   const json = await res.json();
-  return formatAddress(json.address) || json.display_name || `${lat.toFixed(5)}, ${lon.toFixed(5)}`;
+  const address =
+    formatAddress(json.address) ||
+    json.display_name ||
+    `${lat.toFixed(5)}, ${lon.toFixed(5)}`;
+  logger.info("lib/geocoding", "Reverse geocode success via Nominatim", { address });
+  return address;
 }


### PR DESCRIPTION
## Summary
- log incoming coordinates and backend selection at debug level
- record successful address lookups from backend or Nominatim with info logs
- warn on fallback usage and emit error logs on reverse geocode failures

## Testing
- `npm run lint` *(fails: AddressComponents is defined but never used)*
- `cd backend && pytest` *(fails: test_search_geocode_returns_airport)*
- `cd ../frontend && npm test` *(fails: 2 failing tests in useAddressAutocomplete)*

------
https://chatgpt.com/codex/tasks/task_e_68b11fdbfa688331b1e947a3d41a9bc0