### PR TITLE
refactor: import marker icons as modules

### DIFF
--- a/frontend/src/pages/TrackingPage.test.tsx
+++ b/frontend/src/pages/TrackingPage.test.tsx
@@ -4,6 +4,7 @@ import { vi } from 'vitest';
 import type { LocationUpdate } from '@/hooks/useBookingChannel';
 import TrackingPage from './TrackingPage';
 import carIcon from '@/assets/car-marker.svg';
+import dropoffIcon from '@/assets/dropoff-marker-red.svg';
 
 type MapProps = {
   children: React.ReactNode;
@@ -191,7 +192,7 @@ describe('TrackingPage', () => {
     );
     expect(screen.getByTestId('dropoff-marker')).toHaveAttribute(
       'data-icon',
-      '/assets/dropoff-marker-red.svg',
+      dropoffIcon,
     );
   });
 

--- a/frontend/src/pages/TrackingPage.tsx
+++ b/frontend/src/pages/TrackingPage.tsx
@@ -9,10 +9,8 @@ import StatusTimeline, { type StatusStep } from '@/components/StatusTimeline';
 import { calculateDistance } from '@/lib/calculateDistance';
 import type { BookingStatus } from '@/types/BookingStatus';
 import carIcon from '@/assets/car-marker.svg';
-
-
-const pickupIcon = '/assets/pickup-marker-green.svg';
-const dropoffIcon = '/assets/dropoff-marker-red.svg';
+import pickupIcon from '@/assets/pickup-marker-green.svg';
+import dropoffIcon from '@/assets/dropoff-marker-red.svg';
 
 type GoogleLike = {
   maps: {
@@ -158,12 +156,6 @@ export default function TrackingPage() {
     };
     mapRef.current.setCenter(mid);
   }, [pos, nextStop, isDropoff]);
-  const nextStopIcon = ['ARRIVED_PICKUP', 'IN_PROGRESS', 'ARRIVED_DROPOFF', 'COMPLETED'].includes(
-    status as BookingStatus,
-  )
-    ? dropoffIcon
-    : pickupIcon;
-  const nextStopTestId = isDropoff ? 'dropoff-marker' : 'pickup-marker';
 
   return (
     <div>
@@ -184,24 +176,19 @@ export default function TrackingPage() {
             gestureHandling: 'none',
           }}
         >
-          <Marker position={pos} />
-          {nextStop &&
-            (isDropoff ? (
-              <>
-                <Marker
-                  position={nextStop}
-                  icon={dropoffIcon}
-                  data-testid="dropoff-marker"
-                />
-                <div data-testid="marker" data-icon={dropoffIcon} />
-              </>
-            ) : (
+          <Marker position={pos} icon={carIcon} />
+          {nextStop && (
+            <>
               <Marker
                 position={nextStop}
-                icon={pickupIcon}
-                data-testid="pickup-marker"
+                icon={isDropoff ? dropoffIcon : pickupIcon}
+                data-testid={isDropoff ? 'dropoff-marker' : 'pickup-marker'}
               />
-            ))}
+              {isDropoff && (
+                <div data-testid="marker" data-icon={dropoffIcon} />
+              )}
+            </>
+          )}
           {route && (
             <DirectionsRenderer
               directions={route}


### PR DESCRIPTION
## Summary
- import pickup and dropoff marker icons as ES modules
- render pickup and dropoff markers using the imported icons directly
- adjust tests to reference the imported dropoff icon

## Testing
- `npm run lint`
- `pytest -q --maxfail=1 --disable-warnings` (fails: test_confirm_booking_handles_stripe_error)
- `CI=1 npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b815ddc24483319fb36e0b6ff776ce