### PR TITLE
fix: handle nested push message data in service worker

### DIFF
--- a/frontend/public/firebase-messaging-sw.js
+++ b/frontend/public/firebase-messaging-sw.js
@@ -1,5 +1,6 @@
 self.addEventListener('push', event => {
-  const data = event.data ? event.data.json() : {};
+  const payload = event.data?.json() ?? {};
+  const msg = payload.data || payload;
   const notificationMap = {
     NEW_BOOKING: {
       title: 'New booking',
@@ -35,8 +36,8 @@ self.addEventListener('push', event => {
     },
   };
 
-  const lookup = data.type ? notificationMap[data.type] : undefined;
-  const title = data.title || (lookup && lookup.title) || 'Notification';
-  const options = { body: data.body || (lookup && lookup.body) };
+  const lookup = msg.type ? notificationMap[msg.type] : undefined;
+  const title = msg.title || (lookup && lookup.title) || 'Notification';
+  const options = { body: msg.body || (lookup && lookup.body) };
   event.waitUntil(self.registration.showNotification(title, options));
 });


### PR DESCRIPTION
## Summary
- parse raw push payload and fall back to nested data object
- use parsed message in notification map lookup

## Testing
- `npm run lint`
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b80f40dfb4833180fb08fdf1841515