### PR TITLE
feat: add logging to tracking simulator

### DIFF
--- a/backend/tracking-simulator.py
+++ b/backend/tracking-simulator.py
@@ -8,6 +8,7 @@ Requirements:
 
 import asyncio
 import json
+import logging
 import math
 import random
 import time
@@ -16,17 +17,26 @@ from typing import Iterable, Tuple
 import httpx
 import websockets
 
-API_BASE = "http://localhost:8000"   # backend base URL
-BOOKING_CODE = "ABC123"              # public booking code from the customer link
-POINTS = 120                         # samples per leg
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+API_BASE = "http://localhost:8000"  # backend base URL
+BOOKING_CODE = "ABC123"  # public booking code from the customer link
+POINTS = 120  # samples per leg
+
 
 # --- helpers -----------------------------------------------------------------
-def interpolate(a: Tuple[float, float], b: Tuple[float, float], n: int) -> Iterable[Tuple[float, float]]:
+def interpolate(
+    a: Tuple[float, float], b: Tuple[float, float], n: int
+) -> Iterable[Tuple[float, float]]:
     for i in range(n):
         t = i / (n - 1)
         yield (a[0] + t * (b[0] - a[0]), a[1] + t * (b[1] - a[1]))
 
-def random_point_near(lat: float, lng: float, distance_km: float = 5.0) -> Tuple[float, float]:
+
+def random_point_near(
+    lat: float, lng: float, distance_km: float = 5.0
+) -> Tuple[float, float]:
     """Return a point `distance_km` away from (lat,lng) in a random direction."""
     R = 6371.0
     bearing = math.radians(random.uniform(0, 360))
@@ -34,26 +44,44 @@ def random_point_near(lat: float, lng: float, distance_km: float = 5.0) -> Tuple
     lat1 = math.radians(lat)
     lng1 = math.radians(lng)
 
-    lat2 = math.asin(math.sin(lat1)*math.cos(d) + math.cos(lat1)*math.sin(d)*math.cos(bearing))
-    lng2 = lng1 + math.atan2(math.sin(bearing)*math.sin(d)*math.cos(lat1),
-                             math.cos(d) - math.sin(lat1)*math.sin(lat2))
+    lat2 = math.asin(
+        math.sin(lat1) * math.cos(d) + math.cos(lat1) * math.sin(d) * math.cos(bearing)
+    )
+    lng2 = lng1 + math.atan2(
+        math.sin(bearing) * math.sin(d) * math.cos(lat1),
+        math.cos(d) - math.sin(lat1) * math.sin(lat2),
+    )
     return (math.degrees(lat2), math.degrees(lng2))
 
-async def route_metrics(client: httpx.AsyncClient, a: Tuple[float, float], b: Tuple[float, float]):
-    params = {"pickupLat": a[0], "pickupLon": a[1], "dropoffLat": b[0], "dropoffLon": b[1]}
+
+async def route_metrics(
+    client: httpx.AsyncClient, a: Tuple[float, float], b: Tuple[float, float]
+):
+    logger.info("Fetching route metrics from %s to %s", a, b)
+    params = {
+        "pickupLat": a[0],
+        "pickupLon": a[1],
+        "dropoffLat": b[0],
+        "dropoffLon": b[1],
+    }
     r = await client.get(f"{API_BASE}/route-metrics", params=params)
     r.raise_for_status()
-    return r.json()
+    metrics = r.json()
+    logger.info("Route metrics: %s", metrics)
+    return metrics
+
 
 # --- main simulation ---------------------------------------------------------
 async def simulate():
     async with httpx.AsyncClient() as client:
         # 1. Get booking + ws_url
+        logger.info("Fetching booking %s", BOOKING_CODE)
         r = await client.get(f"{API_BASE}/api/v1/track/{BOOKING_CODE}")
         r.raise_for_status()
         data = r.json()
         booking = data["booking"]
         ws_url = data["ws_url"]
+        logger.info("Fetched booking %s", BOOKING_CODE)
 
         pickup = (booking["pickup_lat"], booking["pickup_lng"])
         dropoff = (booking["dropoff_lat"], booking["dropoff_lng"])
@@ -65,22 +93,35 @@ async def simulate():
 
     async with websockets.connect(ws_url) as ws:
         # --- leg 1: home -> pickup
+        logger.info("Starting leg 1: home -> pickup")
         duration1 = leg1["min"] * 60
         interval1 = duration1 / POINTS
         speed1 = leg1["km"] / (leg1["min"] / 60)
 
         for lat, lng in interpolate(start, pickup, POINTS):
-            await ws.send(json.dumps({"lat": lat, "lng": lng, "ts": int(time.time()), "speed": speed1}))
+            await ws.send(
+                json.dumps(
+                    {"lat": lat, "lng": lng, "ts": int(time.time()), "speed": speed1}
+                )
+            )
             await asyncio.sleep(interval1)
 
         # --- leg 2: pickup -> dropoff
+        logger.info("Starting leg 2: pickup -> dropoff")
         duration2 = leg2["min"] * 60
         interval2 = duration2 / POINTS
         speed2 = leg2["km"] / (leg2["min"] / 60)
 
         for lat, lng in interpolate(pickup, dropoff, POINTS):
-            await ws.send(json.dumps({"lat": lat, "lng": lng, "ts": int(time.time()), "speed": speed2}))
+            await ws.send(
+                json.dumps(
+                    {"lat": lat, "lng": lng, "ts": int(time.time()), "speed": speed2}
+                )
+            )
             await asyncio.sleep(interval2)
+
+        logger.info("Simulation completed")
+
 
 if __name__ == "__main__":
     asyncio.run(simulate())


### PR DESCRIPTION
## Summary
- configure logger for tracking simulator
- log booking retrieval, route metrics, leg start, and completion

## Testing
- `npm run lint`
- `cd backend && pytest` *(fails: AssertionError in tests/unit/core/test_security.py::test_decode_token_invalid etc.)*
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b6d90006f48331bcdc449a345c046f