### PR TITLE
fix: update pydantic config for route metrics

### DIFF
--- a/backend/app/api/route_metrics.py
+++ b/backend/app/api/route_metrics.py
@@ -20,7 +20,7 @@ class RouteMetricsRequest(BaseModel):
     dropoff_lon: float = Field(..., alias="dropoffLon")
 
     class Config:
-        allow_population_by_field_name = True
+        populate_by_name = True
 
 
 async def get_request(


### PR DESCRIPTION
## Summary
- use `populate_by_name` in route metrics request model for Pydantic v2 compatibility

## Testing
- `pytest backend/tests/unit/api/test_route_metrics_router.py` *(fails: sqlite3.OperationalError near "TYPE")*
- `npm run lint`
- `cd backend && pytest` *(fails: sqlite3.OperationalError near "TYPE")*
- `cd frontend && npm test` *(fails: Found multiple elements with the text: A → B)*

------
https://chatgpt.com/codex/tasks/task_e_68b6ccefecc88331a7065c75cfbb3eef