### PR TITLE
refactor: use SQLAlchemy UUID type for models

### DIFF
--- a/backend/app/models/booking.py
+++ b/backend/app/models/booking.py
@@ -3,15 +3,7 @@ import uuid
 from datetime import datetime
 from typing import Optional
 
-from sqlalchemy import (
-    DateTime,
-    Enum,
-    ForeignKey,
-    Integer,
-    String,
-    Float,
-)
-from sqlalchemy.dialects.postgresql import UUID as PGUUID
+from sqlalchemy import UUID, DateTime, Enum, Float, ForeignKey, Integer, String
 from sqlalchemy.orm import Mapped, mapped_column
 from sqlalchemy.sql import func
 
@@ -36,23 +28,39 @@ class Booking(Base):
 
     __tablename__ = "bookings_v2"
 
-    id: Mapped[uuid.UUID] = mapped_column(PGUUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
     public_code: Mapped[str] = mapped_column(String(20), unique=True, index=True)
-    status: Mapped[BookingStatus] = mapped_column(Enum(BookingStatus), default=BookingStatus.PENDING)
-    customer_id: Mapped[uuid.UUID] = mapped_column(PGUUID(as_uuid=True), ForeignKey("users_v2.id"), nullable=False)
+    status: Mapped[BookingStatus] = mapped_column(
+        Enum(BookingStatus), default=BookingStatus.PENDING
+    )
+    customer_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("users_v2.id"), nullable=False
+    )
     pickup_address: Mapped[str] = mapped_column(String, nullable=False)
     pickup_lat: Mapped[float] = mapped_column(Float, nullable=False)
     pickup_lng: Mapped[float] = mapped_column(Float, nullable=False)
     dropoff_address: Mapped[str] = mapped_column(String, nullable=False)
     dropoff_lat: Mapped[float] = mapped_column(Float, nullable=False)
     dropoff_lng: Mapped[float] = mapped_column(Float, nullable=False)
-    pickup_when: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    pickup_when: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False
+    )
     notes: Mapped[Optional[str]] = mapped_column(String, nullable=True)
     passengers: Mapped[int] = mapped_column(Integer, nullable=False)
     estimated_price_cents: Mapped[int] = mapped_column(Integer, nullable=False)
     final_price_cents: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
     deposit_required_cents: Mapped[int] = mapped_column(Integer, nullable=False)
-    deposit_payment_intent_id: Mapped[Optional[str]] = mapped_column(String, nullable=True)
-    final_payment_intent_id: Mapped[Optional[str]] = mapped_column(String, nullable=True)
-    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
-    updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
+    deposit_payment_intent_id: Mapped[Optional[str]] = mapped_column(
+        String, nullable=True
+    )
+    final_payment_intent_id: Mapped[Optional[str]] = mapped_column(
+        String, nullable=True
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
+    )

--- a/backend/app/models/notification.py
+++ b/backend/app/models/notification.py
@@ -3,8 +3,7 @@ import uuid
 from datetime import datetime
 from typing import Any, Dict
 
-from sqlalchemy import DateTime, Enum, ForeignKey, String, JSON
-from sqlalchemy.dialects.postgresql import UUID as PGUUID
+from sqlalchemy import JSON, UUID, DateTime, Enum, ForeignKey, String
 from sqlalchemy.orm import Mapped, mapped_column
 from sqlalchemy.sql import func
 
@@ -32,9 +31,19 @@ class Notification(Base):
 
     __tablename__ = "notifications"
 
-    id: Mapped[uuid.UUID] = mapped_column(PGUUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
-    booking_id: Mapped[uuid.UUID] = mapped_column(PGUUID(as_uuid=True), ForeignKey("bookings_v2.id"), nullable=True)
-    type: Mapped[NotificationType] = mapped_column(Enum(NotificationType), nullable=False)
-    to_role: Mapped[NotificationRole] = mapped_column(Enum(NotificationRole), nullable=False)
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    booking_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("bookings_v2.id"), nullable=True
+    )
+    type: Mapped[NotificationType] = mapped_column(
+        Enum(NotificationType), nullable=False
+    )
+    to_role: Mapped[NotificationRole] = mapped_column(
+        Enum(NotificationRole), nullable=False
+    )
     payload: Mapped[Dict[str, Any]] = mapped_column(JSON, default=dict)
-    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )

--- a/backend/app/models/route_point.py
+++ b/backend/app/models/route_point.py
@@ -1,9 +1,8 @@
+import uuid
 from datetime import datetime
 from typing import Optional
-import uuid
 
-from sqlalchemy import DateTime, Float, ForeignKey
-from sqlalchemy.dialects.postgresql import UUID as PGUUID
+from sqlalchemy import UUID, DateTime, Float, ForeignKey
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.db.database import Base
@@ -14,8 +13,12 @@ class RoutePoint(Base):
 
     __tablename__ = "route_points"
 
-    id: Mapped[uuid.UUID] = mapped_column(PGUUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
-    booking_id: Mapped[uuid.UUID] = mapped_column(PGUUID(as_uuid=True), ForeignKey("bookings_v2.id"), nullable=False)
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    booking_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("bookings_v2.id"), nullable=False
+    )
     ts: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
     lat: Mapped[float] = mapped_column(Float, nullable=False)
     lng: Mapped[float] = mapped_column(Float, nullable=False)

--- a/backend/app/models/trip.py
+++ b/backend/app/models/trip.py
@@ -1,8 +1,7 @@
 import uuid
 from datetime import datetime
 
-from sqlalchemy import DateTime, ForeignKey, Integer
-from sqlalchemy.dialects.postgresql import UUID as PGUUID
+from sqlalchemy import UUID, DateTime, ForeignKey, Integer
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.db.database import Base
@@ -13,9 +12,15 @@ class Trip(Base):
 
     __tablename__ = "trips"
 
-    id: Mapped[uuid.UUID] = mapped_column(PGUUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
-    booking_id: Mapped[uuid.UUID] = mapped_column(PGUUID(as_uuid=True), ForeignKey("bookings_v2.id"), nullable=False)
-    started_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    booking_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("bookings_v2.id"), nullable=False
+    )
+    started_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False
+    )
     ended_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=True)
     distance_meters: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
     duration_seconds: Mapped[int] = mapped_column(Integer, nullable=False, default=0)

--- a/backend/app/models/user_v2.py
+++ b/backend/app/models/user_v2.py
@@ -2,11 +2,11 @@ import enum
 import uuid
 from datetime import datetime
 
-from app.db.database import Base
-from sqlalchemy import DateTime, Enum, String, Text
-from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy import UUID, DateTime, Enum, String, Text
 from sqlalchemy.orm import Mapped, mapped_column
 from sqlalchemy.sql import func
+
+from app.db.database import Base
 
 
 class UserRole(str, enum.Enum):


### PR DESCRIPTION
## Summary
- replace PostgreSQL-specific UUID imports with SQLAlchemy's native UUID type
- keep Alembic migrations aligned with generic UUID columns

## Testing
- `npm run lint`
- `cd backend && pytest` *(fails: AttributeError 'int' object has no attribute 'replace')*
- `cd frontend && npm test`
- `cd backend && ENV=development alembic upgrade head`
- `curl -s http://localhost:8000/health`


------
https://chatgpt.com/codex/tasks/task_e_68b2405f721c8331b3e8e0113b9e480a