### PR TITLE
fix: simplify TrackingPage position handling

### DIFF
--- a/frontend/src/pages/TrackingPage.test.tsx
+++ b/frontend/src/pages/TrackingPage.test.tsx
@@ -11,8 +11,10 @@ type MapProps = {
 };
 
 let mockMap: { fitBounds: ReturnType<typeof vi.fn>; setZoom: ReturnType<typeof vi.fn> };
+let mapProps: MapProps | null = null;
 vi.mock('@react-google-maps/api', () => ({
   GoogleMap: (props: MapProps) => {
+    mapProps = props;
     props.onLoad?.(mockMap);
     return <div data-testid="map">{props.children}</div>;
   },


### PR DESCRIPTION
## Summary
- compute driver position directly without useMemo
- guard map zoom calls and unify map load handling
- update TrackingPage tests for new map load handling

## Testing
- `npm run lint`
- `cd backend && pytest -q --maxfail=1 --disable-warnings`
- `cd frontend && npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68b79a00c84c8331a4c3d71c149f99b4