### PR TITLE
feat: log route metrics requests

### DIFF
--- a/frontend/src/hooks/useRouteMetrics.ts
+++ b/frontend/src/hooks/useRouteMetrics.ts
@@ -32,6 +32,17 @@ export function useRouteMetrics() {
         });
         if (rideTime) params.set('ride_time', rideTime);
         url.search = params.toString();
+        logger.debug(
+          'hooks/useRouteMetrics',
+          'Requesting route metrics',
+          {
+            pickupLat,
+            pickupLon,
+            dropoffLat,
+            dropoffLon,
+            rideTime,
+          },
+        );
         const res = await apiFetch(url.toString());
         if (!res.ok) {
           logger.error(
@@ -45,6 +56,11 @@ export function useRouteMetrics() {
         const km = Number(data?.km);
         const min = Number(data?.min);
         if (!Number.isFinite(km) || !Number.isFinite(min)) return null;
+        logger.info(
+          'hooks/useRouteMetrics',
+          'Route metrics computed',
+          { km, min },
+        );
         return { km, min };
       } catch (err) {
         logger.error('hooks/useRouteMetrics', err);


### PR DESCRIPTION
## Summary
- log route metric request parameters for debugging
- add info log when route metrics are computed

## Testing
- `npm run lint`
- `cd backend && pytest`
- `cd ../frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b67bd036ac833182f290a1c582dc83