### PR TITLE
fix: use full_name when creating booking customers

### DIFF
--- a/backend/app/services/booking_service.py
+++ b/backend/app/services/booking_service.py
@@ -33,7 +33,10 @@ async def create_booking(
     customer = result.scalar_one_or_none()
     if customer is None:
         customer = User(
-            email=data.customer.email, name=data.customer.name, role=UserRole.CUSTOMER
+            email=data.customer.email,
+            full_name=data.customer.name,
+            hashed_password="",
+            role=UserRole.CUSTOMER,
         )
         db.add(customer)
         await db.flush()


### PR DESCRIPTION
## Summary
- pass customer full name to User model in booking service
- ensure new customers have a placeholder hashed password

## Testing
- `npm run lint`
- `pytest tests/integration/test_booking_create_api.py::test_create_booking_success tests/integration/test_booking_create_api.py::test_create_booking_route_not_found`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_68b231b15b088331afd76e99b80c12e5