### PR TITLE
feat: show car icon for driver location

### DIFF
--- a/frontend/src/assets/car-marker.svg
+++ b/frontend/src/assets/car-marker.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <rect x="3" y="10" width="18" height="7" fill="#333"/>
+  <circle cx="7" cy="18" r="2" fill="#333"/>
+  <circle cx="17" cy="18" r="2" fill="#333"/>
+  <rect x="6" y="6" width="12" height="5" fill="#555"/>
+</svg>

--- a/frontend/src/pages/TrackingPage.test.tsx
+++ b/frontend/src/pages/TrackingPage.test.tsx
@@ -3,6 +3,7 @@ import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { vi } from 'vitest';
 import type { LocationUpdate } from '@/hooks/useBookingChannel';
 import TrackingPage from './TrackingPage';
+import carIcon from '@/assets/car-marker.svg';
 
 type MapProps = {
   children: React.ReactNode;
@@ -18,11 +19,17 @@ vi.mock('@react-google-maps/api', () => ({
     },
   Marker: ({
     position,
+    icon,
     'data-testid': testId,
   }: {
     position: { lat: number; lng: number };
+    icon?: string;
     'data-testid'?: string;
-  }) => <div data-testid={testId ?? 'marker'}>{position.lat},{position.lng}</div>,
+  }) => (
+    <div data-testid={testId ?? 'marker'} data-icon={icon}>
+      {position.lat},{position.lng}
+    </div>
+  ),
   DirectionsRenderer: () => <div data-testid="route">route</div>,
 }));
 
@@ -102,6 +109,7 @@ describe('TrackingPage', () => {
       expect(screen.getByTestId('pickup-marker')).toBeInTheDocument(),
     );
     expect(screen.getByTestId('marker').textContent).toBe('1,2');
+    expect(screen.getByTestId('marker')).toHaveAttribute('data-icon', carIcon);
     expect(screen.getByTestId('pickup-marker').textContent).toBe('3,4');
     expect(screen.queryByTestId('dropoff-marker')).toBeNull();
     await waitFor(() =>
@@ -171,9 +179,13 @@ describe('TrackingPage', () => {
       </MemoryRouter>,
     );
     await new Promise((r) => setTimeout(r, 0));
-    await waitFor(() => expect(screen.getAllByTestId('marker')).toHaveLength(2));
-    const markers = screen.getAllByTestId('marker');
-    expect(markers[1]).toHaveAttribute('data-icon', '/assets/dropoff-marker-red.svg');
+    await waitFor(() =>
+      expect(screen.getByTestId('dropoff-marker')).toBeInTheDocument(),
+    );
+    expect(screen.getByTestId('dropoff-marker')).toHaveAttribute(
+      'data-icon',
+      '/assets/dropoff-marker-red.svg',
+    );
   });
 
   it('sets zoom to 12 when distance is greater than 5 km', async () => {

--- a/frontend/src/pages/TrackingPage.tsx
+++ b/frontend/src/pages/TrackingPage.tsx
@@ -7,6 +7,7 @@ import { apiFetch } from '@/services/apiFetch';
 import { useBookingChannel } from '@/hooks/useBookingChannel';
 import StatusTimeline, { type StatusStep } from '@/components/StatusTimeline';
 import { calculateDistance } from '@/lib/calculateDistance';
+import carIcon from '@/assets/car-marker.svg';
 
 const pickupIcon = '/assets/pickup-marker-green.svg';
 const dropoffIcon = '/assets/dropoff-marker-red.svg';
@@ -76,11 +77,6 @@ export default function TrackingPage() {
     [status],
   );
 
-  const pickupIcon =
-    'http://maps.google.com/mapfiles/ms/icons/green-dot.png';
-  const dropoffIcon =
-    'http://maps.google.com/mapfiles/ms/icons/blue-dot.png';
-
   useEffect(() => {
     (async () => {
       const res = await apiFetch(
@@ -147,12 +143,6 @@ export default function TrackingPage() {
     mapRef.current.setZoom(zoom);
   }, [pos, nextStop, isDropoff]);
 
-  const nextStopIcon = ['arrive-pickup', 'start-trip', 'arrive-dropoff', 'complete'].includes(
-    status,
-  )
-    ? dropoffIcon
-    : pickupIcon;
-
   return (
     <div>
       {pos ? (
@@ -172,7 +162,7 @@ export default function TrackingPage() {
             gestureHandling: 'none',
           }}
         >
-          <Marker position={pos} />
+          <Marker position={pos} icon={carIcon} />
           {nextStop &&
             (isDropoff ? (
               <Marker
@@ -187,6 +177,7 @@ export default function TrackingPage() {
                 data-testid="pickup-marker"
               />
             ))}
+          {route && <DirectionsRenderer directions={route} />}
         </GoogleMap>
       ) : (
         <p>Waiting for driver...</p>


### PR DESCRIPTION
## Summary
- display a car icon for the driver marker on the tracking map
- include car icon asset and render route directions
- adjust tracking page tests to handle marker icons

## Testing
- `npm run lint`
- Tests were intentionally skipped as per request

------
https://chatgpt.com/codex/tasks/task_e_68b7fc4fde2c8331b4eee999369fcf16