### PR TITLE
fix: unify GoogleMap onLoad handler

### DIFF
--- a/frontend/src/pages/TrackingPage.tsx
+++ b/frontend/src/pages/TrackingPage.tsx
@@ -177,6 +177,7 @@ export default function TrackingPage() {
           zoom={14}
           onLoad={(m) => {
             mapRef.current = m;
+            setMap(m as MapLike);
           }}
           options={{
             disableDefaultUI: true,
@@ -186,7 +187,6 @@ export default function TrackingPage() {
             disableDoubleClickZoom: true,
             gestureHandling: 'none',
           }}
-          onLoad={(m) => setMap(m as MapLike)}
         >
           <Marker position={pos} />
           {nextStop && <Marker position={nextStop} />}


### PR DESCRIPTION
## Summary
- consolidate GoogleMap onLoad handlers in TrackingPage to set map reference and state

## Testing
- `npm run lint`
- `pytest -q --maxfail=1 --disable-warnings`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b799fdeff483319cbab4a4018f068f