### PR TITLE
fix: recognize URLSearchParams entries

### DIFF
--- a/frontend/src/pages/TrackingPage.test.tsx
+++ b/frontend/src/pages/TrackingPage.test.tsx
@@ -11,13 +11,11 @@ type MapProps = {
 };
 
 let mockMap: { fitBounds: ReturnType<typeof vi.fn>; setZoom: ReturnType<typeof vi.fn> };
-let mapProps: MapProps | null = null;
 vi.mock('@react-google-maps/api', () => ({
-  GoogleMap: (props: MapProps) => {
-    mapProps = props;
-    props.onLoad?.(mockMap);
-    return <div data-testid="map">{props.children}</div>;
-  },
+    GoogleMap: (props: MapProps) => {
+      props.onLoad?.(mockMap);
+      return <div data-testid="map">{props.children}</div>;
+    },
   Marker: ({ position }: { position: { lat: number; lng: number } }) => (
     <div data-testid="marker">{position.lat},{position.lng}</div>
   ),

--- a/frontend/tsconfig.base.json
+++ b/frontend/tsconfig.base.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "ES2022",
     "module": "ESNext",
-    "lib": ["ESNext", "DOM"],
+    "lib": ["ESNext", "DOM", "DOM.Iterable"],
     "moduleResolution": "Bundler",
     "jsx": "react-jsx",
     "strict": true,


### PR DESCRIPTION
## Summary
- include DOM.Iterable in frontend TypeScript lib to type URLSearchParams.entries
- clean up unused mapProps in TrackingPage test

## Testing
- `npm run lint`
- `pytest tests/unit -q --maxfail=1 --disable-warnings` *(fails: test_unauthorized_connections_rejected)*
- `npm test` *(fails: TrackingPage tests: map is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68b7a12519b483318f70f0b35ea6436d