### PR TITLE
feat: support coordinate-based route metrics

### DIFF
--- a/backend/app/api/route_metrics.py
+++ b/backend/app/api/route_metrics.py
@@ -5,51 +5,56 @@ from datetime import datetime
 from typing import Union
 
 from app.services.route_metrics_service import get_route_metrics
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, Body, Depends, HTTPException, Query
+from pydantic import BaseModel, Field
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/route-metrics", tags=["route-metrics"])
 
 
-@router.get("", summary="Compute distance and duration between two addresses")
+class RouteMetricsRequest(BaseModel):
+    pickup_lat: float = Field(..., alias="pickupLat")
+    pickup_lon: float = Field(..., alias="pickupLon")
+    dropoff_lat: float = Field(..., alias="dropoffLat")
+    dropoff_lon: float = Field(..., alias="dropoffLon")
+
+    class Config:
+        allow_population_by_field_name = True
+
+
+async def get_request(
+    query: RouteMetricsRequest = Depends(),
+    body: RouteMetricsRequest | None = Body(None),
+) -> RouteMetricsRequest:
+    return body or query
+
+
+@router.api_route(
+    "",
+    methods=["GET", "POST"],
+    summary="Compute distance and duration between coordinates",
+)
 async def api_route_metrics(
-    pickup: str = Query(...),
-    dropoff: str = Query(...),
+    request: RouteMetricsRequest = Depends(get_request),
     ride_time: Union[datetime, None] = Query(
         None, description="Desired pickup time to account for traffic"
     ),
 ):
-    """Return travel metrics between pickup and dropoff addresses."""
+    """Return travel metrics between pickup and dropoff coordinates."""
     try:
-        logger.debug(
-            "route metrics inputs pickup=%s dropoff=%s ride_time=%s",
-            pickup,
-            dropoff,
-            ride_time,
-        )
-        logger.info(
-            "route metrics pickup=%s dropoff=%s ride_time=%s",
-            pickup,
-            dropoff,
-            ride_time,
-        )
+        logger.debug("route metrics inputs %s ride_time=%s", request, ride_time)
+        logger.info("route metrics %s ride_time=%s", request, ride_time)
+        pickup = f"{request.pickup_lat},{request.pickup_lon}"
+        dropoff = f"{request.dropoff_lat},{request.dropoff_lon}"
         metrics = await get_route_metrics(pickup, dropoff, ride_time)
         logger.debug("route metrics result %s", metrics)
         return metrics
     except ValueError as e:
         logger.warning(
-            "route metrics invalid input pickup=%s dropoff=%s ride_time=%s",
-            pickup,
-            dropoff,
-            ride_time,
+            "route metrics invalid input %s ride_time=%s", request, ride_time
         )
         raise HTTPException(status_code=400, detail=str(e))
     except Exception as e:
-        logger.error(
-            "route metrics error pickup=%s dropoff=%s ride_time=%s",
-            pickup,
-            dropoff,
-            ride_time,
-        )
+        logger.error("route metrics error %s ride_time=%s", request, ride_time)
         raise HTTPException(status_code=400, detail=str(e))

--- a/backend/tests/integration/test_route_metrics_api.py
+++ b/backend/tests/integration/test_route_metrics_api.py
@@ -1,19 +1,28 @@
 import pytest
-from httpx import AsyncClient
 from _pytest.monkeypatch import MonkeyPatch
+from httpx import AsyncClient
 
 pytestmark = pytest.mark.asyncio
+
 
 async def test_route_metrics_success(monkeypatch: MonkeyPatch, client: AsyncClient):
     from app.api import route_metrics as router
 
     async def fake_get_route_metrics(pickup: str, dropoff: str, ride_time=None):
-        assert pickup == "A" and dropoff == "B"
+        assert pickup == "1.0,2.0" and dropoff == "3.0,4.0"
         return {"km": 1.23, "min": 4.5}
 
     monkeypatch.setattr(router, "get_route_metrics", fake_get_route_metrics)
 
-    res = await client.get("/route-metrics", params={"pickup": "A", "dropoff": "B"})
+    res = await client.get(
+        "/route-metrics",
+        params={
+            "pickupLat": 1.0,
+            "pickupLon": 2.0,
+            "dropoffLat": 3.0,
+            "dropoffLon": 4.0,
+        },
+    )
     assert res.status_code == 200
     assert res.json() == {"km": 1.23, "min": 4.5}
 
@@ -26,6 +35,14 @@ async def test_route_metrics_error(monkeypatch: MonkeyPatch, client: AsyncClient
 
     monkeypatch.setattr(router, "get_route_metrics", fake_get_route_metrics)
 
-    res = await client.get("/route-metrics", params={"pickup": "A", "dropoff": "B"})
+    res = await client.get(
+        "/route-metrics",
+        params={
+            "pickupLat": 1.0,
+            "pickupLon": 2.0,
+            "dropoffLat": 3.0,
+            "dropoffLon": 4.0,
+        },
+    )
     assert res.status_code == 400
     assert res.json()["detail"] == "bad request"

--- a/backend/tests/unit/api/test_route_metrics_router.py
+++ b/backend/tests/unit/api/test_route_metrics_router.py
@@ -1,15 +1,19 @@
-import pytest
-from httpx import AsyncClient
 from datetime import datetime
 from typing import Union
+
+import pytest
 from _pytest.monkeypatch import MonkeyPatch
+from httpx import AsyncClient
+
 
 @pytest.mark.asyncio
 async def test_route_metrics_router(monkeypatch: MonkeyPatch, client: AsyncClient):
     from app.api import route_metrics as router
 
-    async def fake_get_route_metrics(pickup: str, dropoff: str, ride_time: Union[datetime, None]):
-        assert pickup == "A" and dropoff == "B"
+    async def fake_get_route_metrics(
+        pickup: str, dropoff: str, ride_time: Union[datetime, None]
+    ):
+        assert pickup == "1.0,2.0" and dropoff == "3.0,4.0"
         assert ride_time == datetime(2020, 1, 1)
         return {"km": 1.2, "min": 3.4}
 
@@ -17,7 +21,13 @@ async def test_route_metrics_router(monkeypatch: MonkeyPatch, client: AsyncClien
 
     res = await client.get(
         "/route-metrics",
-        params={"pickup": "A", "dropoff": "B", "ride_time": "2020-01-01T00:00:00"},
+        params={
+            "pickupLat": 1.0,
+            "pickupLon": 2.0,
+            "dropoffLat": 3.0,
+            "dropoffLon": 4.0,
+            "ride_time": "2020-01-01T00:00:00",
+        },
     )
     assert res.status_code == 200
     assert res.json() == {"km": 1.2, "min": 3.4}


### PR DESCRIPTION
## Summary
- accept pickup and dropoff coordinates via RouteMetricsRequest model
- format coordinates as "lat,lon" when calling route metrics service
- test API with coordinate-based parameters

## Testing
- `npm run lint`
- `cd backend && pytest`
- `cd ../frontend && npm test` *(fails: 1 failed test, 2 failing tests? Wait; results show 2 failed tests? The log summary: Test Files 1 failed (2 tests?). It says 'Test Files 1 failed | 38 passed | 1 skipped (40)' and 'Tests 2 failed | 95 passed | 8 skipped (105)'. So we mention failing tests.*

------
https://chatgpt.com/codex/tasks/task_e_68b655610d84833188ebfe2d126e0a9b