### PR TITLE
feat: add radius-km option to tracking simulator

### DIFF
--- a/backend/tracking-simulator.py
+++ b/backend/tracking-simulator.py
@@ -6,6 +6,7 @@ Requirements:
   pip install httpx websockets
 """
 
+import argparse
 import asyncio
 import json
 import math
@@ -16,17 +17,23 @@ from typing import Iterable, Tuple
 import httpx
 import websockets
 
-API_BASE = "http://localhost:8000"   # backend base URL
-BOOKING_CODE = "ABC123"              # public booking code from the customer link
-POINTS = 120                         # samples per leg
+API_BASE = "http://localhost:8000"  # backend base URL
+BOOKING_CODE = "ABC123"  # public booking code from the customer link
+POINTS = 120  # samples per leg
+
 
 # --- helpers -----------------------------------------------------------------
-def interpolate(a: Tuple[float, float], b: Tuple[float, float], n: int) -> Iterable[Tuple[float, float]]:
+def interpolate(
+    a: Tuple[float, float], b: Tuple[float, float], n: int
+) -> Iterable[Tuple[float, float]]:
     for i in range(n):
         t = i / (n - 1)
         yield (a[0] + t * (b[0] - a[0]), a[1] + t * (b[1] - a[1]))
 
-def random_point_near(lat: float, lng: float, distance_km: float = 5.0) -> Tuple[float, float]:
+
+def random_point_near(
+    lat: float, lng: float, distance_km: float = 5.0
+) -> Tuple[float, float]:
     """Return a point `distance_km` away from (lat,lng) in a random direction."""
     R = 6371.0
     bearing = math.radians(random.uniform(0, 360))
@@ -34,19 +41,32 @@ def random_point_near(lat: float, lng: float, distance_km: float = 5.0) -> Tuple
     lat1 = math.radians(lat)
     lng1 = math.radians(lng)
 
-    lat2 = math.asin(math.sin(lat1)*math.cos(d) + math.cos(lat1)*math.sin(d)*math.cos(bearing))
-    lng2 = lng1 + math.atan2(math.sin(bearing)*math.sin(d)*math.cos(lat1),
-                             math.cos(d) - math.sin(lat1)*math.sin(lat2))
+    lat2 = math.asin(
+        math.sin(lat1) * math.cos(d) + math.cos(lat1) * math.sin(d) * math.cos(bearing)
+    )
+    lng2 = lng1 + math.atan2(
+        math.sin(bearing) * math.sin(d) * math.cos(lat1),
+        math.cos(d) - math.sin(lat1) * math.sin(lat2),
+    )
     return (math.degrees(lat2), math.degrees(lng2))
 
-async def route_metrics(client: httpx.AsyncClient, a: Tuple[float, float], b: Tuple[float, float]):
-    params = {"pickupLat": a[0], "pickupLon": a[1], "dropoffLat": b[0], "dropoffLon": b[1]}
+
+async def route_metrics(
+    client: httpx.AsyncClient, a: Tuple[float, float], b: Tuple[float, float]
+):
+    params = {
+        "pickupLat": a[0],
+        "pickupLon": a[1],
+        "dropoffLat": b[0],
+        "dropoffLon": b[1],
+    }
     r = await client.get(f"{API_BASE}/route-metrics", params=params)
     r.raise_for_status()
     return r.json()
 
+
 # --- main simulation ---------------------------------------------------------
-async def simulate():
+async def simulate(radius_km: float) -> None:
     async with httpx.AsyncClient() as client:
         # 1. Get booking + ws_url
         r = await client.get(f"{API_BASE}/api/v1/track/{BOOKING_CODE}")
@@ -57,7 +77,7 @@ async def simulate():
 
         pickup = (booking["pickup_lat"], booking["pickup_lng"])
         dropoff = (booking["dropoff_lat"], booking["dropoff_lng"])
-        start = random_point_near(*pickup, distance_km=5.0)
+        start = random_point_near(*pickup, distance_km=radius_km)
 
         # Metrics for both legs
         leg1 = await route_metrics(client, start, pickup)
@@ -70,7 +90,11 @@ async def simulate():
         speed1 = leg1["km"] / (leg1["min"] / 60)
 
         for lat, lng in interpolate(start, pickup, POINTS):
-            await ws.send(json.dumps({"lat": lat, "lng": lng, "ts": int(time.time()), "speed": speed1}))
+            await ws.send(
+                json.dumps(
+                    {"lat": lat, "lng": lng, "ts": int(time.time()), "speed": speed1}
+                )
+            )
             await asyncio.sleep(interval1)
 
         # --- leg 2: pickup -> dropoff
@@ -79,8 +103,21 @@ async def simulate():
         speed2 = leg2["km"] / (leg2["min"] / 60)
 
         for lat, lng in interpolate(pickup, dropoff, POINTS):
-            await ws.send(json.dumps({"lat": lat, "lng": lng, "ts": int(time.time()), "speed": speed2}))
+            await ws.send(
+                json.dumps(
+                    {"lat": lat, "lng": lng, "ts": int(time.time()), "speed": speed2}
+                )
+            )
             await asyncio.sleep(interval2)
 
+
 if __name__ == "__main__":
-    asyncio.run(simulate())
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--radius-km",
+        type=float,
+        default=5.0,
+        help="radius in kilometers for the initial random point",
+    )
+    args = parser.parse_args()
+    asyncio.run(simulate(args.radius_km))


### PR DESCRIPTION
## Summary
- add `--radius-km` CLI flag to tracking simulator
- forward radius to `random_point_near`

## Testing
- `npm run lint`
- `pytest` *(fails: test_confirm_booking_handles_stripe_error, test_confirm_booking_handles_card_error)*
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b6d8ff032883319112531d3a072a03