### PR TITLE
fix: enable free solo typing for AddressField

### DIFF
--- a/frontend/src/components/AddressField.tsx
+++ b/frontend/src/components/AddressField.tsx
@@ -41,7 +41,7 @@ export function AddressField(props: {
   ) : undefined;
 
   return (
-    <Autocomplete<AddressSuggestion>
+    <Autocomplete<AddressSuggestion, false, false, true>
       freeSolo
       options={props.suggestions}
       getOptionLabel={(option) => option.address}


### PR DESCRIPTION
## Summary
- ensure Material UI Autocomplete is typed for free solo entries in AddressField

## Testing
- `npm run lint`
- `cd backend && pytest`
- `cd ../frontend && npm test` *(fails: advances through steps and aggregates form data)*

------
https://chatgpt.com/codex/tasks/task_e_68b663e785a08331856753309d7760fb