### PR TITLE
refactor: deduplicate settings imports

### DIFF
--- a/backend/app/services/settings_service.py
+++ b/backend/app/services/settings_service.py
@@ -1,10 +1,7 @@
 """Service to manage global application pricing settings."""
 
 import logging
-
-from fastapi import Depends, HTTPException
-from sqlalchemy import select
-from sqlalchemy.ext.asyncio import AsyncSession
+import uuid
 
 from fastapi import Depends, HTTPException
 from sqlalchemy import select


### PR DESCRIPTION
## Summary
- remove duplicate FastAPI and SQLAlchemy imports in settings service
- add missing uuid import

## Testing
- `npm run lint`
- `cd backend && pytest`
- `cd frontend && CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2a67dcc488331a3e6a2ad18f3c0b7