### PR TITLE
fix(frontend): remove duplicate deposit failed status

### DIFF
--- a/frontend/src/pages/Driver/DriverDashboard.tsx
+++ b/frontend/src/pages/Driver/DriverDashboard.tsx
@@ -24,7 +24,6 @@ const statuses: BookingStatus[] = [
   'PENDING',
   'DEPOSIT_FAILED',
   'DRIVER_CONFIRMED',
-  'DEPOSIT_FAILED',
   'ON_THE_WAY',
   'ARRIVED_PICKUP',
   'IN_PROGRESS',

--- a/frontend/src/types/BookingStatus.ts
+++ b/frontend/src/types/BookingStatus.ts
@@ -5,7 +5,6 @@ export type BookingStatus =
   | 'DEPOSIT_FAILED'
   | 'DRIVER_CONFIRMED'
   | 'DECLINED'
-  | 'DEPOSIT_FAILED'
   | 'ON_THE_WAY'
   | 'ARRIVED_PICKUP'
   | 'IN_PROGRESS'
@@ -18,7 +17,6 @@ export const bookingStatusLabels: Record<BookingStatus, string> = {
   DEPOSIT_FAILED: 'Deposit failed',
   DRIVER_CONFIRMED: 'Driver confirmed',
   DECLINED: 'Declined',
-  DEPOSIT_FAILED: 'Deposit failed',
   ON_THE_WAY: 'On the way',
   ARRIVED_PICKUP: 'Arrived pickup',
   IN_PROGRESS: 'In progress',
@@ -32,7 +30,6 @@ export const bookingStatusColors: Record<BookingStatus, ChipProps['color']> = {
   DEPOSIT_FAILED: 'error',
   DRIVER_CONFIRMED: 'info',
   DECLINED: 'error',
-  DEPOSIT_FAILED: 'error',
   ON_THE_WAY: 'info',
   ARRIVED_PICKUP: 'info',
   IN_PROGRESS: 'primary',


### PR DESCRIPTION
## Summary
- remove duplicate `DEPOSIT_FAILED` status from types and driver dashboard

## Testing
- `npm run lint`
- `cd frontend && npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68b6d1db4778833185547ec8db10b5d7