### PR TITLE
refactor: enforce admin access by user id

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -11,7 +11,7 @@ import RideDetailsPage from "@/pages/Booking/RideDetailsPage";
 import RegisterPage from "@/pages/Auth/RegisterPage";
 import ProfilePage from "@/pages/Profile/ProfilePage";
 import SetupPage from "@/pages/Setup/SetupPage";
-import { useAuth, RequireAuth, RequireRole } from "@/contexts/AuthContext";
+import { useAuth, RequireAuth, RequireAdmin } from "@/contexts/AuthContext";
 import NavBar from "@/components/NavBar";
 import PageNotFound from "@/pages/PageNotFound";
 import DevNotes from "@/components/DevNotes";
@@ -49,10 +49,10 @@ function App() {
       <Route path="/history/:id" element={<RequireAuth><RideDetailsPage /></RequireAuth>} />
       <Route path="/me" element={<RequireAuth><ProfilePage /></RequireAuth>} />
 
-      {/* Protected admin/driver route */}
-      <Route path="/admin" element={<RequireRole role="admin"><AdminDashboard /></RequireRole>} />
-      <Route path="/driver" element={<RequireRole role="driver"><DriverDashboard /></RequireRole>} />
-      <Route path="/driver/availability" element={<RequireRole role="driver"><AvailabilityPage /></RequireRole>} />
+      {/* Protected admin-only routes */}
+      <Route path="/admin" element={<RequireAdmin><AdminDashboard /></RequireAdmin>} />
+      <Route path="/driver" element={<RequireAdmin><DriverDashboard /></RequireAdmin>} />
+      <Route path="/driver/availability" element={<RequireAdmin><AvailabilityPage /></RequireAdmin>} />
       <Route path="/t/:code" element={<TrackingPage />} />
 
       {devEnabled && <Route path="/devnotes" element={<DevNotes />} />}

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -335,25 +335,21 @@ export const RequireAuth: React.FC<{ children: React.ReactNode }> = ({ children 
   return <>{children}</>;
 };
 
-export const RequireRole: React.FC<{ role: string; children: React.ReactNode }> = ({
-  role,
-  children,
-}) => {
-  const { accessToken, loading, role: userRole, userID, adminID } = useAuth();
+export const RequireAdmin: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const { accessToken, loading, userID, adminID } = useAuth();
   const navigate = useNavigate();
   const location = useLocation();
 
   useEffect(() => {
     if (!loading) {
       const from = encodeURIComponent(location.pathname + location.search);
-      const allowed = accessToken && (userRole === role || userID === adminID);
+      const allowed = accessToken && userID === adminID;
       if (!allowed) {
         navigate(`/login?from=${from}`, { replace: true });
       }
     }
-  }, [loading, accessToken, userRole, userID, adminID, role, location, navigate]);
+  }, [loading, accessToken, userID, adminID, location, navigate]);
 
-  if (loading || !accessToken || (userRole !== role && userID !== adminID))
-    return null;
+  if (loading || !accessToken || userID !== adminID) return null;
   return <>{children}</>;
 };


### PR DESCRIPTION
## Summary
- replace role-based route guard with RequireAdmin that checks user ID against admin ID
- update protected routes to use admin ID check instead of role

## Testing
- `npm run lint`
- `cd backend && pytest`
- `cd ../frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2fc3553148331acd20a17a6a05ec7