### PR TITLE
feat(frontend): render directions on tracking map

### DIFF
--- a/frontend/src/pages/TrackingPage.test.tsx
+++ b/frontend/src/pages/TrackingPage.test.tsx
@@ -105,6 +105,7 @@ describe('TrackingPage', () => {
     );
 
     await screen.findByText('ETA: 10 min');
+    await screen.findByTestId('route');
     await waitFor(() => expect(mockMap.fitBounds).toHaveBeenCalled());
   });
 

--- a/frontend/src/pages/TrackingPage.tsx
+++ b/frontend/src/pages/TrackingPage.tsx
@@ -1,7 +1,7 @@
 /// <reference types="google.maps" />
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useParams } from 'react-router-dom';
-import { GoogleMap, Marker } from '@react-google-maps/api';
+import { GoogleMap, Marker, DirectionsRenderer } from '@react-google-maps/api';
 import { CONFIG } from '@/config';
 import { apiFetch } from '@/services/apiFetch';
 import { useBookingChannel } from '@/hooks/useBookingChannel';
@@ -61,6 +61,7 @@ export default function TrackingPage() {
   const [nextStop, setNextStop] = useState<{ lat: number; lng: number } | null>(
     null,
   );
+  const [route, setRoute] = useState<google.maps.DirectionsResult | null>(null);
   const update = useBookingChannel(bookingId);
   const mapRef = useRef<google.maps.Map | null>(null);
 
@@ -101,6 +102,7 @@ export default function TrackingPage() {
           destination: dest,
           travelMode: g.maps.TravelMode.DRIVING,
         });
+        setRoute(res as unknown as google.maps.DirectionsResult);
         const leg = res.routes[0].legs[0];
         const sec = leg.duration.value;
         setEta(Math.round(sec / 60));
@@ -108,6 +110,7 @@ export default function TrackingPage() {
       } catch {
         setEta(null);
         setNextStop(null);
+        setRoute(null);
       }
     }
     void calcEta();
@@ -154,6 +157,15 @@ export default function TrackingPage() {
         >
           <Marker position={pos} />
           {nextStop && <Marker position={nextStop} />}
+          {route && (
+            <DirectionsRenderer
+              directions={route}
+              options={{
+                suppressMarkers: true,
+                polylineOptions: { strokeColor: '#4285F4' },
+              }}
+            />
+          )}
         </GoogleMap>
       ) : (
         <p>Waiting for driver...</p>


### PR DESCRIPTION
## Summary
- maintain route state and render DirectionsRenderer on TrackingPage
- expand TrackingPage test to verify route rendering

## Testing
- `npm run lint`
- `cd backend && pytest -q --maxfail=1 --disable-warnings` *(fails: HTTPException status_code 402)*
- `cd ../frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b7fc77c7a4833189a6157db5791f55