### PR TITLE
feat: track admin user for settings

### DIFF
--- a/backend/alembic/versions/0d3b77dfdf03_add_admin_user_id.py
+++ b/backend/alembic/versions/0d3b77dfdf03_add_admin_user_id.py
@@ -1,0 +1,33 @@
+"""add admin_user_id to admin_config
+
+Revision ID: 0d3b77dfdf03
+Revises: 8e1b5e99d2a5
+Create Date: 2025-02-15 00:00:00.000000
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "0d3b77dfdf03"
+down_revision = "8e1b5e99d2a5"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("admin_config") as batch_op:
+        batch_op.add_column(sa.Column("admin_user_id", sa.UUID(), nullable=True))
+        batch_op.create_foreign_key(
+            "admin_config_admin_user_id_fkey",
+            "users_v2",
+            ["admin_user_id"],
+            ["id"],
+        )
+
+
+def downgrade():
+    with op.batch_alter_table("admin_config") as batch_op:
+        batch_op.drop_constraint("admin_config_admin_user_id_fkey", type_="foreignkey")
+        batch_op.drop_column("admin_user_id")

--- a/backend/app/models/settings.py
+++ b/backend/app/models/settings.py
@@ -1,8 +1,11 @@
 """Administrative configuration stored in the database."""
 
-from sqlalchemy import CheckConstraint, Float, Boolean, text
-from app.db.database import Base
+import uuid
+
+from sqlalchemy import UUID, Boolean, CheckConstraint, Float, ForeignKey, text
 from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db.database import Base
 
 
 class AdminConfig(Base):
@@ -20,7 +23,8 @@ class AdminConfig(Base):
     per_km_rate: Mapped[float] = mapped_column(Float, nullable=False)
     # Cost charged per minute
     per_minute_rate: Mapped[float] = mapped_column(Float, nullable=False)
-
-    __table_args__ = (
-        CheckConstraint("id = 1", name="settings_singleton_id_check"),
+    admin_user_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("users_v2.id"), nullable=True
     )
+
+    __table_args__ = (CheckConstraint("id = 1", name="settings_singleton_id_check"),)

--- a/backend/app/services/settings_service.py
+++ b/backend/app/services/settings_service.py
@@ -3,23 +3,41 @@
 import logging
 import uuid
 
-from app.dependencies import get_db
-from app.models.settings import AdminConfig
-from app.schemas.setup import SettingsPayload
-from app.schemas.user import UserRead
 from fastapi import Depends, HTTPException
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.dependencies import get_db
+from app.models.settings import AdminConfig
+from app.schemas.setup import SettingsPayload
+from app.schemas.user import UserRead
+
 logger = logging.getLogger(__name__)
 
 
-ADMIN_USER_ID = uuid.UUID(int=1)
+_cached_admin_user_id: uuid.UUID | None = None
 
 
-def ensure_admin(user: UserRead):
-    """Allow only the designated admin (user_id 1) to modify settings."""
-    if getattr(user, "id", None) != ADMIN_USER_ID:
+async def get_admin_user_id(db: AsyncSession) -> uuid.UUID:
+    """Fetch and cache the designated admin user's ID."""
+    global _cached_admin_user_id
+    if _cached_admin_user_id is None:
+        result = await db.execute(
+            select(AdminConfig.admin_user_id).where(AdminConfig.id == 1)
+        )
+        value = result.scalar_one_or_none()
+        if isinstance(value, int):
+            value = uuid.UUID(int=value)
+        _cached_admin_user_id = value
+    if _cached_admin_user_id is None:
+        raise HTTPException(status_code=500, detail="Admin not configured")
+    return _cached_admin_user_id
+
+
+async def ensure_admin(user: UserRead, db: AsyncSession) -> None:
+    """Allow only the designated admin to modify settings."""
+    admin_id = await get_admin_user_id(db)
+    if getattr(user, "id", None) != admin_id:
         raise HTTPException(status_code=403, detail="Admin only")
 
 
@@ -41,7 +59,7 @@ async def get_settings(db: AsyncSession = Depends(get_db)) -> SettingsPayload:
 
 async def update_settings(data: SettingsPayload, db: AsyncSession, user: UserRead):
     """Persist updated pricing configuration."""
-    ensure_admin(user)
+    await ensure_admin(user, db)
     logger.info(
         "updating settings",
         extra={"user_id": getattr(user, "id", "unknown")},

--- a/backend/app/services/setup_service.py
+++ b/backend/app/services/setup_service.py
@@ -3,13 +3,14 @@
 import logging
 from typing import Union
 
+from fastapi import HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.sql import select
+
 from app.core.security import hash_password
 from app.models.settings import AdminConfig
 from app.models.user_v2 import User
 from app.schemas.setup import SettingsPayload, SetupPayload
-from fastapi import HTTPException
-from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.sql import select
 
 logger = logging.getLogger(__name__)
 
@@ -29,6 +30,7 @@ async def complete_initial_setup(db: AsyncSession, data: SetupPayload):
         hashed_password=hash_password(data.admin_password),
     )
     db.add(admin_user)
+    await db.flush()
 
     cfg = AdminConfig(
         account_mode=(data.settings.account_mode),
@@ -36,6 +38,7 @@ async def complete_initial_setup(db: AsyncSession, data: SetupPayload):
         per_km_rate=data.settings.per_km_rate,
         per_minute_rate=data.settings.per_minute_rate,
     )
+    cfg.admin_user_id = admin_user.id
     db.add(cfg)
 
     await db.commit()

--- a/backend/tests/integration/test_users_me_api.py
+++ b/backend/tests/integration/test_users_me_api.py
@@ -1,14 +1,18 @@
+import uuid
+
 import pytest
-from app.core.security import create_jwt_token, hash_password
-from app.models.user_v2 import User
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.security import create_jwt_token, hash_password
+from app.models.user_v2 import User
 
 
 @pytest.mark.asyncio
 async def test_get_and_update_me(client: AsyncClient, async_session: AsyncSession):
+    email = f"{uuid.uuid4()}@example.com"
     user = User(
-        email="me@example.com",
+        email=email,
         full_name="Me",
         hashed_password=hash_password("pass"),
     )
@@ -23,7 +27,7 @@ async def test_get_and_update_me(client: AsyncClient, async_session: AsyncSessio
     res = await client.get("/users/me", headers=headers)
     assert res.status_code == 200
     data = res.json()
-    assert data["email"] == "me@example.com"
+    assert data["email"] == email
 
     # PATCH /users/me
     payload = {"full_name": "New Name"}

--- a/backend/tests/unit/services/test_settings_service.py
+++ b/backend/tests/unit/services/test_settings_service.py
@@ -1,12 +1,13 @@
 import uuid
 
 import pytest
-from app.schemas.setup import SettingsPayload
-from app.schemas.user import UserRead
-from app.services import settings_service
 from fastapi import HTTPException
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.schemas.setup import SettingsPayload
+from app.schemas.user import UserRead
+from app.services import settings_service
 
 pytestmark = pytest.mark.asyncio
 
@@ -22,10 +23,13 @@ async def test_get_settings_404_when_missing(async_session: AsyncSession):
 
 
 async def test_update_then_get_returns_values(async_session: AsyncSession):
+    admin_id = uuid.UUID(int=1)
+    settings_service._cached_admin_user_id = admin_id
+
     user: UserRead = UserRead(
         email="test@na.com",
         full_name="bloke",
-        id=uuid.UUID(int=1),
+        id=admin_id,
     )
 
     payload: SettingsPayload = SettingsPayload(
@@ -42,3 +46,5 @@ async def test_update_then_get_returns_values(async_session: AsyncSession):
     # Now get should return the same values
     got = await settings_service.get_settings(async_session)
     assert got == payload
+
+    settings_service._cached_admin_user_id = None


### PR DESCRIPTION
## Summary
- add `admin_user_id` to settings model and schema with migration
- cache admin user in settings service and ensure setup seeds it
- adjust tests to retrieve dynamic admin id

## Testing
- `npm run lint`
- `cd backend && pytest`
- `cd ../frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b29d3b262883319b3de0bb8cb103ab