### PR TITLE
feat: show next stop marker on tracking page

### DIFF
--- a/frontend/src/pages/TrackingPage.test.tsx
+++ b/frontend/src/pages/TrackingPage.test.tsx
@@ -43,7 +43,16 @@ describe('TrackingPage', () => {
       DirectionsService: class {
         route() {
           return Promise.resolve({
-            routes: [{ legs: [{ duration: { value: 600 } }] }],
+            routes: [
+              {
+                legs: [
+                  {
+                    duration: { value: 600 },
+                    end_location: { toJSON: () => ({ lat: 3, lng: 4 }) },
+                  },
+                ],
+              },
+            ],
           });
         }
       },
@@ -67,11 +76,13 @@ describe('TrackingPage', () => {
         </Routes>
       </MemoryRouter>
     );
-    const { rerender, findByTestId } = render(wrapper);
+    const { rerender } = render(wrapper);
     currentUpdate = { lat: 1, lng: 2, status: 'leave', ts: 0 };
     rerender(wrapper);
-    const marker = await findByTestId('marker');
-    expect(marker.textContent).toBe('1,2');
+    await waitFor(() => expect(screen.getAllByTestId('marker')).toHaveLength(2));
+    const markers = screen.getAllByTestId('marker');
+    expect(markers[0].textContent).toBe('1,2');
+    expect(markers[1].textContent).toBe('3,4');
     await waitFor(() =>
       expect(
         screen.getByText('En route to pickup').getAttribute('data-active'),

--- a/frontend/src/pages/TrackingPage.tsx
+++ b/frontend/src/pages/TrackingPage.tsx
@@ -14,7 +14,12 @@ type GoogleLike = {
         destination: string;
         travelMode: string;
       }) => Promise<{
-        routes: { legs: { duration: { value: number } }[] }[];
+        routes: {
+          legs: {
+            duration: { value: number };
+            end_location: { toJSON: () => { lat: number; lng: number } };
+          }[];
+        }[];
       }>;
     };
     LatLng: new (lat: number, lng: number) => unknown;
@@ -48,6 +53,9 @@ export default function TrackingPage() {
   const [dropoff, setDropoff] = useState('');
   const [status, setStatus] = useState('');
   const [eta, setEta] = useState<number | null>(null);
+  const [nextStop, setNextStop] = useState<{ lat: number; lng: number } | null>(
+    null,
+  );
   const update = useBookingChannel(bookingId);
 
   useEffect(() => {
@@ -87,10 +95,13 @@ export default function TrackingPage() {
           destination: dest,
           travelMode: g.maps.TravelMode.DRIVING,
         });
-        const sec = res.routes[0].legs[0].duration.value;
+        const leg = res.routes[0].legs[0];
+        const sec = leg.duration.value;
         setEta(Math.round(sec / 60));
+        setNextStop(leg.end_location.toJSON());
       } catch {
         setEta(null);
+        setNextStop(null);
       }
     }
     void calcEta();
@@ -107,6 +118,7 @@ export default function TrackingPage() {
           zoom={14}
         >
           <Marker position={pos} />
+          {nextStop && <Marker position={nextStop} />}
         </GoogleMap>
       ) : (
         <p>Waiting for driver...</p>


### PR DESCRIPTION
## Summary
- add state for next stop lat/lng from Google Directions
- render marker for upcoming waypoint alongside driver marker
- adjust tracking tests to expect both driver and next-stop markers

## Testing
- `npm run lint`
- `cd backend && pytest`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b7817451108331bedc72df8faa58a0