### PR TITLE
fix: include auth header when loading driver bookings

### DIFF
--- a/frontend/src/pages/Driver/DriverDashboard.tsx
+++ b/frontend/src/pages/Driver/DriverDashboard.tsx
@@ -48,7 +48,13 @@ export default function DriverDashboard() {
   useEffect(() => {
     (async () => {
       try {
-        const { data } = await bookingsApi.listBookingsApiV1DriverBookingsGet();
+        const token = getAccessToken();
+        const { data } = await bookingsApi.listBookingsApiV1DriverBookingsGet(
+          undefined,
+          token
+            ? { headers: { Authorization: `Bearer ${token}` } }
+            : undefined,
+        );
         setBookings(data as unknown as Booking[]);
       } catch {
         /* ignore */


### PR DESCRIPTION
## Summary
- ensure driver dashboard sends bearer token when listing bookings

## Testing
- `npm run lint`
- `cd backend && pytest`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b56ba00578833189d119423ebf457c