### PR TITLE
feat: secure booking websocket channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,9 +94,9 @@ npm run dev
 
 ## Realtime tracking
 
-The backend exposes a WebSocket at `/ws/bookings/{id}` which streams driver
-location updates. Customers can retrieve a tracking link via
-`GET /api/v1/track/{public_code}` and connect to the WebSocket for live
+Drivers send location updates over `/ws/bookings/{id}` using a JWT token.
+Customers can retrieve a tracking link via `GET /api/v1/track/{public_code}`
+and connect to `/ws/bookings/{id}/watch` (also authenticated) for live
 updates.
 
 ## Availability

--- a/backend/app/api/v1/track.py
+++ b/backend/app/api/v1/track.py
@@ -1,15 +1,16 @@
 from fastapi import APIRouter, Depends, HTTPException
-from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.config import get_settings
 from app.db.database import get_async_session
 from app.models.booking import Booking
-from app.schemas.booking import BookingRead
 from app.schemas.api_track import TrackResponse
-from app.core.config import get_settings
+from app.schemas.booking import BookingRead
 
 router = APIRouter(prefix="/api/v1/track", tags=["track"])
 settings = get_settings()
+
 
 @router.get("/{code}", response_model=TrackResponse)
 async def track_booking(code: str, db: AsyncSession = Depends(get_async_session)):
@@ -17,5 +18,5 @@ async def track_booking(code: str, db: AsyncSession = Depends(get_async_session)
     booking = result.scalar_one_or_none()
     if not booking:
         raise HTTPException(status_code=404, detail="booking not found")
-    ws_url = f"{settings.app_base_url}/ws/bookings/{booking.id}"
+    ws_url = f"{settings.app_base_url}/ws/bookings/{booking.id}/watch"
     return TrackResponse(booking=BookingRead.model_validate(booking), ws_url=ws_url)

--- a/backend/app/api/ws.py
+++ b/backend/app/api/ws.py
@@ -7,9 +7,11 @@ from datetime import datetime, timezone
 from broadcaster import Broadcast
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect
 
+from app.core.security import decode_token
 from app.db.database import AsyncSessionLocal
 from app.models.booking import Booking, BookingStatus
 from app.models.route_point import RoutePoint
+from app.models.user_v2 import User, UserRole
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
@@ -18,9 +20,31 @@ broadcast = Broadcast("memory://")
 
 @router.websocket("/ws/bookings/{booking_id}")
 async def booking_ws(websocket: WebSocket, booking_id: uuid.UUID):
+    token = websocket.query_params.get("token")
+    if not token:
+        await websocket.close(code=1008)
+        return
+
+    try:
+        payload = decode_token(token)
+        user_id = uuid.UUID(str(payload["sub"]))
+    except Exception:
+        await websocket.close(code=1008)
+        return
+
+    async with AsyncSessionLocal() as db:
+        user = await db.get(User, user_id)
+        booking = await db.get(Booking, booking_id)
+        if user is None or booking is None or user.role is not UserRole.DRIVER:
+            await websocket.close(code=1008)
+            return
+
     await websocket.accept()
     channel = f"booking:{booking_id}"
-    logger.info("ws connected", extra={"booking_id": str(booking_id)})
+    logger.info(
+        "ws connected",
+        extra={"booking_id": str(booking_id), "user_id": str(user_id)},
+    )
     async with broadcast.subscribe(channel=channel) as subscriber:
         send_task = asyncio.create_task(_forward_messages(websocket, subscriber))
         try:
@@ -57,9 +81,64 @@ async def booking_ws(websocket: WebSocket, booking_id: uuid.UUID):
                             )
                 await broadcast.publish(channel=channel, message=data)
         except WebSocketDisconnect:
-            logger.info("ws disconnected", extra={"booking_id": str(booking_id)})
+            logger.info(
+                "ws disconnected",
+                extra={"booking_id": str(booking_id), "user_id": str(user_id)},
+            )
         except Exception:
-            logger.exception("ws error", extra={"booking_id": str(booking_id)})
+            logger.exception(
+                "ws error",
+                extra={"booking_id": str(booking_id), "user_id": str(user_id)},
+            )
+        finally:
+            send_task.cancel()
+
+
+@router.websocket("/ws/bookings/{booking_id}/watch")
+async def booking_watch_ws(websocket: WebSocket, booking_id: uuid.UUID):
+    token = websocket.query_params.get("token")
+    if not token:
+        await websocket.close(code=1008)
+        return
+
+    try:
+        payload = decode_token(token)
+        user_id = uuid.UUID(str(payload["sub"]))
+    except Exception:
+        await websocket.close(code=1008)
+        return
+
+    async with AsyncSessionLocal() as db:
+        user = await db.get(User, user_id)
+        booking = await db.get(Booking, booking_id)
+        if user is None or booking is None or user.id != booking.customer_id:
+            await websocket.close(code=1008)
+            return
+
+    await websocket.accept()
+    channel = f"booking:{booking_id}"
+    logger.info(
+        "watch ws connected",
+        extra={"booking_id": str(booking_id), "user_id": str(user_id)},
+    )
+    async with broadcast.subscribe(channel=channel) as subscriber:
+        send_task = asyncio.create_task(_forward_messages(websocket, subscriber))
+        try:
+            while True:
+                try:
+                    await websocket.receive_text()
+                except WebSocketDisconnect:
+                    raise
+        except WebSocketDisconnect:
+            logger.info(
+                "watch ws disconnected",
+                extra={"booking_id": str(booking_id), "user_id": str(user_id)},
+            )
+        except Exception:
+            logger.exception(
+                "watch ws error",
+                extra={"booking_id": str(booking_id), "user_id": str(user_id)},
+            )
         finally:
             send_task.cancel()
 

--- a/backend/tests/unit/api/test_ws_channels.py
+++ b/backend/tests/unit/api/test_ws_channels.py
@@ -1,0 +1,104 @@
+import json
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from starlette.testclient import TestClient
+from starlette.websockets import WebSocketDisconnect
+
+from app.core.security import create_jwt_token, hash_password
+from app.main import app
+from app.models.booking import Booking, BookingStatus
+from app.models.user_v2 import User, UserRole
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _prepare_data(async_session):
+    driver = User(
+        email=f"d{uuid.uuid4()}@example.com",
+        full_name="D",
+        hashed_password=hash_password("pwd"),
+        role=UserRole.DRIVER,
+    )
+    customer = User(
+        email=f"c{uuid.uuid4()}@example.com",
+        full_name="C",
+        hashed_password=hash_password("pwd"),
+        role=UserRole.CUSTOMER,
+    )
+    async_session.add_all([driver, customer])
+    await async_session.flush()
+    booking = Booking(
+        public_code=str(uuid.uuid4())[:6],
+        customer_id=customer.id,
+        pickup_address="A",
+        pickup_lat=0.0,
+        pickup_lng=0.0,
+        dropoff_address="B",
+        dropoff_lat=1.0,
+        dropoff_lng=1.0,
+        pickup_when=datetime.now(timezone.utc) + timedelta(hours=1),
+        passengers=1,
+        estimated_price_cents=1000,
+        deposit_required_cents=500,
+        status=BookingStatus.IN_PROGRESS,
+    )
+    async_session.add(booking)
+    await async_session.commit()
+    await async_session.refresh(booking)
+    return driver, customer, booking
+
+
+async def test_unauthorized_connections_rejected(async_session):
+    driver, customer, booking = await _prepare_data(async_session)
+    other = User(
+        email=f"o{uuid.uuid4()}@example.com",
+        full_name="O",
+        hashed_password=hash_password("pwd"),
+        role=UserRole.CUSTOMER,
+    )
+    async_session.add(other)
+    await async_session.commit()
+    other_token = create_jwt_token(other.id)
+    customer_token = create_jwt_token(customer.id)
+
+    client = TestClient(app)
+    with pytest.raises(WebSocketDisconnect):
+        with client.websocket_connect(f"/ws/bookings/{booking.id}"):
+            pass
+    with pytest.raises(WebSocketDisconnect):
+        with client.websocket_connect(
+            f"/ws/bookings/{booking.id}?token={customer_token}"
+        ):
+            pass
+    with pytest.raises(WebSocketDisconnect):
+        with client.websocket_connect(f"/ws/bookings/{booking.id}/watch"):
+            pass
+    with pytest.raises(WebSocketDisconnect):
+        with client.websocket_connect(
+            f"/ws/bookings/{booking.id}/watch?token={other_token}"
+        ):
+            pass
+
+
+async def test_driver_and_owner_channels(async_session):
+    driver, customer, booking = await _prepare_data(async_session)
+    driver_token = create_jwt_token(driver.id)
+    customer_token = create_jwt_token(customer.id)
+
+    client = TestClient(app)
+    with client.websocket_connect(
+        f"/ws/bookings/{booking.id}?token={driver_token}"
+    ) as driver_ws, client.websocket_connect(
+        f"/ws/bookings/{booking.id}/watch?token={customer_token}"
+    ) as owner_ws:
+        payload = {"lat": 1.0, "lng": 2.0, "ts": 1}
+        driver_ws.send_text(json.dumps(payload))
+        assert owner_ws.receive_json() == payload
+        assert driver_ws.receive_json() == payload
+
+        owner_ws.send_text(json.dumps({"lat": 9, "lng": 9, "ts": 1}))
+        payload2 = {"lat": 3.0, "lng": 4.0, "ts": 2}
+        driver_ws.send_text(json.dumps(payload2))
+        assert owner_ws.receive_json() == payload2

--- a/backend/tracking-simulator.py
+++ b/backend/tracking-simulator.py
@@ -16,17 +16,24 @@ from typing import Iterable, Tuple
 import httpx
 import websockets
 
-API_BASE = "http://localhost:8000"   # backend base URL
-BOOKING_CODE = "ABC123"              # public booking code from the customer link
-POINTS = 120                         # samples per leg
+API_BASE = "http://localhost:8000"  # backend base URL
+BOOKING_CODE = "ABC123"  # public booking code from the customer link
+DRIVER_TOKEN = "REPLACE_ME"  # JWT for the driver user
+POINTS = 120  # samples per leg
+
 
 # --- helpers -----------------------------------------------------------------
-def interpolate(a: Tuple[float, float], b: Tuple[float, float], n: int) -> Iterable[Tuple[float, float]]:
+def interpolate(
+    a: Tuple[float, float], b: Tuple[float, float], n: int
+) -> Iterable[Tuple[float, float]]:
     for i in range(n):
         t = i / (n - 1)
         yield (a[0] + t * (b[0] - a[0]), a[1] + t * (b[1] - a[1]))
 
-def random_point_near(lat: float, lng: float, distance_km: float = 5.0) -> Tuple[float, float]:
+
+def random_point_near(
+    lat: float, lng: float, distance_km: float = 5.0
+) -> Tuple[float, float]:
     """Return a point `distance_km` away from (lat,lng) in a random direction."""
     R = 6371.0
     bearing = math.radians(random.uniform(0, 360))
@@ -34,16 +41,29 @@ def random_point_near(lat: float, lng: float, distance_km: float = 5.0) -> Tuple
     lat1 = math.radians(lat)
     lng1 = math.radians(lng)
 
-    lat2 = math.asin(math.sin(lat1)*math.cos(d) + math.cos(lat1)*math.sin(d)*math.cos(bearing))
-    lng2 = lng1 + math.atan2(math.sin(bearing)*math.sin(d)*math.cos(lat1),
-                             math.cos(d) - math.sin(lat1)*math.sin(lat2))
+    lat2 = math.asin(
+        math.sin(lat1) * math.cos(d) + math.cos(lat1) * math.sin(d) * math.cos(bearing)
+    )
+    lng2 = lng1 + math.atan2(
+        math.sin(bearing) * math.sin(d) * math.cos(lat1),
+        math.cos(d) - math.sin(lat1) * math.sin(lat2),
+    )
     return (math.degrees(lat2), math.degrees(lng2))
 
-async def route_metrics(client: httpx.AsyncClient, a: Tuple[float, float], b: Tuple[float, float]):
-    params = {"pickupLat": a[0], "pickupLon": a[1], "dropoffLat": b[0], "dropoffLon": b[1]}
+
+async def route_metrics(
+    client: httpx.AsyncClient, a: Tuple[float, float], b: Tuple[float, float]
+):
+    params = {
+        "pickupLat": a[0],
+        "pickupLon": a[1],
+        "dropoffLat": b[0],
+        "dropoffLon": b[1],
+    }
     r = await client.get(f"{API_BASE}/route-metrics", params=params)
     r.raise_for_status()
     return r.json()
+
 
 # --- main simulation ---------------------------------------------------------
 async def simulate():
@@ -53,7 +73,6 @@ async def simulate():
         r.raise_for_status()
         data = r.json()
         booking = data["booking"]
-        ws_url = data["ws_url"]
 
         pickup = (booking["pickup_lat"], booking["pickup_lng"])
         dropoff = (booking["dropoff_lat"], booking["dropoff_lng"])
@@ -63,14 +82,19 @@ async def simulate():
         leg1 = await route_metrics(client, start, pickup)
         leg2 = await route_metrics(client, pickup, dropoff)
 
-    async with websockets.connect(ws_url) as ws:
+    send_url = f"{API_BASE.replace('http', 'ws')}/ws/bookings/{booking['id']}?token={DRIVER_TOKEN}"
+    async with websockets.connect(send_url) as ws:
         # --- leg 1: home -> pickup
         duration1 = leg1["min"] * 60
         interval1 = duration1 / POINTS
         speed1 = leg1["km"] / (leg1["min"] / 60)
 
         for lat, lng in interpolate(start, pickup, POINTS):
-            await ws.send(json.dumps({"lat": lat, "lng": lng, "ts": int(time.time()), "speed": speed1}))
+            await ws.send(
+                json.dumps(
+                    {"lat": lat, "lng": lng, "ts": int(time.time()), "speed": speed1}
+                )
+            )
             await asyncio.sleep(interval1)
 
         # --- leg 2: pickup -> dropoff
@@ -79,8 +103,13 @@ async def simulate():
         speed2 = leg2["km"] / (leg2["min"] / 60)
 
         for lat, lng in interpolate(pickup, dropoff, POINTS):
-            await ws.send(json.dumps({"lat": lat, "lng": lng, "ts": int(time.time()), "speed": speed2}))
+            await ws.send(
+                json.dumps(
+                    {"lat": lat, "lng": lng, "ts": int(time.time()), "speed": speed2}
+                )
+            )
             await asyncio.sleep(interval2)
+
 
 if __name__ == "__main__":
     asyncio.run(simulate())

--- a/frontend/src/__tests__/useBookingChannel.test.ts
+++ b/frontend/src/__tests__/useBookingChannel.test.ts
@@ -16,6 +16,7 @@ describe('useBookingChannel', () => {
   beforeAll(() => {
     vi.stubGlobal('WebSocket', WSStub as unknown as typeof WebSocket);
     vi.stubEnv('VITE_BACKEND_URL', 'http://api');
+    vi.stubGlobal('localStorage', { getItem: () => 'test-token' });
   });
   afterAll(() => {
     vi.unstubAllGlobals();
@@ -25,6 +26,7 @@ describe('useBookingChannel', () => {
   it('updates state on message', () => {
     const { result } = renderHook(() => useBookingChannel('42'));
     const ws = WSStub.instances[0];
+    expect(ws.url).toBe('ws://api/ws/bookings/42/watch?token=test-token');
     act(() => {
       if (ws.onmessage) {
         ws.onmessage({ data: JSON.stringify({ lat: 1, lng: 2, ts: 0 }) });

--- a/frontend/src/hooks/useBookingChannel.ts
+++ b/frontend/src/hooks/useBookingChannel.ts
@@ -13,7 +13,8 @@ export function useBookingChannel(bookingId: string | null) {
 
   useEffect(() => {
     if (!bookingId) return;
-    const wsUrl = `${import.meta.env.VITE_BACKEND_URL.replace('http', 'ws')}/ws/bookings/${bookingId}`;
+    const token = localStorage.getItem('token');
+    const wsUrl = `${import.meta.env.VITE_BACKEND_URL.replace('http', 'ws')}/ws/bookings/${bookingId}/watch?token=${token}`;
     const ws = new WebSocket(wsUrl);
     ws.onmessage = (e) => {
       try {


### PR DESCRIPTION
## Summary
- secure booking websocket endpoint with driver auth and token verification
- add read-only watch websocket for booking owners
- send auth tokens from clients and add websocket channel tests

## Testing
- `npm run lint`
- `cd backend && pytest`
- `cd frontend && npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68b6d7c83060833194547788ca679333