### PR TITLE
feat: load auth tokens from storage on startup

### DIFF
--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -2,12 +2,16 @@
 import React, { createContext, useCallback, useContext, useEffect, useMemo, useState } from "react";
 import { authApi } from "@/components/ApiConfig";
 import { CONFIG } from "@/config";
-import { setTokens, getRefreshToken } from "../services/tokenStore";
+import { setTokens, getRefreshToken, initTokensFromStorage } from "../services/tokenStore";
 import { beginLogin, completeLoginFromRedirect, refreshTokens, TokenResponse, OAuthConfig } from "../services/oauth";
 import { useLocation, useNavigate } from "react-router-dom";
 import { type AuthContextType } from "@/types/AuthContextType";
 import { subscribePush } from "@/services/push";
 import * as logger from "@/lib/logger";
+
+// Seed token store from localStorage before any React code runs so that
+// getAccessToken() returns a value on first render.
+initTokensFromStorage();
 
 type UserShape = { email?: string; full_name?: string; role?: string } | null;
 

--- a/frontend/src/services/tokenStore.ts
+++ b/frontend/src/services/tokenStore.ts
@@ -3,6 +3,23 @@ let accessToken: string | null = null;
 let refreshToken: string | null = null;
 let listeners: Array<() => void> = [];
 
+// Load tokens from localStorage on startup so callers can access them
+// immediately after this module is imported.
+export function initTokensFromStorage() {
+  if (typeof window === "undefined" || typeof localStorage === "undefined") {
+    return;
+  }
+  const raw = localStorage.getItem("auth_tokens");
+  if (!raw) return;
+  try {
+    const { access_token, refresh_token } = JSON.parse(raw);
+    accessToken = access_token ?? null;
+    refreshToken = refresh_token ?? null;
+  } catch {
+    // ignore parse errors
+  }
+}
+
 export function setTokens(a?: string | null, r?: string | null) {
   accessToken = a ?? null;
   refreshToken = r ?? null;


### PR DESCRIPTION
## Summary
- seed token store from `localStorage` on import so access token is available immediately
- initialize token store during auth context setup

## Testing
- `npm run lint`
- `cd backend && pytest`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b2ff9880b8833194c07dc3cba3fa22