### PR TITLE
refactor: unify booking form data type

### DIFF
--- a/frontend/src/components/BookingWizard/BookingWizard.tsx
+++ b/frontend/src/components/BookingWizard/BookingWizard.tsx
@@ -5,33 +5,23 @@ import TripDetailsStep from './TripDetailsStep';
 import PaymentStep from './PaymentStep';
 import { MapProvider } from '@/components/MapProvider';
 import { MapRoute } from '@/components/MapRoute';
-
-interface Location {
-  address: string;
-  lat: number;
-  lng: number;
-}
-
-interface FormData {
-  pickup_when?: string;
-  pickup?: Location;
-  dropoff?: Location;
-  passengers?: number;
-  notes?: string;
-  customer?: { name?: string; email?: string; phone?: string };
-  pickupValid?: boolean;
-  dropoffValid?: boolean;
-}
+import { BookingFormData } from '@/types/BookingFormData';
 
 const steps = ['Select time', 'Trip details', 'Payment'];
 
 export default function BookingWizard() {
   const [active, setActive] = useState(0);
-  const [form, setForm] = useState<FormData>({ passengers: 1 });
-  const update = (data: Partial<FormData>) => {
+  const [form, setForm] = useState<BookingFormData>({
+    passengers: 1,
+    notes: '',
+    customer: {},
+    pickupValid: false,
+    dropoffValid: false,
+  });
+  const update = (data: Partial<BookingFormData>) => {
     setForm((f) => ({ ...f, ...data }));
   };
-  const next = (data: Partial<FormData>) => {
+  const next = (data: Partial<BookingFormData>) => {
     update(data);
     setActive((s) => s + 1);
   };
@@ -50,7 +40,9 @@ export default function BookingWizard() {
       {active === 1 && (
         <TripDetailsStep data={form} onChange={update} onNext={next} onBack={back} />
       )}
-      {active === 2 && <PaymentStep data={form} onBack={back} />}
+      {active === 2 && (
+        <PaymentStep data={form as Required<BookingFormData>} onBack={back} />
+      )}
       {active > 0 && form.pickupValid && form.dropoffValid && (
         <Box mt={2}>
           <MapProvider>

--- a/frontend/src/components/BookingWizard/PaymentStep.test.tsx
+++ b/frontend/src/components/BookingWizard/PaymentStep.test.tsx
@@ -41,7 +41,10 @@ test('shows tracking link after booking', async () => {
             pickup: { address: 'A', lat: 0, lng: 0 },
             dropoff: { address: 'B', lat: 1, lng: 1 },
             passengers: 1,
-            customer: { name: '', email: '' },
+            notes: '',
+            customer: { name: '', email: '', phone: '' },
+            pickupValid: true,
+            dropoffValid: true,
           }}
           onBack={() => {}}
         />
@@ -67,7 +70,10 @@ test('renders fare breakdown when dev features enabled', () => {
             pickup: { address: 'A', lat: 0, lng: 0 },
             dropoff: { address: 'B', lat: 1, lng: 1 },
             passengers: 1,
-            customer: { name: '', email: '' },
+            notes: '',
+            customer: { name: '', email: '', phone: '' },
+            pickupValid: true,
+            dropoffValid: true,
           }}
           onBack={() => {}}
         />
@@ -90,7 +96,10 @@ test('hides fare breakdown when dev features disabled', () => {
             pickup: { address: 'A', lat: 0, lng: 0 },
             dropoff: { address: 'B', lat: 1, lng: 1 },
             passengers: 1,
-            customer: { name: '', email: '' },
+            notes: '',
+            customer: { name: '', email: '', phone: '' },
+            pickupValid: true,
+            dropoffValid: true,
           }}
           onBack={() => {}}
         />

--- a/frontend/src/components/BookingWizard/PaymentStep.tsx
+++ b/frontend/src/components/BookingWizard/PaymentStep.tsx
@@ -13,6 +13,7 @@ import { useSettings } from '@/hooks/useSettings';
 import { useRouteMetrics } from '@/hooks/useRouteMetrics';
 import FareBreakdown from '@/components/FareBreakdown';
 import * as logger from '@/lib/logger';
+import { BookingFormData } from '@/types/BookingFormData';
 
 const stripePromise = (async () => {
   try {
@@ -29,23 +30,8 @@ const stripePromise = (async () => {
   }
 })();
 
-interface Location {
-  address: string;
-  lat: number;
-  lng: number;
-}
-
-interface BookingData {
-  pickup_when: string;
-  pickup: Location;
-  dropoff: Location;
-  passengers: number;
-  notes?: string;
-  customer?: { name?: string; email?: string; phone?: string };
-}
-
 interface Props {
-  data: BookingData;
+  data: Required<BookingFormData>;
   onBack: () => void;
 }
 
@@ -117,7 +103,11 @@ function PaymentInner({ data, onBack }: Props) {
     }
     const card = elements.getElement(CardElement);
     const payload = {
-      ...data,
+      pickup_when: data.pickup_when,
+      pickup: data.pickup,
+      dropoff: data.dropoff,
+      passengers: data.passengers,
+      notes: data.notes,
       customer: { name, email, phone },
     };
     logger.info(

--- a/frontend/src/components/BookingWizard/SelectTimeStep.test.tsx
+++ b/frontend/src/components/BookingWizard/SelectTimeStep.test.tsx
@@ -9,7 +9,7 @@ vi.mock('@/hooks/useAvailability', () => ({
 
 test('passes ISO string to onNext', async () => {
   const onNext = vi.fn();
-  render(<SelectTimeStep data={{}} onNext={onNext} />);
+  render(<SelectTimeStep data={{ passengers: 1 }} onNext={onNext} />);
   const input = screen.getByLabelText(/pickup time/i);
   const value = '2025-01-01T10:00';
   await userEvent.clear(input);

--- a/frontend/src/components/BookingWizard/SelectTimeStep.tsx
+++ b/frontend/src/components/BookingWizard/SelectTimeStep.tsx
@@ -1,14 +1,11 @@
 import { useState } from 'react';
 import { Stack, TextField, Button, Typography } from '@mui/material';
 import useAvailability from '@/hooks/useAvailability';
-
-interface FormData {
-  pickup_when?: string;
-}
+import { BookingFormData } from '@/types/BookingFormData';
 
 interface Props {
-  data: FormData;
-  onNext: (data: FormData) => void;
+  data: BookingFormData;
+  onNext: (data: Partial<BookingFormData>) => void;
 }
 
 export default function SelectTimeStep({ data, onNext }: Props) {

--- a/frontend/src/components/BookingWizard/TripDetailsStep.tsx
+++ b/frontend/src/components/BookingWizard/TripDetailsStep.tsx
@@ -2,27 +2,13 @@ import { useState } from 'react';
 import { Stack, TextField, Button } from '@mui/material';
 import { AddressField } from '@/components/AddressField';
 import { useAddressAutocomplete } from '@/hooks/useAddressAutocomplete';
-
-interface Location {
-  address: string;
-  lat: number;
-  lng: number;
-}
-
-interface FormData {
-  pickup?: Location;
-  dropoff?: Location;
-  passengers?: number;
-  notes?: string;
-  pickupValid?: boolean;
-  dropoffValid?: boolean;
-}
+import { BookingFormData } from '@/types/BookingFormData';
 
 interface Props {
-  data: FormData;
-  onNext: (data: FormData) => void;
+  data: BookingFormData;
+  onNext: (data: Partial<BookingFormData>) => void;
   onBack: () => void;
-  onChange: (data: Partial<FormData>) => void;
+  onChange: (data: Partial<BookingFormData>) => void;
 }
 
 export default function TripDetailsStep({ data, onNext, onBack, onChange }: Props) {

--- a/frontend/src/pages/Booking/BookingWizardPage.test.tsx
+++ b/frontend/src/pages/Booking/BookingWizardPage.test.tsx
@@ -79,12 +79,10 @@ test('advances through steps and aggregates form data', async () => {
 
   expect(createBooking).toHaveBeenCalledWith({
     pickup_when: new Date('2025-01-01T10:00').toISOString(),
-    pickup: undefined,
-    dropoff: undefined,
+    pickup: { address: '123 A St', lat: 0, lng: 0 },
+    dropoff: { address: '456 B St', lat: 0, lng: 0 },
     passengers: 2,
     notes: 'Be quick',
-    pickupValid: true,
-    dropoffValid: true,
     customer: { name: 'John Doe', email: 'john@example.com', phone: '' },
   });
 });

--- a/frontend/src/types/BookingFormData.ts
+++ b/frontend/src/types/BookingFormData.ts
@@ -1,0 +1,23 @@
+export interface Location {
+  address: string;
+  lat: number;
+  lng: number;
+}
+
+export interface CustomerInfo {
+  name?: string;
+  email?: string;
+  phone?: string;
+}
+
+export interface BookingFormData {
+  pickup_when?: string;
+  pickup?: Location;
+  dropoff?: Location;
+  passengers: number;
+  notes?: string;
+  customer?: CustomerInfo;
+  pickupValid?: boolean;
+  dropoffValid?: boolean;
+}
+


### PR DESCRIPTION
## Summary
- centralize booking field definitions in `BookingFormData`
- use shared form type across wizard steps and require full data in payment stage
- update tests and helpers for unified booking state management

## Testing
- `npm run lint`
- `cd backend && pytest`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b6640919608331b6bbc9ad5aaa2a5c