### PR TITLE
feat: enhance logging across app

### DIFF
--- a/backend/app/api/health.py
+++ b/backend/app/api/health.py
@@ -1,21 +1,27 @@
 """Health check endpoint."""
 
+import logging
+
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.db.database import get_async_session
 
+logger = logging.getLogger(__name__)
 router = APIRouter(tags=["health"])
 
 
 @router.get("/health", status_code=status.HTTP_200_OK)
 async def health(db: AsyncSession = Depends(get_async_session)):
     """Return 200 if database connection succeeds, 503 otherwise."""
+    logger.debug("health check start")
     try:
         await db.execute(text("SELECT 1"))
+        logger.info("health check ok")
         return {"status": "ok"}
     except Exception as exc:  # noqa: BLE001
+        logger.exception("health check failed")
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail="Service unavailable",

--- a/backend/app/api/ws.py
+++ b/backend/app/api/ws.py
@@ -1,14 +1,17 @@
 import asyncio
-import uuid
 import json
+import logging
+import uuid
 from datetime import datetime, timezone
-from fastapi import APIRouter, WebSocket, WebSocketDisconnect
+
 from broadcaster import Broadcast
+from fastapi import APIRouter, WebSocket, WebSocketDisconnect
 
 from app.db.database import AsyncSessionLocal
 from app.models.booking import Booking, BookingStatus
 from app.models.route_point import RoutePoint
 
+logger = logging.getLogger(__name__)
 router = APIRouter()
 broadcast = Broadcast("memory://")
 
@@ -17,6 +20,7 @@ broadcast = Broadcast("memory://")
 async def booking_ws(websocket: WebSocket, booking_id: uuid.UUID):
     await websocket.accept()
     channel = f"booking:{booking_id}"
+    logger.info("ws connected", extra={"booking_id": str(booking_id)})
     async with broadcast.subscribe(channel=channel) as subscriber:
         send_task = asyncio.create_task(_forward_messages(websocket, subscriber))
         try:
@@ -25,6 +29,10 @@ async def booking_ws(websocket: WebSocket, booking_id: uuid.UUID):
                 try:
                     payload = json.loads(data)
                 except json.JSONDecodeError:
+                    logger.warning(
+                        "invalid json",
+                        extra={"booking_id": str(booking_id), "data": data},
+                    )
                     payload = None
                 if isinstance(payload, dict) and {"lat", "lng", "ts"} <= payload.keys():
                     async with AsyncSessionLocal() as db:
@@ -39,13 +47,24 @@ async def booking_ws(websocket: WebSocket, booking_id: uuid.UUID):
                             )
                             db.add(point)
                             await db.commit()
+                            logger.debug(
+                                "route point saved",
+                                extra={
+                                    "booking_id": str(booking_id),
+                                    "lat": payload["lat"],
+                                    "lng": payload["lng"],
+                                },
+                            )
                 await broadcast.publish(channel=channel, message=data)
         except WebSocketDisconnect:
-            pass
+            logger.info("ws disconnected", extra={"booking_id": str(booking_id)})
+        except Exception:
+            logger.exception("ws error", extra={"booking_id": str(booking_id)})
         finally:
             send_task.cancel()
 
 
 async def _forward_messages(websocket: WebSocket, subscriber):
     async for event in subscriber:
+        logger.debug("forward", extra={"message": event.message})
         await websocket.send_text(event.message)


### PR DESCRIPTION
## Summary
- add structured logs for health check endpoint
- track websocket connections and message handling
- use shared logger in payment step and log booking flow

## Testing
- `npm run lint`
- `cd backend && pytest`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1823940408331a1bb6b22c8e26aa3