### PR TITLE
fix: enforce admin access using dynamic admin ID

### DIFF
--- a/backend/app/dependencies.py
+++ b/backend/app/dependencies.py
@@ -78,3 +78,14 @@ async def get_current_user(
 
 
 get_current_user_v2 = get_current_user
+
+
+async def require_admin(
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> User:
+    """Ensure the current user matches the configured admin user."""
+    from app.services.settings_service import ensure_admin
+
+    await ensure_admin(user, db)
+    return user

--- a/backend/app/schemas/setup.py
+++ b/backend/app/schemas/setup.py
@@ -1,25 +1,29 @@
-from pydantic import BaseModel, EmailStr, ConfigDict
-
 """Schemas for initial application setup."""
 
-from pydantic import BaseModel, EmailStr, ConfigDict
+import uuid
+
+from pydantic import BaseModel, ConfigDict, EmailStr
 
 
 class SettingsPayload(BaseModel):
     """Configuration values provided during setup."""
+
     account_mode: bool
     flagfall: float
     per_km_rate: float
     per_minute_rate: float
+    admin_user_id: uuid.UUID | None = None
     model_config = ConfigDict(from_attributes=True)
 
 
 class SetupPayload(BaseModel):
     """Payload containing admin user and settings."""
+
     admin_email: EmailStr
     full_name: str
     admin_password: str
     settings: SettingsPayload
+
 
 # class SetupSummary(TypedDict):
 #     account_mode: bool

--- a/backend/app/services/settings_service.py
+++ b/backend/app/services/settings_service.py
@@ -54,6 +54,7 @@ async def get_settings(db: AsyncSession = Depends(get_db)) -> SettingsPayload:
         flagfall=row.flagfall,
         per_km_rate=row.per_km_rate,
         per_minute_rate=row.per_minute_rate,
+        admin_user_id=row.admin_user_id,
     )
 
 

--- a/backend/app/services/setup_service.py
+++ b/backend/app/services/setup_service.py
@@ -57,4 +57,5 @@ async def is_setup_complete(db: AsyncSession) -> Union[SettingsPayload, None]:
         flagfall=cfg.flagfall,
         per_km_rate=cfg.per_km_rate,
         per_minute_rate=cfg.per_minute_rate,
+        admin_user_id=cfg.admin_user_id,
     )

--- a/backend/tests/integration/test_driver_leave_api.py
+++ b/backend/tests/integration/test_driver_leave_api.py
@@ -2,12 +2,13 @@ import uuid
 from datetime import datetime, timedelta, timezone
 
 import pytest
+from httpx import AsyncClient
+from sqlalchemy import select
+
 from app.core.security import hash_password
 from app.models.booking import Booking, BookingStatus
 from app.models.notification import Notification, NotificationType
 from app.models.user_v2 import User, UserRole
-from httpx import AsyncClient
-from sqlalchemy import select
 
 pytestmark = pytest.mark.asyncio
 
@@ -42,10 +43,12 @@ async def _create_confirmed_booking(async_session) -> Booking:
     return booking
 
 
-async def test_driver_leave_booking(async_session, client: AsyncClient):
+async def test_driver_leave_booking(async_session, client: AsyncClient, admin_headers):
     booking = await _create_confirmed_booking(async_session)
 
-    res = await client.post(f"/api/v1/driver/bookings/{booking.id}/leave")
+    res = await client.post(
+        f"/api/v1/driver/bookings/{booking.id}/leave", headers=admin_headers
+    )
     assert res.status_code == 200
     data = res.json()
     assert data["status"] == "ON_THE_WAY"

--- a/backend/tests/unit/services/test_settings_service.py
+++ b/backend/tests/unit/services/test_settings_service.py
@@ -41,10 +41,16 @@ async def test_update_then_get_returns_values(async_session: AsyncSession):
 
     # First call update to seed settings
     updated = await settings_service.update_settings(payload, async_session, user)
-    assert updated == payload
+    assert updated.account_mode == payload.account_mode
+    assert updated.flagfall == payload.flagfall
+    assert updated.per_km_rate == payload.per_km_rate
+    assert updated.per_minute_rate == payload.per_minute_rate
 
     # Now get should return the same values
     got = await settings_service.get_settings(async_session)
-    assert got == payload
+    assert got.account_mode == payload.account_mode
+    assert got.flagfall == payload.flagfall
+    assert got.per_km_rate == payload.per_km_rate
+    assert got.per_minute_rate == payload.per_minute_rate
 
     settings_service._cached_admin_user_id = None

--- a/frontend/src/__tests__/AccessControl.test.tsx
+++ b/frontend/src/__tests__/AccessControl.test.tsx
@@ -19,6 +19,7 @@ const baseAuth: AuthContextType = {
   userName: null,
   userID: null,
   role: null,
+  adminID: CONFIG.ADMIN_USER_ID,
   loginWithPassword: vi.fn(),
   registerWithPassword: vi.fn(),
   loginWithOAuth: vi.fn(),

--- a/frontend/src/__tests__/setup/msw.handlers.ts
+++ b/frontend/src/__tests__/setup/msw.handlers.ts
@@ -9,6 +9,7 @@ type SettingsBody = {
   flagfall: number;
   per_km_rate: number;
   per_minute_rate: number;
+  admin_user_id: string;
 };
 
 const BASE_URL = CONFIG.API_BASE_URL
@@ -20,6 +21,7 @@ let __settings: SettingsBody = {
   flagfall: 10.5,
   per_km_rate: 2.75,
   per_minute_rate: 1.1,
+  admin_user_id: CONFIG.ADMIN_USER_ID,
 };
 
 export const handlers = [
@@ -91,7 +93,7 @@ export const handlers = [
 
   http.put(apiUrl('/settings'), async ({ request }) => {
     const body = (await request.json()) as SettingsBody;
-    __settings = body; // naive in-memory update
+    __settings = { ...__settings, ...body };
     return HttpResponse.json({ ok: true });
   }),
 ];

--- a/frontend/src/components/NavBar.test.tsx
+++ b/frontend/src/components/NavBar.test.tsx
@@ -14,6 +14,7 @@ function seedAuth({ id, name, role }: { id: string; name: string; role: string }
   localStorage.setItem('userName', name);
   localStorage.setItem('userRole', role);
   localStorage.setItem('role', role);
+  localStorage.setItem('adminID', CONFIG.ADMIN_USER_ID);
 }
 
 function renderWithAuth(initialPath = '/book', extraRoutes?: ReactNode) {
@@ -104,7 +105,7 @@ describe('NavBar', () => {
   });
 
   test('driver dashboard menu navigates to driver dashboard', async () => {
-    seedAuth({ id: '00000000-0000-0000-0000-000000000002', name: 'Driver User', role: 'DRIVER' });
+    seedAuth({ id: CONFIG.ADMIN_USER_ID, name: 'Admin User', role: 'ADMIN' });
     renderWithAuth('/book', <Route path="/driver" element={<h1>Driver</h1>} />);
 
     const accountBtn = await screen.findByLabelText(/account/i);
@@ -118,7 +119,7 @@ describe('NavBar', () => {
   });
 
   test('availability menu navigates to driver availability', async () => {
-    seedAuth({ id: '00000000-0000-0000-0000-000000000002', name: 'Driver User', role: 'DRIVER' });
+    seedAuth({ id: CONFIG.ADMIN_USER_ID, name: 'Admin User', role: 'ADMIN' });
     renderWithAuth(
       '/book',
       <Route path="/driver/availability" element={<h1>Availability</h1>} />,

--- a/frontend/src/components/NavBar.tsx
+++ b/frontend/src/components/NavBar.tsx
@@ -13,7 +13,7 @@ import { useAuth } from '@/contexts/AuthContext';
 import { useDevFeatures } from '@/contexts/DevFeaturesContext';
 
 const NavBar: React.FC = () => {
-  const { logout, userName, role } = useAuth();  // get logout (and maybe user info) from context
+  const { logout, userName, userID, adminID } = useAuth();
   const { enabled: devEnabled } = useDevFeatures();
   const navigate = useNavigate();
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
@@ -109,13 +109,11 @@ const NavBar: React.FC = () => {
           <MenuItem onClick={navBook}>Book</MenuItem>
           <MenuItem onClick={navHistory}>Ride History</MenuItem>
           <MenuItem onClick={navProfile}>Profile</MenuItem>
-          {role?.toLowerCase() === 'driver' && [
+          {userID === adminID && [
             <MenuItem key="driver-dashboard" onClick={navDriverDashboard}>Driver Dashboard</MenuItem>,
             <MenuItem key="driver-availability" onClick={navDriverAvailability}>Availability</MenuItem>,
+            <MenuItem key="admin-dashboard" onClick={navAdmin}>Admin Dashboard</MenuItem>,
           ]}
-          {role?.toLowerCase() === 'admin' && (
-            <MenuItem onClick={navAdmin}>Admin Dashboard</MenuItem>
-          )}
           {devEnabled && <MenuItem onClick={navDevNotes}>Dev Notes</MenuItem>}
         </Menu>
       </Toolbar>

--- a/frontend/src/pages/Dashboard/HomePage.test.tsx
+++ b/frontend/src/pages/Dashboard/HomePage.test.tsx
@@ -13,6 +13,7 @@ function seedAuth(id: string, role = 'CUSTOMER') {
   localStorage.setItem('userID', id);
   localStorage.setItem('userName', 'Test User');
   localStorage.setItem('role', role);
+  localStorage.setItem('adminID', CONFIG.ADMIN_USER_ID);
 }
 
 describe('HomePage', () => {

--- a/frontend/src/pages/Dashboard/HomePage.tsx
+++ b/frontend/src/pages/Dashboard/HomePage.tsx
@@ -1,7 +1,6 @@
 import { Grid, Button, Typography } from '@mui/material';
 import { Link } from 'react-router-dom';
 import { useAuth } from '@/contexts/AuthContext';
-import { CONFIG } from '@/config';
 
 interface Tile {
   label: string;
@@ -9,7 +8,7 @@ interface Tile {
 }
 
 export default function HomePage() {
-  const { userID } = useAuth();
+  const { userID, adminID } = useAuth();
 
   const tiles: Tile[] = [
     { label: 'Book a Ride', path: '/book' },
@@ -17,7 +16,7 @@ export default function HomePage() {
     { label: 'Profile', path: '/me' },
   ];
 
-  if (userID === CONFIG.ADMIN_USER_ID) {
+  if (userID && userID === adminID) {
     tiles.splice(2, 0, { label: 'Driver Dashboard', path: '/driver' });
     tiles.splice(3, 0, { label: 'Availability', path: '/driver/availability' });
     tiles.push({ label: 'Admin Dashboard', path: '/admin' });

--- a/frontend/src/types/AuthContextType.tsx
+++ b/frontend/src/types/AuthContextType.tsx
@@ -9,8 +9,7 @@ export type AuthContextType = {
   userName: string | null;
   userID: string | null;
   role: string | null;
-
-  role: string | null;
+  adminID: string | null;
 
   loginWithPassword: (email: string, password: string) => Promise<string | null>;
   registerWithPassword: (fullName: string, email: string, password: string) => Promise<void>;


### PR DESCRIPTION
## Summary
- gate driver and availability APIs with admin checks
- surface admin_user_id in settings and fetch it on the client
- show admin/driver features only for configured admin user

## Testing
- `npm run lint`
- `cd backend && pytest`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2aab184d48331b503bec0e0ef21cb