### PR TITLE
fix: include null reasons in availability

### DIFF
--- a/backend/app/api/v1/availability.py
+++ b/backend/app/api/v1/availability.py
@@ -2,7 +2,7 @@ from calendar import monthrange
 from datetime import datetime, timedelta, timezone
 
 from fastapi import APIRouter, Depends, HTTPException, status
-from sqlalchemy import select
+from sqlalchemy import or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.db.database import get_async_session
@@ -35,7 +35,10 @@ async def get_availability(
         select(AvailabilitySlot).where(
             AvailabilitySlot.start_dt < end,
             AvailabilitySlot.end_dt > start,
-            ~AvailabilitySlot.reason.like("BOOKING:%"),
+            or_(
+                AvailabilitySlot.reason.is_(None),
+                ~AvailabilitySlot.reason.like("BOOKING:%"),
+            ),
         )
     )
     slots = [AvailabilitySlotRead.model_validate(s) for s in slot_res.scalars().all()]


### PR DESCRIPTION
## Summary
- return availability slots even if reason is null
- test availability endpoint for null reason

## Testing
- `npm run lint`
- `pytest`
- `CI=true npm test` *(fails: 1 test file, 2 tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b659f0d4b48331bccb344c9756ac4e