### PR TITLE
refactor: update HomePage to modern MUI Grid

### DIFF
--- a/frontend/src/pages/Dashboard/HomePage.tsx
+++ b/frontend/src/pages/Dashboard/HomePage.tsx
@@ -1,4 +1,5 @@
-import { Grid, Button, Typography } from '@mui/material';
+import Grid from '@mui/material/Grid';
+import { Button, Typography } from '@mui/material';
 import { Link } from 'react-router-dom';
 import { useAuth } from '@/contexts/AuthContext';
 
@@ -25,7 +26,7 @@ export default function HomePage() {
   return (
     <Grid container spacing={2} sx={{ p: 2 }}>
       {tiles.map((tile) => (
-        <Grid item xs={12} sm={6} md={4} key={tile.path}>
+        <Grid size={{ xs: 12, sm: 6, md: 4 }} key={tile.path}>
           <Button
             component={Link}
             to={tile.path}


### PR DESCRIPTION
## Summary
- use MUI's modern Grid component on the dashboard home page
- replace item props with responsive size definitions

## Testing
- `npm run lint`
- `cd backend && pytest`
- `cd frontend && npm test` *(fails: BookingWizardPage.test.tsx)*
- `npm run typecheck` *(fails: AddressField.tsx, BookingWizard.tsx, AuthContext.tsx, BookingConfirmationPage.tsx, RideHistoryPage.tsx, DriverDashboard.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68b66478c4208331a1c017d775f29f78