### PR TITLE
feat: migrate auth to UUID user IDs

### DIFF
--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -1,34 +1,48 @@
 """Utilities for hashing passwords and issuing JWT tokens."""
 
+import uuid
 from datetime import datetime, timedelta, timezone
-from typing import Dict, Any
-from jose import jwt, JWTError, ExpiredSignatureError
+from typing import Any, Dict
+
+from app.core.config import (
+    get_settings,
+)  # contains SECRET_KEY, ALGORITHM, ACCESS_TOKEN_EXPIRE_MINUTES
+from jose import ExpiredSignatureError, JWTError, jwt
 from passlib.context import CryptContext
-from app.core.config import get_settings  # contains SECRET_KEY, ALGORITHM, ACCESS_TOKEN_EXPIRE_MINUTES
 
 settings = get_settings()
 
 pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
 
+
 def verify_password(plain: str, hashed: str) -> bool:
     """Check a plaintext password against its hashed value."""
     return pwd_context.verify(plain, hashed)
 
-def create_jwt_token(user_id: int) -> str:
+
+def create_jwt_token(user_id: uuid.UUID) -> str:
     """Generate a signed JWT for the given user id."""
     to_encode: Dict[str, Any] = {"sub": str(user_id)}
-    expire = datetime.now(timezone.utc) + timedelta(minutes=settings.access_token_expire_minutes)
+    expire = datetime.now(timezone.utc) + timedelta(
+        minutes=settings.access_token_expire_minutes
+    )
     to_encode.update({"exp": expire})
-    return jwt.encode(to_encode, settings.jwt_secret_key, algorithm=settings.jwt_algorithm)
+    return jwt.encode(
+        to_encode, settings.jwt_secret_key, algorithm=settings.jwt_algorithm
+    )
+
 
 def hash_password(password: str) -> str:
     """Hash a password using bcrypt."""
     return pwd_context.hash(password)
 
+
 def decode_token(token: str):
     """Decode and validate a JWT, raising on failure."""
     try:
-        payload = jwt.decode(token, settings.jwt_secret_key, algorithms=[settings.jwt_algorithm])
+        payload = jwt.decode(
+            token, settings.jwt_secret_key, algorithms=[settings.jwt_algorithm]
+        )
         return payload
     except (JWTError, ExpiredSignatureError) as e:
         raise ValueError("Token is invalid or expired") from e

--- a/backend/app/models/user_v2.py
+++ b/backend/app/models/user_v2.py
@@ -2,12 +2,11 @@ import enum
 import uuid
 from datetime import datetime
 
-from sqlalchemy import String, Enum, DateTime
+from app.db.database import Base
+from sqlalchemy import DateTime, Enum, String, Text
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column
 from sqlalchemy.sql import func
-
-from app.db.database import Base
 
 
 class UserRole(str, enum.Enum):
@@ -26,7 +25,8 @@ class User(Base):
         UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
     )
     email: Mapped[str] = mapped_column(String, unique=True, index=True)
-    name: Mapped[str] = mapped_column(String)
+    full_name: Mapped[str] = mapped_column(String)
+    hashed_password: Mapped[str] = mapped_column(Text, name="password_hash")
     role: Mapped[UserRole] = mapped_column(Enum(UserRole), default=UserRole.CUSTOMER)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now()

--- a/backend/app/schemas/auth.py
+++ b/backend/app/schemas/auth.py
@@ -1,21 +1,25 @@
 # app/schemas/auth.py
 """Pydantic schemas for authentication endpoints."""
 
-from pydantic import BaseModel, EmailStr, ConfigDict
+import uuid
+
+from pydantic import BaseModel, ConfigDict, EmailStr
 
 
 class LoginRequest(BaseModel):
     """User credentials supplied during login."""
+
     email: EmailStr
     password: str
 
 
 class LoginResponse(BaseModel):
     """Response returned on successful login."""
+
     token: str
     full_name: str
     email: EmailStr
-    id: int
+    id: uuid.UUID
 
     model_config = ConfigDict(
         json_schema_extra={
@@ -23,7 +27,7 @@ class LoginResponse(BaseModel):
                 "token": "your.jwt.token",
                 "full_name": "Naomi Bertrand",
                 "email": "naomi@example.com",
-                "id": 123,
+                "id": "123e4567-e89b-12d3-a456-426614174000",
             }
         }
     )
@@ -31,6 +35,7 @@ class LoginResponse(BaseModel):
 
 class RegisterRequest(BaseModel):
     """Payload required to create a new user."""
+
     email: EmailStr
     full_name: str
     password: str
@@ -38,10 +43,12 @@ class RegisterRequest(BaseModel):
 
 class TokenResponse(BaseModel):
     """Simple token wrapper."""
+
     token: str
 
 
 class OAuth2Token(BaseModel):
     """OAuth2 compliant access token."""
+
     access_token: str
     token_type: str = "bearer"

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -1,5 +1,6 @@
 """User-related Pydantic models."""
 
+import uuid
 from typing import Optional
 
 from pydantic import BaseModel, ConfigDict, EmailStr
@@ -22,7 +23,7 @@ class UserCreate(UserBase):
 class UserRead(UserBase):
     """User data returned from the API."""
 
-    id: int
+    id: uuid.UUID
     # role: str
     # is_approved: bool
     fcm_token: Optional[str] = None

--- a/frontend/src/__tests__/AccessControl.test.tsx
+++ b/frontend/src/__tests__/AccessControl.test.tsx
@@ -5,6 +5,7 @@ import { AuthContextType, UserShape } from '@/types/AuthContextType';
 import { AuthContext } from '@/contexts/AuthContext';
 import { DevFeaturesProvider } from '@/contexts/DevFeaturesContext';
 import { vi } from 'vitest';
+import { CONFIG } from '@/config';
 
 vi.mock('@/pages/Admin/AdminDashboard', () => ({ default: () => <div>Admin Page</div> }));
 vi.mock('@/pages/Driver/DriverDashboard', () => ({ default: () => <div>Driver Page</div> }));
@@ -40,22 +41,22 @@ function renderWithAuth(value: Partial<AuthContextType>, initial: string) {
 
 describe('route access control', () => {
   it('allows first user to access admin dashboard', () => {
-    renderWithAuth({ accessToken: 'tok', userID: '1' }, '/admin');
+    renderWithAuth({ accessToken: 'tok', userID: CONFIG.ADMIN_USER_ID }, '/admin');
     expect(screen.getByText('Admin Page')).toBeInTheDocument();
   });
 
   it('redirects other users from admin dashboard', async () => {
-    renderWithAuth({ accessToken: 'tok', userID: '2' }, '/admin');
+    renderWithAuth({ accessToken: 'tok', userID: '00000000-0000-0000-0000-000000000002' }, '/admin');
     await waitFor(() => expect(screen.getByText('Login Page')).toBeInTheDocument());
   });
 
   it('allows first user to access driver dashboard', () => {
-    renderWithAuth({ accessToken: 'tok', userID: '1' }, '/driver');
+    renderWithAuth({ accessToken: 'tok', userID: CONFIG.ADMIN_USER_ID }, '/driver');
     expect(screen.getByText('Driver Page')).toBeInTheDocument();
   });
 
   it('redirects other users from driver dashboard', async () => {
-    renderWithAuth({ accessToken: 'tok', userID: '2' }, '/driver');
+    renderWithAuth({ accessToken: 'tok', userID: '00000000-0000-0000-0000-000000000002' }, '/driver');
     await waitFor(() => expect(screen.getByText('Login Page')).toBeInTheDocument());
   });
 });

--- a/frontend/src/__tests__/setup/msw.handlers.ts
+++ b/frontend/src/__tests__/setup/msw.handlers.ts
@@ -32,7 +32,14 @@ export const handlers = [
     if (body.email === 'dupe@example.com') {
       return HttpResponse.json({ detail: 'Email already registered' }, { status: 400 });
     }
-    return HttpResponse.json({ id: 123, full_name: body.full_name, email: body.email }, { status: 201 });
+    return HttpResponse.json(
+      {
+        id: '123e4567-e89b-12d3-a456-426614174000',
+        full_name: body.full_name,
+        email: body.email,
+      },
+      { status: 201 },
+    );
   }),
 
   // ---- POST /auth/login ----
@@ -47,14 +54,19 @@ export const handlers = [
       access_token: 'test-token',
       token_type: 'bearer',
       role: 'CUSTOMER',
-      user: { id: 1, full_name: 'Test User', email: body.email, role: 'CUSTOMER' },
+      user: {
+        id: CONFIG.ADMIN_USER_ID,
+        full_name: 'Test User',
+        email: body.email,
+        role: 'CUSTOMER',
+      },
     });
   }),
 
   // ---- GET /users/me : return current user based on token ----
   http.get(apiUrl('/users/me'), () => {
     return HttpResponse.json({
-      id: 1,
+      id: CONFIG.ADMIN_USER_ID,
       full_name: 'Test User',
       email: 'test@example.com',
       default_pickup_address: '123 Street',
@@ -63,7 +75,13 @@ export const handlers = [
 
   http.patch(apiUrl('/users/me'), async ({ request }) => {
     const body = await request.json();
-    return HttpResponse.json({ id: 1, full_name: body.full_name ?? 'Test User', email: body.email ?? 'test@example.com', default_pickup_address: body.default_pickup_address ?? '123 Street' });
+    return HttpResponse.json({
+      id: CONFIG.ADMIN_USER_ID,
+      full_name: body.full_name ?? 'Test User',
+      email: body.email ?? 'test@example.com',
+      default_pickup_address:
+        body.default_pickup_address ?? '123 Street',
+    });
   }),
 
   // ---- Settings endpoints used by AdminDashboard ----

--- a/frontend/src/api-client/api.ts
+++ b/frontend/src/api-client/api.ts
@@ -784,10 +784,10 @@ export interface UserRead {
   default_pickup_address?: string | null;
   /**
    *
-   * @type {number}
+   * @type {string}
    * @memberof UserRead
    */
-  id: number;
+  id: string;
   /**
    *
    * @type {string}

--- a/frontend/src/components/NavBar.test.tsx
+++ b/frontend/src/components/NavBar.test.tsx
@@ -6,6 +6,7 @@ import { DevFeaturesProvider } from '@/contexts/DevFeaturesContext';
 import NavBar from './NavBar';
 import { render } from '@testing-library/react';
 import type { ReactNode } from 'react';
+import { CONFIG } from '@/config';
 
 function seedAuth({ id, name, role }: { id: string; name: string; role: string }) {
   localStorage.setItem('auth_tokens', JSON.stringify({ access_token: 't', refresh_token: 'r', user: { email: 'x' }, role }));
@@ -33,7 +34,7 @@ function renderWithAuth(initialPath = '/book', extraRoutes?: ReactNode) {
 
 describe('NavBar', () => {
   test.skip('shows Admin Dashboard when role is ADMIN', async () => {
-    seedAuth({ id: '1', name: 'Admin User', role: 'ADMIN' });
+    seedAuth({ id: CONFIG.ADMIN_USER_ID, name: 'Admin User', role: 'ADMIN' });
     renderWithAuth();
 
     const accountBtn = await screen.findByLabelText(/account/i);
@@ -42,7 +43,7 @@ describe('NavBar', () => {
   });
 
   test.skip('shows driver menu items for DRIVER role', async () => {
-    seedAuth({ id: '2', name: 'Driver User', role: 'DRIVER' });
+    seedAuth({ id: '00000000-0000-0000-0000-000000000002', name: 'Driver User', role: 'DRIVER' });
     renderWithAuth();
 
     const accountBtn = await screen.findByLabelText(/account/i);
@@ -53,7 +54,7 @@ describe('NavBar', () => {
   });
 
   test('hides role-specific items for CUSTOMER role', async () => {
-    seedAuth({ id: '3', name: 'Regular User', role: 'CUSTOMER' });
+    seedAuth({ id: '00000000-0000-0000-0000-000000000003', name: 'Regular User', role: 'CUSTOMER' });
     renderWithAuth();
 
     const accountBtn = await screen.findByLabelText(/account/i);
@@ -63,7 +64,7 @@ describe('NavBar', () => {
   });
 
   test('Logout clears state and navigates to /login', async () => {
-    seedAuth({ id: '1', name: 'Admin User', role: 'ADMIN' });
+    seedAuth({ id: CONFIG.ADMIN_USER_ID, name: 'Admin User', role: 'ADMIN' });
     renderWithAuth('/book');
 
     const accountBtn = await screen.findByLabelText(/account/i);
@@ -79,7 +80,7 @@ describe('NavBar', () => {
   });
 
   test('book menu item navigates to booking wizard', async () => {
-    seedAuth({ id: '3', name: 'Regular User', role: 'CUSTOMER' });
+    seedAuth({ id: '00000000-0000-0000-0000-000000000003', name: 'Regular User', role: 'CUSTOMER' });
     renderWithAuth('/home', <Route path="/book" element={<h1>Book</h1>} />);
 
     const accountBtn = await screen.findByLabelText(/account/i);
@@ -91,7 +92,7 @@ describe('NavBar', () => {
   });
 
   test('ride history menu item navigates to history page', async () => {
-    seedAuth({ id: '3', name: 'Regular User', role: 'CUSTOMER' });
+    seedAuth({ id: '00000000-0000-0000-0000-000000000003', name: 'Regular User', role: 'CUSTOMER' });
     renderWithAuth('/home', <Route path="/history" element={<h1>History</h1>} />);
 
     const accountBtn = await screen.findByLabelText(/account/i);
@@ -103,7 +104,7 @@ describe('NavBar', () => {
   });
 
   test('driver dashboard menu navigates to driver dashboard', async () => {
-    seedAuth({ id: '2', name: 'Driver User', role: 'DRIVER' });
+    seedAuth({ id: '00000000-0000-0000-0000-000000000002', name: 'Driver User', role: 'DRIVER' });
     renderWithAuth('/book', <Route path="/driver" element={<h1>Driver</h1>} />);
 
     const accountBtn = await screen.findByLabelText(/account/i);
@@ -117,7 +118,7 @@ describe('NavBar', () => {
   });
 
   test('availability menu navigates to driver availability', async () => {
-    seedAuth({ id: '2', name: 'Driver User', role: 'DRIVER' });
+    seedAuth({ id: '00000000-0000-0000-0000-000000000002', name: 'Driver User', role: 'DRIVER' });
     renderWithAuth(
       '/book',
       <Route path="/driver/availability" element={<h1>Availability</h1>} />,
@@ -134,7 +135,7 @@ describe('NavBar', () => {
   });
 
   test('admin menu item navigates to admin dashboard', async () => {
-    seedAuth({ id: '1', name: 'Admin User', role: 'ADMIN' });
+    seedAuth({ id: CONFIG.ADMIN_USER_ID, name: 'Admin User', role: 'ADMIN' });
     renderWithAuth('/book', <Route path="/admin" element={<h1>Admin</h1>} />);
 
     const accountBtn = await screen.findByLabelText(/account/i);

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -20,5 +20,8 @@ export const CONFIG = {
   ORS_API_KEY: import.meta.env.VITE_ORS_API_KEY || '',
   JWT_SECRET_KEY: import.meta.env.VITE_JWT_SECRET_KEY || '',
   ENV: import.meta.env.ENV || 'development',
+  ADMIN_USER_ID:
+    import.meta.env.VITE_ADMIN_USER_ID ||
+    '00000000-0000-0000-0000-000000000001',
 };
 

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -18,7 +18,7 @@ type LoginResponse = {
   role?: string | null;
   user?: { role?: string } | null;
   full_name?: string;
-  id?: number | string;
+  id?: string;
 };
 
 type AuthState = {
@@ -321,13 +321,19 @@ export const RequireRole: React.FC<{ role: string; children: React.ReactNode }> 
   useEffect(() => {
     if (!loading) {
       const from = encodeURIComponent(location.pathname + location.search);
-      const allowed = accessToken && (userRole === role || userID === '1');
+      const allowed =
+        accessToken && (userRole === role || userID === CONFIG.ADMIN_USER_ID);
       if (!allowed) {
         navigate(`/login?from=${from}`, { replace: true });
       }
     }
   }, [loading, accessToken, userRole, userID, role, location, navigate]);
 
-  if (loading || !accessToken || (userRole !== role && userID !== '1')) return null;
+  if (
+    loading ||
+    !accessToken ||
+    (userRole !== role && userID !== CONFIG.ADMIN_USER_ID)
+  )
+    return null;
   return <>{children}</>;
 };

--- a/frontend/src/pages/Dashboard/HomePage.test.tsx
+++ b/frontend/src/pages/Dashboard/HomePage.test.tsx
@@ -3,6 +3,7 @@ import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { Route } from 'react-router-dom';
 import HomePage from './HomePage';
+import { CONFIG } from '@/config';
 
 function seedAuth(id: string, role = 'CUSTOMER') {
   localStorage.setItem(
@@ -20,7 +21,7 @@ describe('HomePage', () => {
   });
 
   it('shows common tiles for a regular user', () => {
-    seedAuth('2');
+    seedAuth('00000000-0000-0000-0000-000000000002');
     renderWithProviders(<HomePage />);
     expect(screen.getByRole('link', { name: /book a ride/i })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /ride history/i })).toBeInTheDocument();
@@ -30,13 +31,13 @@ describe('HomePage', () => {
   });
 
   it('shows admin dashboard tile for admin user', () => {
-    seedAuth('1');
+    seedAuth(CONFIG.ADMIN_USER_ID);
     renderWithProviders(<HomePage />);
     expect(screen.getByRole('link', { name: /admin dashboard/i })).toBeInTheDocument();
   });
 
   it('navigates to booking wizard', async () => {
-    seedAuth('2');
+    seedAuth('00000000-0000-0000-0000-000000000002');
     renderWithProviders(<HomePage />, {
       extraRoutes: <Route path="/book" element={<h1>Book</h1>} />,
     });
@@ -47,7 +48,7 @@ describe('HomePage', () => {
   });
 
   it('navigates to ride history details', async () => {
-    seedAuth('2');
+    seedAuth('00000000-0000-0000-0000-000000000002');
     renderWithProviders(<HomePage />, {
       extraRoutes: <Route path="/history" element={<h1>History</h1>} />,
     });
@@ -58,7 +59,7 @@ describe('HomePage', () => {
   });
 
   it('navigates to driver dashboard for first user', async () => {
-    seedAuth('1');
+    seedAuth(CONFIG.ADMIN_USER_ID);
     renderWithProviders(<HomePage />, {
       extraRoutes: <Route path="/driver" element={<h1>Driver</h1>} />,
     });
@@ -69,7 +70,7 @@ describe('HomePage', () => {
   });
 
   it('navigates to admin dashboard for admin user', async () => {
-    seedAuth('1');
+    seedAuth(CONFIG.ADMIN_USER_ID);
     renderWithProviders(<HomePage />, {
       extraRoutes: <Route path="/admin" element={<h1>Admin</h1>} />,
     });

--- a/frontend/src/pages/Dashboard/HomePage.tsx
+++ b/frontend/src/pages/Dashboard/HomePage.tsx
@@ -1,6 +1,7 @@
 import { Grid, Button, Typography } from '@mui/material';
 import { Link } from 'react-router-dom';
 import { useAuth } from '@/contexts/AuthContext';
+import { CONFIG } from '@/config';
 
 interface Tile {
   label: string;
@@ -16,7 +17,7 @@ export default function HomePage() {
     { label: 'Profile', path: '/me' },
   ];
 
-  if (userID === '1') {
+  if (userID === CONFIG.ADMIN_USER_ID) {
     tiles.splice(2, 0, { label: 'Driver Dashboard', path: '/driver' });
     tiles.splice(3, 0, { label: 'Availability', path: '/driver/availability' });
     tiles.push({ label: 'Admin Dashboard', path: '/admin' });


### PR DESCRIPTION
## Summary
- switch auth service to UserV2 and issue tokens with UUID user IDs
- encode UUIDs in JWTs and update auth schemas
- adjust frontend for UUID-based user IDs

## Testing
- `npm run lint`
- `pytest` *(fails: no such table: users_v2)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b19f9e385c8331b852a40bd790a35f