### PR TITLE
fix: handle string options in AddressField

### DIFF
--- a/frontend/src/components/AddressField.tsx
+++ b/frontend/src/components/AddressField.tsx
@@ -44,10 +44,19 @@ export function AddressField(props: {
     <Autocomplete<AddressSuggestion, false, false, true>
       freeSolo
       options={props.suggestions}
-      getOptionLabel={(option) => option.address}
+      getOptionLabel={(option) =>
+        typeof option === "string" ? option : option.address
+      }
       renderOption={(optionProps, option) => (
-        <li {...optionProps} key={option.address}>
-          {option.name ? `${option.name} – ${option.address}` : option.address}
+        <li
+          {...optionProps}
+          key={typeof option === "string" ? option : option.address}
+        >
+          {typeof option === "string"
+            ? option
+            : option.name
+            ? `${option.name} – ${option.address}`
+            : option.address}
         </li>
       )}
       inputValue={props.value}


### PR DESCRIPTION
## Summary
- guard AddressField autocomplete option labels when the option is a string

## Testing
- `npm run lint`
- `cd backend && pytest -q --maxfail=1 --disable-warnings` *(fails: KeyboardInterrupt)*
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b792b2e7c08331a79b21ef8648d639