### PR TITLE
refactor: extract distance calculation utility

### DIFF
--- a/frontend/src/lib/calculateDistance.test.ts
+++ b/frontend/src/lib/calculateDistance.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test, vi } from 'vitest';
+import { calculateDistance } from './calculateDistance';
+
+describe('calculateDistance', () => {
+  test('falls back to haversine when google compute is unavailable', () => {
+    const dist = calculateDistance({ lat: 0, lng: 0 }, { lat: 0, lng: 1 });
+    expect(Math.round(dist)).toBe(111195);
+  });
+
+  test('uses google.maps geometry computeDistanceBetween when provided', () => {
+    const computeDistanceBetween = vi.fn(() => 42);
+    const g = {
+      maps: {
+        LatLng: class {
+          constructor(public lat: number, public lng: number) {}
+        },
+        geometry: { spherical: { computeDistanceBetween } },
+      },
+    } as unknown as typeof google;
+
+    const dist = calculateDistance({ lat: 0, lng: 0 }, { lat: 0, lng: 1 }, g);
+    expect(dist).toBe(42);
+    expect(computeDistanceBetween).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/lib/calculateDistance.ts
+++ b/frontend/src/lib/calculateDistance.ts
@@ -1,0 +1,28 @@
+export interface LatLng {
+  lat: number;
+  lng: number;
+}
+
+export function calculateDistance(
+  pos: LatLng,
+  nextStop: LatLng,
+  g?: typeof google,
+): number {
+  const compute = g?.maps?.geometry?.spherical?.computeDistanceBetween;
+  if (compute) {
+    return compute(
+      new g.maps.LatLng(pos.lat, pos.lng),
+      new g.maps.LatLng(nextStop.lat, nextStop.lng),
+    );
+  }
+  const R = 6371e3;
+  const phi1 = (pos.lat * Math.PI) / 180;
+  const phi2 = (nextStop.lat * Math.PI) / 180;
+  const dphi = ((nextStop.lat - pos.lat) * Math.PI) / 180;
+  const dlambda = ((nextStop.lng - pos.lng) * Math.PI) / 180;
+  const a =
+    Math.sin(dphi / 2) ** 2 +
+    Math.cos(phi1) * Math.cos(phi2) * Math.sin(dlambda / 2) ** 2;
+  const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+  return R * c;
+}


### PR DESCRIPTION
## Summary
- factor distance computation into `calculateDistance` utility with optional Google Maps support and Haversine fallback
- simplify `TrackingPage` by using `calculateDistance` and combining map load handling
- add unit tests for `calculateDistance`

## Testing
- `npm run lint`
- `cd backend && pytest -q --maxfail=1 --disable-warnings`
- `cd frontend && npm test -- --run src/lib/calculateDistance.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b79a0303f8833194268635e24ab219