### PR TITLE
docs: reduce test log noise

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,10 +24,13 @@ These instructions apply to the entire repository.
 
 Run the following before committing:
 
+To prevent excessive console output from hanging sessions, redirect test
+and lint output to log files and view the tail for context.
+
 ```bash
-npm run lint           # frontend lint
-cd backend && pytest   # backend tests
-cd ../frontend && npm test  # frontend unit tests
+npm run lint 2>&1 | tee /tmp/lint.log | tail -n 200
+cd backend && pytest >/tmp/backend.log 2>&1; tail -n 200 /tmp/backend.log
+cd ../frontend && npm test >/tmp/frontend.log 2>&1; tail -n 200 /tmp/frontend.log
 ```
 
 ## Commit Messages


### PR DESCRIPTION
## Summary
- clarify AGENTS instructions on capturing and tailing logs for lint and tests

## Testing
- `npm run lint >/tmp/lint.log 2>&1; tail -n 20 /tmp/lint.log`
- `cd backend && pytest >/tmp/backend.log 2>&1; tail -n 20 /tmp/backend.log`
- `cd frontend && npm test >/tmp/frontend.log 2>&1; tail -n 20 /tmp/frontend.log`


------
https://chatgpt.com/codex/tasks/task_e_68b77d010bbc8331a9507e0788f170d0