### PR TITLE
fix: handle card errors during booking confirmation

### DIFF
--- a/backend/app/services/booking_service.py
+++ b/backend/app/services/booking_service.py
@@ -6,10 +6,6 @@ from datetime import datetime, timedelta, timezone
 from math import atan2, cos, radians, sin, sqrt
 
 import stripe
-from fastapi import HTTPException
-from sqlalchemy import select
-from sqlalchemy.ext.asyncio import AsyncSession
-
 from app.models.availability_slot import AvailabilitySlot
 from app.models.booking import Booking, BookingStatus
 from app.models.route_point import RoutePoint
@@ -18,6 +14,9 @@ from app.models.trip import Trip
 from app.models.user_v2 import User, UserRole
 from app.schemas.api_booking import BookingCreateRequest
 from app.services import pricing_service, routing, stripe_client
+from fastapi import HTTPException
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 
 
 async def create_booking(
@@ -103,6 +102,8 @@ async def confirm_booking(db: AsyncSession, booking_id: uuid.UUID) -> Booking:
 
     try:
         intent = stripe_client.charge_deposit(booking.deposit_required_cents)
+    except stripe.error.CardError as exc:
+        raise HTTPException(status_code=402, detail=exc.user_message) from exc
     except stripe.error.StripeError as exc:
         raise HTTPException(
             status_code=400, detail="Failed to process deposit"

--- a/backend/tests/unit/services/test_booking_service.py
+++ b/backend/tests/unit/services/test_booking_service.py
@@ -21,7 +21,7 @@ async def test_confirm_booking_handles_stripe_error(
     await async_session.commit()
 
     user = User(
-        email="test@example.com",
+        email="test2@example.com",
         full_name="Test",
         hashed_password=hash_password("pass"),
         role=UserRole.CUSTOMER,
@@ -57,6 +57,59 @@ async def test_confirm_booking_handles_stripe_error(
         await booking_service.confirm_booking(async_session, booking.id)
 
     assert excinfo.value.status_code == 400
+    await async_session.refresh(booking)
+    assert booking.status is BookingStatus.PENDING
+    assert booking.deposit_payment_intent_id is None
+
+
+async def test_confirm_booking_handles_card_error(async_session: AsyncSession, mocker):
+    await async_session.execute(text("DELETE FROM availability_slots"))
+    await async_session.commit()
+
+    user = User(
+        email="test@example.com",
+        full_name="Test",
+        hashed_password=hash_password("pass"),
+        role=UserRole.CUSTOMER,
+    )
+    async_session.add(user)
+    await async_session.flush()
+
+    booking = Booking(
+        public_code=uuid.uuid4().hex[:6].upper(),
+        customer_id=user.id,
+        pickup_address="A",
+        pickup_lat=0.0,
+        pickup_lng=0.0,
+        dropoff_address="B",
+        dropoff_lat=1.0,
+        dropoff_lng=1.0,
+        pickup_when=datetime.now(timezone.utc) + timedelta(days=30),
+        notes=None,
+        passengers=1,
+        estimated_price_cents=1000,
+        deposit_required_cents=500,
+        status=BookingStatus.PENDING,
+    )
+    async_session.add(booking)
+    await async_session.commit()
+
+    card_error = stripe.error.CardError(
+        "Card declined",
+        param=None,
+        code="card_declined",
+        json_body={"error": {"message": "Card declined"}},
+    )
+    mocker.patch(
+        "app.services.stripe_client.charge_deposit",
+        side_effect=card_error,
+    )
+
+    with pytest.raises(HTTPException) as excinfo:
+        await booking_service.confirm_booking(async_session, booking.id)
+
+    assert excinfo.value.status_code == 402
+    assert excinfo.value.detail == "Card declined"
     await async_session.refresh(booking)
     assert booking.status is BookingStatus.PENDING
     assert booking.deposit_payment_intent_id is None

--- a/frontend/src/pages/Driver/DriverDashboard.tsx
+++ b/frontend/src/pages/Driver/DriverDashboard.tsx
@@ -96,7 +96,7 @@ export default function DriverDashboard() {
         ),
       );
     } else {
-      setError(`${res.status} ${data.message ?? res.statusText}`);
+      setError(`${res.status} ${data.message ?? data.detail ?? res.statusText}`);
     }
   }
 


### PR DESCRIPTION
## Summary
- return HTTP 402 with Stripe card error message when deposit charge fails
- show backend error details in driver dashboard updates
- test Stripe card error handling

## Testing
- `npm run lint`
- `ENV=test pytest`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b6be7effd48331ab98916f15e07b07