### PR TITLE
feat: add CLI args to tracking simulator

### DIFF
--- a/backend/tracking-simulator.py
+++ b/backend/tracking-simulator.py
@@ -4,8 +4,14 @@ Simulate driver movement with a random start ~5 km from the pickup.
 
 Requirements:
   pip install httpx websockets
+
+Example:
+  python tracking-simulator.py --booking ABC123
+  python tracking-simulator.py --api-base http://localhost:8000 \
+    --booking ABC123 --distance-km 10 --points 200
 """
 
+import argparse
 import asyncio
 import json
 import math
@@ -16,17 +22,51 @@ from typing import Iterable, Tuple
 import httpx
 import websockets
 
-API_BASE = "http://localhost:8000"   # backend base URL
-BOOKING_CODE = "ABC123"              # public booking code from the customer link
-POINTS = 120                         # samples per leg
+DEFAULT_API_BASE = "http://localhost:8000"
+DEFAULT_BOOKING_CODE = "ABC123"
+DEFAULT_DISTANCE_KM = 5.0
+DEFAULT_POINTS = 120
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--api-base",
+        default=DEFAULT_API_BASE,
+        help="backend base URL",
+    )
+    parser.add_argument(
+        "--booking",
+        default=DEFAULT_BOOKING_CODE,
+        help="public booking code from the customer link",
+    )
+    parser.add_argument(
+        "--distance-km",
+        type=float,
+        default=DEFAULT_DISTANCE_KM,
+        help="starting distance from pickup in km",
+    )
+    parser.add_argument(
+        "--points",
+        type=int,
+        default=DEFAULT_POINTS,
+        help="samples per leg",
+    )
+    return parser.parse_args()
+
 
 # --- helpers -----------------------------------------------------------------
-def interpolate(a: Tuple[float, float], b: Tuple[float, float], n: int) -> Iterable[Tuple[float, float]]:
+def interpolate(
+    a: Tuple[float, float], b: Tuple[float, float], n: int
+) -> Iterable[Tuple[float, float]]:
     for i in range(n):
         t = i / (n - 1)
         yield (a[0] + t * (b[0] - a[0]), a[1] + t * (b[1] - a[1]))
 
-def random_point_near(lat: float, lng: float, distance_km: float = 5.0) -> Tuple[float, float]:
+
+def random_point_near(
+    lat: float, lng: float, distance_km: float = 5.0
+) -> Tuple[float, float]:
     """Return a point `distance_km` away from (lat,lng) in a random direction."""
     R = 6371.0
     bearing = math.radians(random.uniform(0, 360))
@@ -34,22 +74,38 @@ def random_point_near(lat: float, lng: float, distance_km: float = 5.0) -> Tuple
     lat1 = math.radians(lat)
     lng1 = math.radians(lng)
 
-    lat2 = math.asin(math.sin(lat1)*math.cos(d) + math.cos(lat1)*math.sin(d)*math.cos(bearing))
-    lng2 = lng1 + math.atan2(math.sin(bearing)*math.sin(d)*math.cos(lat1),
-                             math.cos(d) - math.sin(lat1)*math.sin(lat2))
+    lat2 = math.asin(
+        math.sin(lat1) * math.cos(d) + math.cos(lat1) * math.sin(d) * math.cos(bearing)
+    )
+    lng2 = lng1 + math.atan2(
+        math.sin(bearing) * math.sin(d) * math.cos(lat1),
+        math.cos(d) - math.sin(lat1) * math.sin(lat2),
+    )
     return (math.degrees(lat2), math.degrees(lng2))
 
-async def route_metrics(client: httpx.AsyncClient, a: Tuple[float, float], b: Tuple[float, float]):
-    params = {"pickupLat": a[0], "pickupLon": a[1], "dropoffLat": b[0], "dropoffLon": b[1]}
-    r = await client.get(f"{API_BASE}/route-metrics", params=params)
+
+async def route_metrics(
+    client: httpx.AsyncClient,
+    api_base: str,
+    a: Tuple[float, float],
+    b: Tuple[float, float],
+) -> dict:
+    params = {
+        "pickupLat": a[0],
+        "pickupLon": a[1],
+        "dropoffLat": b[0],
+        "dropoffLon": b[1],
+    }
+    r = await client.get(f"{api_base}/route-metrics", params=params)
     r.raise_for_status()
     return r.json()
 
+
 # --- main simulation ---------------------------------------------------------
-async def simulate():
+async def simulate(api_base: str, booking_code: str, distance_km: float, points: int):
     async with httpx.AsyncClient() as client:
         # 1. Get booking + ws_url
-        r = await client.get(f"{API_BASE}/api/v1/track/{BOOKING_CODE}")
+        r = await client.get(f"{api_base}/api/v1/track/{booking_code}")
         r.raise_for_status()
         data = r.json()
         booking = data["booking"]
@@ -57,30 +113,57 @@ async def simulate():
 
         pickup = (booking["pickup_lat"], booking["pickup_lng"])
         dropoff = (booking["dropoff_lat"], booking["dropoff_lng"])
-        start = random_point_near(*pickup, distance_km=5.0)
+        start = random_point_near(*pickup, distance_km=distance_km)
 
         # Metrics for both legs
-        leg1 = await route_metrics(client, start, pickup)
-        leg2 = await route_metrics(client, pickup, dropoff)
+        leg1 = await route_metrics(client, api_base, start, pickup)
+        leg2 = await route_metrics(client, api_base, pickup, dropoff)
 
     async with websockets.connect(ws_url) as ws:
         # --- leg 1: home -> pickup
         duration1 = leg1["min"] * 60
-        interval1 = duration1 / POINTS
+        interval1 = duration1 / points
         speed1 = leg1["km"] / (leg1["min"] / 60)
 
-        for lat, lng in interpolate(start, pickup, POINTS):
-            await ws.send(json.dumps({"lat": lat, "lng": lng, "ts": int(time.time()), "speed": speed1}))
+        for lat, lng in interpolate(start, pickup, points):
+            await ws.send(
+                json.dumps(
+                    {
+                        "lat": lat,
+                        "lng": lng,
+                        "ts": int(time.time()),
+                        "speed": speed1,
+                    }
+                )
+            )
             await asyncio.sleep(interval1)
 
         # --- leg 2: pickup -> dropoff
         duration2 = leg2["min"] * 60
-        interval2 = duration2 / POINTS
+        interval2 = duration2 / points
         speed2 = leg2["km"] / (leg2["min"] / 60)
 
-        for lat, lng in interpolate(pickup, dropoff, POINTS):
-            await ws.send(json.dumps({"lat": lat, "lng": lng, "ts": int(time.time()), "speed": speed2}))
+        for lat, lng in interpolate(pickup, dropoff, points):
+            await ws.send(
+                json.dumps(
+                    {
+                        "lat": lat,
+                        "lng": lng,
+                        "ts": int(time.time()),
+                        "speed": speed2,
+                    }
+                )
+            )
             await asyncio.sleep(interval2)
 
+
 if __name__ == "__main__":
-    asyncio.run(simulate())
+    args = parse_args()
+    asyncio.run(
+        simulate(
+            api_base=args.api_base,
+            booking_code=args.booking,
+            distance_km=args.distance_km,
+            points=args.points,
+        )
+    )


### PR DESCRIPTION
## Summary
- allow overriding tracking simulator settings from CLI
- update simulator docstring with usage examples

## Testing
- `npm run lint`
- `pytest` (fails: tests/unit/services/test_booking_service.py::test_confirm_booking_handles_stripe_error, tests/unit/services/test_booking_service.py::test_confirm_booking_handles_card_error)
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b6d900d30483319c518f7e665a6ad7