### PR TITLE
fix: delay route fetch until coordinates known

### DIFF
--- a/frontend/src/components/BookingWizard/TripDetailsStep.tsx
+++ b/frontend/src/components/BookingWizard/TripDetailsStep.tsx
@@ -25,11 +25,11 @@ interface Props {
 
 export default function TripDetailsStep({ data, onNext, onBack, onChange }: Props) {
   const [pickup, setPickup] = useState(data.pickup?.address || '');
-  const [pickupLat, setPickupLat] = useState<number>(data.pickup?.lat ?? 0);
-  const [pickupLng, setPickupLng] = useState<number>(data.pickup?.lng ?? 0);
+  const [pickupLat, setPickupLat] = useState<number | undefined>(data.pickup?.lat);
+  const [pickupLng, setPickupLng] = useState<number | undefined>(data.pickup?.lng);
   const [dropoff, setDropoff] = useState(data.dropoff?.address || '');
-  const [dropLat, setDropLat] = useState<number>(data.dropoff?.lat ?? 0);
-  const [dropLng, setDropLng] = useState<number>(data.dropoff?.lng ?? 0);
+  const [dropLat, setDropLat] = useState<number | undefined>(data.dropoff?.lat);
+  const [dropLng, setDropLng] = useState<number | undefined>(data.dropoff?.lng);
   const [passengers, setPassengers] = useState<number>(data.passengers ?? 1);
   const [notes, setNotes] = useState(data.notes || '');
 
@@ -44,7 +44,9 @@ export default function TripDetailsStep({ data, onNext, onBack, onChange }: Prop
         value={pickup}
         onChange={(val) => {
           setPickup(val);
-          onChange({ pickup: { address: val, lat: pickupLat, lng: pickupLng } });
+          setPickupLat(undefined);
+          setPickupLng(undefined);
+          onChange({ pickup: undefined });
         }}
         onSelect={(s) => {
           setPickup(s.address);
@@ -61,7 +63,9 @@ export default function TripDetailsStep({ data, onNext, onBack, onChange }: Prop
         value={dropoff}
         onChange={(val) => {
           setDropoff(val);
-          onChange({ dropoff: { address: val, lat: dropLat, lng: dropLng } });
+          setDropLat(undefined);
+          setDropLng(undefined);
+          onChange({ dropoff: undefined });
         }}
         onSelect={(s) => {
           setDropoff(s.address);
@@ -96,8 +100,14 @@ export default function TripDetailsStep({ data, onNext, onBack, onChange }: Prop
           variant="contained"
           onClick={() =>
             onNext({
-              pickup: { address: pickup, lat: pickupLat, lng: pickupLng },
-              dropoff: { address: dropoff, lat: dropLat, lng: dropLng },
+              pickup:
+                pickupLat !== undefined && pickupLng !== undefined
+                  ? { address: pickup, lat: pickupLat, lng: pickupLng }
+                  : undefined,
+              dropoff:
+                dropLat !== undefined && dropLng !== undefined
+                  ? { address: dropoff, lat: dropLat, lng: dropLng }
+                  : undefined,
               passengers,
               notes,
             })

--- a/frontend/src/components/MapRoute.tsx
+++ b/frontend/src/components/MapRoute.tsx
@@ -37,7 +37,11 @@ function Placeholder({ text = 'map unavailable' }: { text?: string }) {
 
 
 export function MapRoute({ pickup, dropoff, rideTime, onMetrics }: Props) {
-  const { valid, directions } = useRoute(pickup?.address || '', dropoff?.address || '');
+  const { valid, directions } = useRoute(
+    pickup?.address || '',
+    dropoff?.address || '',
+    Boolean(pickup?.lat && dropoff?.lat),
+  );
   const getMetrics = useRouteMetrics();
 
   useEffect(() => {

--- a/frontend/src/hooks/useRoute.ts
+++ b/frontend/src/hooks/useRoute.ts
@@ -14,12 +14,12 @@ export function useRoute(pickup: string, dropoff: string, enabled = true) {
   const [directions, setDirections] = useState<google.maps.DirectionsResult | null>(null);
 
   useEffect(() => {
-    let cancelled = false;
-    setDirections(null);
     if (!enabled) {
       setValid(false);
       return;
     }
+    let cancelled = false;
+    setDirections(null);
     const g = (window as { google?: GMaps }).google;
     if (!pickup || !dropoff || !g?.maps) {
       setValid(false);

--- a/frontend/src/pages/Booking/BookingWizardPage.test.tsx
+++ b/frontend/src/pages/Booking/BookingWizardPage.test.tsx
@@ -74,8 +74,8 @@ test('advances through steps and aggregates form data', async () => {
 
   expect(createBooking).toHaveBeenCalledWith({
     pickup_when: new Date('2025-01-01T10:00').toISOString(),
-    pickup: { address: '123 A St', lat: 0, lng: 0 },
-    dropoff: { address: '456 B St', lat: 0, lng: 0 },
+    pickup: undefined,
+    dropoff: undefined,
     passengers: 2,
     notes: 'Be quick',
     customer: { name: 'John Doe', email: 'john@example.com', phone: '' },


### PR DESCRIPTION
## Summary
- pass enabled flag to useRoute so directions fetch waits for coordinates
- treat unset pickup/dropoff as undefined until coords are chosen
- handle useRoute `enabled` parameter without resetting directions

## Testing
- `npm run lint`
- `cd backend && pytest` *(fails: tests/unit/core/test_security.py::test_decode_token_invalid)*
- `cd ../frontend && npm test` *(fails: src/__tests__/DriverDashboard.test.tsx > DriverDashboard > loads and confirms booking)*

------
https://chatgpt.com/codex/tasks/task_e_68b65b0023448331bfe647ee968982bd