### PR TITLE
fix: import useMemo in tracking page

### DIFF
--- a/frontend/src/pages/TrackingPage.tsx
+++ b/frontend/src/pages/TrackingPage.tsx
@@ -1,5 +1,5 @@
 /// <reference types="google.maps" />
-import { useEffect, useState, useRef } from 'react';
+import { useEffect, useState, useRef, useMemo } from 'react';
 import { useParams } from 'react-router-dom';
 import { GoogleMap, Marker } from '@react-google-maps/api';
 import { CONFIG } from '@/config';


### PR DESCRIPTION
## Summary
- import useMemo from React in TrackingPage

## Testing
- `npm run lint` *(fails: /usr/bin/npm: No such file or directory)*
- `cd backend && pytest -q --maxfail=1 --disable-warnings` *(fails: /usr/bin/pytest: No such file or directory)*
- `cd frontend && npm test` *(fails: /usr/bin/npm: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b799f9777c83318ff182b78e42c5e9