### PR TITLE
fix: recalc route on status update

### DIFF
--- a/frontend/src/pages/TrackingPage.tsx
+++ b/frontend/src/pages/TrackingPage.tsx
@@ -96,7 +96,7 @@ export default function TrackingPage() {
 
   useEffect(() => {
     if (update?.status) setStatus(update.status as BookingStatus);
-  }, [update?.status]);
+  }, [update]);
 
   useEffect(() => {
     async function calcEta() {
@@ -104,7 +104,13 @@ export default function TrackingPage() {
       const g = (window as { google?: GoogleLike }).google;
       if (!g?.maps) return;
       const svc = new g.maps.DirectionsService();
-      const dest = isDropoff ? dropoff : pickup;
+      const goingToDropoff = [
+        'ARRIVED_PICKUP',
+        'IN_PROGRESS',
+        'ARRIVED_DROPOFF',
+        'COMPLETED',
+      ].includes(update.status as BookingStatus);
+      const dest = goingToDropoff ? dropoff : pickup;
       try {
         const res = await svc.route({
           origin: new g.maps.LatLng(update.lat, update.lng),
@@ -123,7 +129,7 @@ export default function TrackingPage() {
       }
     }
     void calcEta();
-  }, [update, pickup, dropoff, isDropoff]);
+  }, [update, update?.status, pickup, dropoff]);
 
   const pos = useMemo(
     () => (update ? { lat: update.lat, lng: update.lng } : null),
@@ -157,12 +163,8 @@ export default function TrackingPage() {
       lng: (pos.lng + nextStop.lng) / 2,
     };
     mapRef.current.setCenter(mid);
-  }, [pos, nextStop, isDropoff]);
-  const nextStopIcon = ['ARRIVED_PICKUP', 'IN_PROGRESS', 'ARRIVED_DROPOFF', 'COMPLETED'].includes(
-    status as BookingStatus,
-  )
-    ? dropoffIcon
-    : pickupIcon;
+  }, [pos, nextStop]);
+  const nextStopIcon = isDropoff ? dropoffIcon : pickupIcon;
   const nextStopTestId = isDropoff ? 'dropoff-marker' : 'pickup-marker';
 
   return (
@@ -184,24 +186,14 @@ export default function TrackingPage() {
             gestureHandling: 'none',
           }}
         >
-          <Marker position={pos} />
-          {nextStop &&
-            (isDropoff ? (
-              <>
-                <Marker
-                  position={nextStop}
-                  icon={dropoffIcon}
-                  data-testid="dropoff-marker"
-                />
-                <div data-testid="marker" data-icon={dropoffIcon} />
-              </>
-            ) : (
-              <Marker
-                position={nextStop}
-                icon={pickupIcon}
-                data-testid="pickup-marker"
-              />
-            ))}
+          <Marker position={pos} icon={carIcon} />
+          {nextStop && (
+            <Marker
+              position={nextStop}
+              icon={nextStopIcon}
+              data-testid={nextStopTestId}
+            />
+          )}
           {route && (
             <DirectionsRenderer
               directions={route}


### PR DESCRIPTION
## Summary
- derive destination from websocket status rather than local state
- simplify next stop marker rendering and keep isDropoff for UI only
- track status in ETA effect dependencies

## Testing
- `npm run lint`
- `cd backend && pytest -q --maxfail=1 --disable-warnings` (fails: test_confirm_booking_handles_stripe_error)
- `cd ../frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b816220c0c8331a7e6f86ffaa79a24