### PR TITLE
feat: add log level threshold

### DIFF
--- a/frontend/src/lib/logger.test.ts
+++ b/frontend/src/lib/logger.test.ts
@@ -1,8 +1,9 @@
-import { describe, expect, test } from "vitest";
-import { createPayload } from "./logger";
+import { describe, expect, test, vi } from "vitest";
 
 describe("logger", () => {
-  test("creates payload with standard fields", () => {
+  test("creates payload with standard fields", async () => {
+    vi.resetModules();
+    const { createPayload } = await import("./logger");
     const payload = createPayload("info", "testFacility", ["hello", { foo: "bar" }]);
     expect(payload).toMatchObject({
       level: "info",
@@ -12,5 +13,47 @@ describe("logger", () => {
       node: "frontend",
       facility: "testFacility",
     });
+  });
+
+  test("skips logs below threshold", async () => {
+    const originalLevel = import.meta.env.VITE_LOG_LEVEL;
+    const originalUrl = import.meta.env.VITE_GRAYLOG_URL;
+    import.meta.env.VITE_LOG_LEVEL = "warn";
+    import.meta.env.VITE_GRAYLOG_URL = "http://example.com";
+    vi.resetModules();
+    const { info } = await import("./logger");
+    const fetchSpy = vi
+      .spyOn(global, "fetch")
+      .mockResolvedValue({} as Response);
+    const infoSpy = vi.spyOn(console, "info").mockImplementation(() => {});
+    info("test", "hello");
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(infoSpy).not.toHaveBeenCalled();
+    expect(fetchSpy).not.toHaveBeenCalled();
+    infoSpy.mockRestore();
+    fetchSpy.mockRestore();
+    import.meta.env.VITE_LOG_LEVEL = originalLevel;
+    import.meta.env.VITE_GRAYLOG_URL = originalUrl;
+  });
+
+  test("logs at or above threshold", async () => {
+    const originalLevel = import.meta.env.VITE_LOG_LEVEL;
+    const originalUrl = import.meta.env.VITE_GRAYLOG_URL;
+    import.meta.env.VITE_LOG_LEVEL = "warn";
+    import.meta.env.VITE_GRAYLOG_URL = "http://example.com";
+    vi.resetModules();
+    const { warn } = await import("./logger");
+    const fetchSpy = vi
+      .spyOn(global, "fetch")
+      .mockResolvedValue({} as Response);
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    warn("test", "hello");
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(warnSpy).toHaveBeenCalled();
+    expect(fetchSpy).toHaveBeenCalled();
+    warnSpy.mockRestore();
+    fetchSpy.mockRestore();
+    import.meta.env.VITE_LOG_LEVEL = originalLevel;
+    import.meta.env.VITE_GRAYLOG_URL = originalUrl;
   });
 });


### PR DESCRIPTION
## Summary
- add `VITE_LOG_LEVEL` threshold to frontend logger and ignore messages below it
- test logger filtering for low-level messages

## Testing
- `npm run lint`
- `cd backend && pytest`
- `cd frontend && npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68b67bcf178483318469e94fce29a7e4