### PR TITLE
feat: add price estimation debug logs

### DIFF
--- a/frontend/src/components/BookingWizard/PaymentStep.tsx
+++ b/frontend/src/components/BookingWizard/PaymentStep.tsx
@@ -67,10 +67,34 @@ function PaymentInner({ data, onBack }: Props) {
         { lat: data.dropoff.lat, lon: data.dropoff.lng }
       );
       if (!ignore && metrics) {
+        logger.debug(
+          'components/BookingWizard/PaymentStep',
+          'Route distance km',
+          metrics.km
+        );
+        logger.debug(
+          'components/BookingWizard/PaymentStep',
+          'Route duration min',
+          metrics.min
+        );
+        logger.debug(
+          'components/BookingWizard/PaymentStep',
+          'Tariff',
+          {
+            flagfall: tariff.flagfall,
+            perKm: tariff.perKm,
+            perMin: tariff.perMin,
+          }
+        );
         const estimate =
           tariff.flagfall +
           metrics.km * tariff.perKm +
           metrics.min * tariff.perMin;
+        logger.info(
+          'components/BookingWizard/PaymentStep',
+          'Price estimate',
+          estimate
+        );
         setPrice(estimate);
         setDistanceKm(metrics.km);
         setDurationMin(metrics.min);


### PR DESCRIPTION
## Summary
- log route distance, duration, and tariff at debug level
- log final price estimate at info level

## Testing
- `npm run lint`
- `cd backend && pytest`
- `cd frontend && CI=1 npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b67bd81c3883319ff6c01d3615f3e9