### PR TITLE
fix: use asset-based marker icons on tracking page

### DIFF
--- a/frontend/src/pages/TrackingPage.test.tsx
+++ b/frontend/src/pages/TrackingPage.test.tsx
@@ -18,11 +18,17 @@ vi.mock('@react-google-maps/api', () => ({
     },
   Marker: ({
     position,
+    icon,
     'data-testid': testId,
   }: {
     position: { lat: number; lng: number };
+    icon?: string;
     'data-testid'?: string;
-  }) => <div data-testid={testId ?? 'marker'}>{position.lat},{position.lng}</div>,
+  }) => (
+    <div data-testid={testId ?? 'marker'} data-icon={icon}>
+      {position.lat},{position.lng}
+    </div>
+  ),
   DirectionsRenderer: () => <div data-testid="route">route</div>,
 }));
 
@@ -171,9 +177,8 @@ describe('TrackingPage', () => {
       </MemoryRouter>,
     );
     await new Promise((r) => setTimeout(r, 0));
-    await waitFor(() => expect(screen.getAllByTestId('marker')).toHaveLength(2));
-    const markers = screen.getAllByTestId('marker');
-    expect(markers[1]).toHaveAttribute('data-icon', '/assets/dropoff-marker-red.svg');
+    const marker = await screen.findByTestId('dropoff-marker');
+    expect(marker).toHaveAttribute('data-icon', '/assets/dropoff-marker-red.svg');
   });
 
   it('sets zoom to 12 when distance is greater than 5 km', async () => {

--- a/frontend/src/pages/TrackingPage.tsx
+++ b/frontend/src/pages/TrackingPage.tsx
@@ -76,11 +76,6 @@ export default function TrackingPage() {
     [status],
   );
 
-  const pickupIcon =
-    'http://maps.google.com/mapfiles/ms/icons/green-dot.png';
-  const dropoffIcon =
-    'http://maps.google.com/mapfiles/ms/icons/blue-dot.png';
-
   useEffect(() => {
     (async () => {
       const res = await apiFetch(
@@ -147,11 +142,8 @@ export default function TrackingPage() {
     mapRef.current.setZoom(zoom);
   }, [pos, nextStop, isDropoff]);
 
-  const nextStopIcon = ['arrive-pickup', 'start-trip', 'arrive-dropoff', 'complete'].includes(
-    status,
-  )
-    ? dropoffIcon
-    : pickupIcon;
+  const nextStopIcon = isDropoff ? dropoffIcon : pickupIcon;
+  const nextStopTestId = isDropoff ? 'dropoff-marker' : 'pickup-marker';
 
   return (
     <div>
@@ -173,20 +165,14 @@ export default function TrackingPage() {
           }}
         >
           <Marker position={pos} />
-          {nextStop &&
-            (isDropoff ? (
-              <Marker
-                position={nextStop}
-                icon={dropoffIcon}
-                data-testid="dropoff-marker"
-              />
-            ) : (
-              <Marker
-                position={nextStop}
-                icon={pickupIcon}
-                data-testid="pickup-marker"
-              />
-            ))}
+          {route && <DirectionsRenderer directions={route} />}
+          {nextStop && (
+            <Marker
+              position={nextStop}
+              icon={nextStopIcon}
+              data-testid={nextStopTestId}
+            />
+          )}
         </GoogleMap>
       ) : (
         <p>Waiting for driver...</p>


### PR DESCRIPTION
## Summary
- remove hardcoded Google marker URLs in TrackingPage and rely on asset-based icons
- render directions on map and simplify marker handling
- adjust tracking page tests to assert asset icon usage

## Testing
- `npm run lint`
- `cd backend && pytest -q --maxfail=1 --disable-warnings` (fails: tests/unit/core/test_security.py::test_decode_token_invalid)
- `cd frontend && npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68b80c0cb9c08331888d7208e34a71ae