### PR TITLE
feat: add reason field for availability

### DIFF
--- a/frontend/src/__tests__/DriverDashboard.test.tsx
+++ b/frontend/src/__tests__/DriverDashboard.test.tsx
@@ -12,6 +12,14 @@ import DriverDashboard from '@/pages/Driver/DriverDashboard';
 import { driverBookingsApi } from '@/components/ApiConfig';
 
 describe('DriverDashboard', () => {
+  beforeEach(() => {
+    vi.stubGlobal('getAccessToken', vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
   it('loads and confirms booking', async () => {
     const bookings = [
       {
@@ -34,7 +42,6 @@ describe('DriverDashboard', () => {
     fireEvent.click(screen.getByText('Confirm'));
     fireEvent.click(screen.getByRole('tab', { name: /driver confirmed/i }));
     await waitFor(() => expect(screen.getByText('Leave now')).toBeInTheDocument());
-    vi.unstubAllGlobals();
   });
 
   it('shows error message when confirm fails', async () => {
@@ -68,7 +75,6 @@ describe('DriverDashboard', () => {
     await waitFor(() =>
       expect(screen.getByText(/500 fail/i)).toBeInTheDocument(),
     );
-    vi.unstubAllGlobals();
   });
 });
 

--- a/frontend/src/pages/Driver/AvailabilityPage.test.tsx
+++ b/frontend/src/pages/Driver/AvailabilityPage.test.tsx
@@ -35,6 +35,7 @@ describe('AvailabilityPage', () => {
 
     await userEvent.type(screen.getByLabelText(/start/i), '2024-01-01T10:00');
     await userEvent.type(screen.getByLabelText(/end/i), '2024-01-01T11:00');
+    await userEvent.type(screen.getByLabelText(/reason/i), 'Busy');
     await userEvent.click(screen.getByRole('button', { name: /add/i }));
 
     expect(fetch).toHaveBeenCalledWith(
@@ -44,6 +45,7 @@ describe('AvailabilityPage', () => {
         body: JSON.stringify({
           start_dt: '2024-01-01T10:00',
           end_dt: '2024-01-01T11:00',
+          reason: 'Busy',
         }),
       }),
     );

--- a/frontend/src/pages/Driver/AvailabilityPage.tsx
+++ b/frontend/src/pages/Driver/AvailabilityPage.tsx
@@ -9,15 +9,17 @@ export default function AvailabilityPage() {
   const { data, refresh } = useAvailability(month);
   const [start, setStart] = useState('');
   const [end, setEnd] = useState('');
+  const [reason, setReason] = useState('');
 
   async function create() {
     await apiFetch(`${CONFIG.API_BASE_URL}/api/v1/availability`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ start_dt: start, end_dt: end }),
+      body: JSON.stringify({ start_dt: start, end_dt: end, reason }),
     });
     setStart('');
     setEnd('');
+    setReason('');
     await refresh();
   }
 
@@ -38,6 +40,11 @@ export default function AvailabilityPage() {
           value={end}
           onChange={e => setEnd(e.target.value)}
           InputLabelProps={{ shrink: true }}
+        />
+        <TextField
+          label="Reason"
+          value={reason}
+          onChange={e => setReason(e.target.value)}
         />
         <Button variant="contained" onClick={create} disabled={!start || !end}>
           Add

--- a/frontend/tests/e2e/pages/driver/DriverAvailabilityPage.ts
+++ b/frontend/tests/e2e/pages/driver/DriverAvailabilityPage.ts
@@ -20,13 +20,20 @@ export class DriverAvailabilityPage {
     return this.page.getByLabel(/end/i);
   }
 
+  reasonField() {
+    return this.page.getByLabel(/reason/i);
+  }
+
   addButton() {
     return this.page.getByRole('button', { name: /add/i });
   }
 
-  async addSlot(start: string, end: string) {
+  async addSlot(start: string, end: string, reason?: string) {
     await this.startField().fill(start);
     await this.endField().fill(end);
+    if (reason) {
+      await this.reasonField().fill(reason);
+    }
     await this.addButton().click();
   }
 }

--- a/frontend/tests/e2e/specs/driver/availability-management.spec.ts
+++ b/frontend/tests/e2e/specs/driver/availability-management.spec.ts
@@ -4,6 +4,7 @@ import { DriverAvailabilityPage } from '../../pages/driver/DriverAvailabilityPag
 interface Slot {
   start_dt?: string;
   end_dt?: string;
+  reason?: string;
 }
 
 const token = 'driver-token';
@@ -48,9 +49,11 @@ test('driver manages availability slots', async ({ page }) => {
 
   const start = '2024-01-01T10:00';
   const end = '2024-01-01T11:00';
-  await availability.addSlot(start, end);
+  const reason = 'Busy';
+  await availability.addSlot(start, end, reason);
 
   expect(captured.start_dt).toBe(start);
   expect(captured.end_dt).toBe(end);
+  expect(captured.reason).toBe(reason);
 });
 


### PR DESCRIPTION
## Summary
- allow drivers to specify a reason when creating availability blocks
- cover availability reason in unit, e2e, and dashboard tests

## Testing
- `npm run lint`
- `cd backend && pytest`
- `cd frontend && npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68b65a4ea79083319df4922931914a53