### PR TITLE
refactor: use BookingRead type for booking pages

### DIFF
--- a/frontend/src/pages/Booking/BookingConfirmationPage.tsx
+++ b/frontend/src/pages/Booking/BookingConfirmationPage.tsx
@@ -5,11 +5,11 @@ import PriceSummary from '@/components/PriceSummary';
 import FareBreakdown from '@/components/FareBreakdown';
 import { useSettings } from '@/hooks/useSettings';
 import { useRouteMetrics } from '@/hooks/useRouteMetrics';
-import type { AppSchemasBookingV2BookingRead } from '@/api-client';
+import type { BookingRead } from '@/api-client';
 
 function BookingConfirmationPage() {
   const location = useLocation();
-  const booking = location.state as AppSchemasBookingV2BookingRead | undefined;
+  const booking = location.state as BookingRead | undefined;
 
   const { data: settings } = useSettings();
   interface SettingsAliases {

--- a/frontend/src/pages/Booking/RideHistoryPage.tsx
+++ b/frontend/src/pages/Booking/RideHistoryPage.tsx
@@ -13,7 +13,7 @@ import {
 } from '@mui/material';
 
 import { customerBookingsApi } from '@/components/ApiConfig';
-import type { AppSchemasBookingV2BookingRead as Booking } from '@/api-client';
+import type { BookingRead as Booking } from '@/api-client';
 
 function RideHistoryPage() {
   const navigate = useNavigate();


### PR DESCRIPTION
## Summary
- replace AppSchemasBookingV2BookingRead imports with BookingRead in booking pages
- keep Booking alias when fetching ride history

## Testing
- `npm run lint`
- `cd backend && pytest`
- `cd frontend && npm test` *(fails: advances through steps and aggregates form data)*
- `cd frontend && npm run typecheck` *(fails: TS errors in AuthContext, HomePage, DriverDashboard)*

------
https://chatgpt.com/codex/tasks/task_e_68b664652040833187da4787a78b320a