### PR TITLE
fix: use token store for booking channel

### DIFF
--- a/frontend/src/__tests__/useBookingChannel.test.ts
+++ b/frontend/src/__tests__/useBookingChannel.test.ts
@@ -1,6 +1,7 @@
-import { renderHook, act } from '@testing-library/react';
-import { useBookingChannel } from '@/hooks/useBookingChannel';
-import { vi } from 'vitest';
+import { renderHook, act } from "@testing-library/react";
+import { useBookingChannel } from "@/hooks/useBookingChannel";
+import { vi } from "vitest";
+import { setTokens } from "@/services/tokenStore";
 
 class WSStub {
   static instances: WSStub[] = [];
@@ -14,13 +15,14 @@ class WSStub {
 
 describe('useBookingChannel', () => {
   beforeAll(() => {
-    vi.stubGlobal('WebSocket', WSStub as unknown as typeof WebSocket);
-    vi.stubEnv('VITE_BACKEND_URL', 'http://api');
-    vi.stubGlobal('localStorage', { getItem: () => 'test-token' });
+    vi.stubGlobal("WebSocket", WSStub as unknown as typeof WebSocket);
+    vi.stubEnv("VITE_BACKEND_URL", "http://api");
+    setTokens("test-token");
   });
   afterAll(() => {
     vi.unstubAllGlobals();
     vi.unstubAllEnvs();
+    setTokens(null);
   });
 
   it('updates state on message', () => {


### PR DESCRIPTION
## Summary
- use shared token store and token change hook for booking channel
- update booking channel test to seed token via token store

## Testing
- `npm run lint`
- `cd backend && pytest` *(failed: process terminated after partial run)*
- `cd frontend && npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68b6e6c053f08331b75311b68fa240b6