### PR TITLE
fix: handle null final price

### DIFF
--- a/frontend/src/pages/Driver/DriverDashboard.tsx
+++ b/frontend/src/pages/Driver/DriverDashboard.tsx
@@ -207,7 +207,7 @@ export default function DriverDashboard() {
                   </Button>
                 )}
                 {b.status === 'COMPLETED' &&
-                  b.final_price_cents !== undefined && (
+                  b.final_price_cents != null && (
                     <Typography>
                       ${(b.final_price_cents / 100).toFixed(2)}
                     </Typography>


### PR DESCRIPTION
## Summary
- handle null `final_price_cents` before formatting in driver dashboard

## Testing
- `npm run lint`
- `pytest -q --maxfail=1 --disable-warnings`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b792bdca8c8331925f08bff69a182b