### PR TITLE
feat: display route map in booking wizard

### DIFF
--- a/frontend/src/components/BookingWizard/BookingWizard.tsx
+++ b/frontend/src/components/BookingWizard/BookingWizard.tsx
@@ -3,6 +3,8 @@ import { Stepper, Step, StepLabel, Box } from '@mui/material';
 import SelectTimeStep from './SelectTimeStep';
 import TripDetailsStep from './TripDetailsStep';
 import PaymentStep from './PaymentStep';
+import { MapProvider } from '@/components/MapProvider';
+import { MapRoute } from '@/components/MapRoute';
 
 interface Location {
   address: string;
@@ -24,9 +26,11 @@ const steps = ['Select time', 'Trip details', 'Payment'];
 export default function BookingWizard() {
   const [active, setActive] = useState(0);
   const [form, setForm] = useState<FormData>({ passengers: 1 });
-
+  const update = (data: Partial<FormData>) => {
+    setForm((f) => ({ ...f, ...data }));
+  };
   const next = (data: Partial<FormData>) => {
-    setForm({ ...form, ...data });
+    update(data);
     setActive((s) => s + 1);
   };
   const back = () => setActive((s) => s - 1);
@@ -41,8 +45,21 @@ export default function BookingWizard() {
         ))}
       </Stepper>
       {active === 0 && <SelectTimeStep data={form} onNext={next} />}
-      {active === 1 && <TripDetailsStep data={form} onNext={next} onBack={back} />}
+      {active === 1 && (
+        <TripDetailsStep data={form} onChange={update} onNext={next} onBack={back} />
+      )}
       {active === 2 && <PaymentStep data={form} onBack={back} />}
+      {active > 0 && form.pickup?.address && form.dropoff?.address && (
+        <Box mt={2}>
+          <MapProvider>
+            <MapRoute
+              pickup={form.pickup}
+              dropoff={form.dropoff}
+              rideTime={form.pickup_when}
+            />
+          </MapProvider>
+        </Box>
+      )}
     </Box>
   );
 }

--- a/frontend/src/components/BookingWizard/TripDetailsStep.tsx
+++ b/frontend/src/components/BookingWizard/TripDetailsStep.tsx
@@ -20,9 +20,10 @@ interface Props {
   data: FormData;
   onNext: (data: FormData) => void;
   onBack: () => void;
+  onChange: (data: Partial<FormData>) => void;
 }
 
-export default function TripDetailsStep({ data, onNext, onBack }: Props) {
+export default function TripDetailsStep({ data, onNext, onBack, onChange }: Props) {
   const [pickup, setPickup] = useState(data.pickup?.address || '');
   const [pickupLat, setPickupLat] = useState<number>(data.pickup?.lat ?? 0);
   const [pickupLng, setPickupLng] = useState<number>(data.pickup?.lng ?? 0);
@@ -41,11 +42,15 @@ export default function TripDetailsStep({ data, onNext, onBack }: Props) {
         id="pickup"
         label="Pickup address"
         value={pickup}
-        onChange={setPickup}
+        onChange={(val) => {
+          setPickup(val);
+          onChange({ pickup: { address: val, lat: pickupLat, lng: pickupLng } });
+        }}
         onSelect={(s) => {
           setPickup(s.address);
           setPickupLat(s.lat);
           setPickupLng(s.lng);
+          onChange({ pickup: { address: s.address, lat: s.lat, lng: s.lng } });
         }}
         suggestions={pickupAuto.suggestions}
         loading={pickupAuto.loading}
@@ -54,17 +59,37 @@ export default function TripDetailsStep({ data, onNext, onBack }: Props) {
         id="dropoff"
         label="Dropoff address"
         value={dropoff}
-        onChange={setDropoff}
+        onChange={(val) => {
+          setDropoff(val);
+          onChange({ dropoff: { address: val, lat: dropLat, lng: dropLng } });
+        }}
         onSelect={(s) => {
           setDropoff(s.address);
           setDropLat(s.lat);
           setDropLng(s.lng);
+          onChange({ dropoff: { address: s.address, lat: s.lat, lng: s.lng } });
         }}
         suggestions={dropoffAuto.suggestions}
         loading={dropoffAuto.loading}
       />
-      <TextField label="Passengers" type="number" value={passengers} onChange={(e) => setPassengers(Number(e.target.value))} />
-      <TextField label="Notes" value={notes} onChange={(e) => setNotes(e.target.value)} />
+      <TextField
+        label="Passengers"
+        type="number"
+        value={passengers}
+        onChange={(e) => {
+          const val = Number(e.target.value);
+          setPassengers(val);
+          onChange({ passengers: val });
+        }}
+      />
+      <TextField
+        label="Notes"
+        value={notes}
+        onChange={(e) => {
+          setNotes(e.target.value);
+          onChange({ notes: e.target.value });
+        }}
+      />
       <Stack direction="row" spacing={1}>
         <Button onClick={onBack}>Back</Button>
         <Button

--- a/frontend/src/pages/Booking/BookingWizardPage.test.tsx
+++ b/frontend/src/pages/Booking/BookingWizardPage.test.tsx
@@ -34,6 +34,12 @@ vi.mock('@/hooks/useRouteMetrics', () => ({
 vi.mock('@/hooks/useAddressAutocomplete', () => ({
   useAddressAutocomplete: () => ({ suggestions: [], loading: false }),
 }));
+vi.mock('@/components/MapProvider', () => ({
+  MapProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+vi.mock('@/components/MapRoute', () => ({
+  MapRoute: () => <div data-testid="map-route" />,
+}));
 
 beforeAll(() => {
   server.use(


### PR DESCRIPTION
## Summary
- show map route once both pickup and dropoff addresses are entered in booking wizard
- sync trip detail inputs with wizard state for live map updates
- mock map components in booking wizard test

## Testing
- `npm run lint`
- `cd backend && pytest` *(fails: pydantic ValidationError)*
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b22b1005e883319e09dbd98ffefcb9