### PR TITLE
fix: refine address autocomplete logging

### DIFF
--- a/frontend/src/hooks/useAddressAutocomplete.ts
+++ b/frontend/src/hooks/useAddressAutocomplete.ts
@@ -63,7 +63,7 @@ export function useAddressAutocomplete(
           lng: r.lng,
           placeId: r.placeId,
         }));
-        logger.debug(
+        logger.info(
           "hooks/useAddressAutocomplete",
           "suggestion count",
           mapped.length
@@ -71,7 +71,6 @@ export function useAddressAutocomplete(
         setSuggestions(mapped);
       } catch (e) {
         if (!controller.signal.aborted) {
-          logger.error("hooks/useAddressAutocomplete", e);
           logger.warn("hooks/useAddressAutocomplete", e);
           setSuggestions([]);
         }


### PR DESCRIPTION
## Summary
- simplify useAddressAutocomplete error handling and add info log for suggestion count

## Testing
- `npm run lint`
- `cd backend && pytest`
- `cd ../frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b67bd16b0483319a9d605f7c20cab9