### PR TITLE
fix: use single map ref on tracking page

### DIFF
--- a/frontend/src/pages/TrackingPage.test.tsx
+++ b/frontend/src/pages/TrackingPage.test.tsx
@@ -11,8 +11,10 @@ type MapProps = {
 };
 
 let mockMap: { fitBounds: ReturnType<typeof vi.fn>; setZoom: ReturnType<typeof vi.fn> };
+let mapProps: MapProps | null = null;
 vi.mock('@react-google-maps/api', () => ({
   GoogleMap: (props: MapProps) => {
+    mapProps = props;
     props.onLoad?.(mockMap);
     return <div data-testid="map">{props.children}</div>;
   },
@@ -91,14 +93,9 @@ describe('TrackingPage', () => {
         </Routes>
       </MemoryRouter>
     );
-    const fitBounds = vi.fn();
-    const fakeMap = { fitBounds, getZoom: vi.fn(() => 17), setZoom: vi.fn() };
-
     const { rerender } = render(wrapper);
     currentUpdate = { lat: 1, lng: 2, status: 'leave', ts: 0 };
     rerender(wrapper);
-    await waitFor(() => expect(mapProps).not.toBeNull());
-    mapProps?.onLoad?.(fakeMap);
     await waitFor(() => expect(screen.getAllByTestId('marker')).toHaveLength(2));
     const markers = screen.getAllByTestId('marker');
     expect(markers[0].textContent).toBe('1,2');
@@ -110,7 +107,7 @@ describe('TrackingPage', () => {
     );
 
     await screen.findByText('ETA: 10 min');
-    await waitFor(() => expect(fitBounds).toHaveBeenCalled());
+    await waitFor(() => expect(mockMap.fitBounds).toHaveBeenCalled());
   });
 
   it('sets zoom to 12 when distance is greater than 5 km', async () => {

--- a/frontend/src/pages/TrackingPage.tsx
+++ b/frontend/src/pages/TrackingPage.tsx
@@ -1,5 +1,5 @@
 /// <reference types="google.maps" />
-import { useEffect, useState, useRef } from 'react';
+import { useEffect, useState, useRef, useMemo } from 'react';
 import { useParams } from 'react-router-dom';
 import { GoogleMap, Marker } from '@react-google-maps/api';
 import { CONFIG } from '@/config';
@@ -31,12 +31,6 @@ type GoogleLike = {
   };
 };
 
-type MapLike = {
-  fitBounds: (bounds: unknown) => void;
-  getZoom: () => number;
-  setZoom: (zoom: number) => void;
-};
-
 interface TrackResponse {
   booking: {
     id: string;
@@ -66,7 +60,6 @@ export default function TrackingPage() {
   const [nextStop, setNextStop] = useState<{ lat: number; lng: number } | null>(
     null,
   );
-  const [map, setMap] = useState<MapLike | null>(null);
   const update = useBookingChannel(bookingId);
   const mapRef = useRef<google.maps.Map | null>(null);
 
@@ -125,17 +118,6 @@ export default function TrackingPage() {
   );
 
   useEffect(() => {
-    if (!map || !pos || !nextStop) return;
-    const g = (window as { google?: GoogleLike }).google;
-    if (!g?.maps) return;
-    const bounds = new g.maps.LatLngBounds();
-    bounds.extend(pos);
-    bounds.extend(nextStop);
-    map.fitBounds(bounds);
-    if (map.getZoom() > 16) map.setZoom(16);
-  }, [map, pos, nextStop]);
-
-  useEffect(() => {
     if (!mapRef.current || !pos || !nextStop) return;
     const g = (window as { google?: typeof google }).google;
     if (!g?.maps) return;
@@ -186,7 +168,6 @@ export default function TrackingPage() {
             disableDoubleClickZoom: true,
             gestureHandling: 'none',
           }}
-          onLoad={(m) => setMap(m as MapLike)}
         >
           <Marker position={pos} />
           {nextStop && <Marker position={nextStop} />}


### PR DESCRIPTION
## Summary
- rely on a single `mapRef` for Google Map instance
- streamline map effect logic and remove unused state
- adjust tracking page tests for new map handling

## Testing
- `npm run lint`
- `cd backend && pytest -q --maxfail=1 --disable-warnings`
- `cd frontend && npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68b799ffcc54833186f489fb3875f768