### PR TITLE
chore: add tracking simulator launch config

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -101,6 +101,15 @@
       "console": "integratedTerminal",
       "preLaunchTask": "npm: dev",
       "envFile": "${workspaceFolder}/frontend/.env.e2e"
+    },
+    {
+      "name": "Tracking Simulator",
+      "type": "debugpy",
+      "request": "launch",
+      "program": "${workspaceFolder}/backend/tracking-simulator.py",
+      "cwd": "${workspaceFolder}/backend",
+      "console": "integratedTerminal",
+      "justMyCode": true
     }
   ],
   


### PR DESCRIPTION
## Summary
- add VS Code launch config to run tracking simulator

## Testing
- `npm run lint`
- `cd backend && pytest`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b76e3c4c4083319ba1624760a9d046