### PR TITLE
feat: notify customer on driver confirmation

### DIFF
--- a/backend/app/api/v1/driver_bookings.py
+++ b/backend/app/api/v1/driver_bookings.py
@@ -47,6 +47,13 @@ async def confirm_booking(
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
     leave_at = await scheduler.schedule_leave_now(booking)
+    await notifications.create_notification(
+        db,
+        booking.id,
+        NotificationType.CONFIRMATION,
+        UserRole.CUSTOMER,
+        {"deposit_required_cents": booking.deposit_required_cents},
+    )
     return BookingStatusResponse(status=booking.status, leave_at=leave_at)
 
 


### PR DESCRIPTION
## Summary
- send confirmation notification to customer when driver confirms booking, including deposit info

## Testing
- `npm run lint`
- `cd backend && pytest` (fails: tests/unit/core/test_security.py::test_decode_token_invalid)
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b6bed56c70833183a73ec46d70f420