### PR TITLE
fix: handle Stripe deposit errors

### DIFF
--- a/backend/tests/unit/services/test_booking_service.py
+++ b/backend/tests/unit/services/test_booking_service.py
@@ -1,0 +1,57 @@
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+import stripe
+from fastapi import HTTPException
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.booking import Booking, BookingStatus
+from app.models.user_v2 import User, UserRole
+from app.services import booking_service
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_confirm_booking_handles_stripe_error(
+    async_session: AsyncSession, mocker
+):
+    await async_session.execute(text("DELETE FROM availability_slots"))
+    await async_session.commit()
+
+    user = User(email="test@example.com", name="Test", role=UserRole.CUSTOMER)
+    async_session.add(user)
+    await async_session.flush()
+
+    booking = Booking(
+        public_code=uuid.uuid4().hex[:6].upper(),
+        customer_id=user.id,
+        pickup_address="A",
+        pickup_lat=0.0,
+        pickup_lng=0.0,
+        dropoff_address="B",
+        dropoff_lat=1.0,
+        dropoff_lng=1.0,
+        pickup_when=datetime.now(timezone.utc) + timedelta(days=30),
+        notes=None,
+        passengers=1,
+        estimated_price_cents=1000,
+        deposit_required_cents=500,
+        status=BookingStatus.PENDING,
+    )
+    async_session.add(booking)
+    await async_session.commit()
+
+    mocker.patch(
+        "app.services.stripe_client.charge_deposit",
+        side_effect=stripe.error.StripeError("fail"),
+    )
+
+    with pytest.raises(HTTPException) as excinfo:
+        await booking_service.confirm_booking(async_session, booking.id)
+
+    assert excinfo.value.status_code == 400
+    await async_session.refresh(booking)
+    assert booking.status is BookingStatus.PENDING
+    assert booking.deposit_payment_intent_id is None


### PR DESCRIPTION
## Summary
- wrap deposit charge in Stripe error handling that returns HTTP 400
- add unit test for failed deposit charge

## Testing
- `npm run lint`
- `cd backend && pytest`
- `cd frontend && npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_68b1958238048331975c7366dc9522c4