### PR TITLE
feat: refine tracking car marker

### DIFF
--- a/frontend/src/assets/car-marker.svg
+++ b/frontend/src/assets/car-marker.svg
@@ -1,6 +1,6 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-  <rect x="3" y="10" width="18" height="7" fill="#333"/>
-  <circle cx="7" cy="18" r="2" fill="#333"/>
-  <circle cx="17" cy="18" r="2" fill="#333"/>
-  <rect x="6" y="6" width="12" height="5" fill="#555"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none" stroke="#333" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <rect x="4" y="15" width="24" height="6" rx="2" ry="2"/>
+  <path d="M7 15l2-6h14l2 6"/>
+  <circle cx="10" cy="23" r="2"/>
+  <circle cx="22" cy="23" r="2"/>
 </svg>

--- a/frontend/src/pages/TrackingPage.tsx
+++ b/frontend/src/pages/TrackingPage.tsx
@@ -164,6 +164,13 @@ export default function TrackingPage() {
   }, [pos, nextStop]);
   const nextStopIcon = isDropoff ? dropoffIcon : pickupIcon;
   const nextStopTestId = isDropoff ? 'dropoff-marker' : 'pickup-marker';
+  const carMarkerIcon = useMemo(() => {
+    const g = (window as { google?: typeof google }).google;
+    if (g?.maps && typeof g.maps.Size === 'function') {
+      return { url: carIcon, scaledSize: new g.maps.Size(20, 20) };
+    }
+    return carIcon;
+  }, []);
 
   return (
     <div>
@@ -184,7 +191,7 @@ export default function TrackingPage() {
             gestureHandling: 'none',
           }}
         >
-          <Marker position={pos} icon={carIcon} />
+          <Marker position={pos} icon={carMarkerIcon} />
           {nextStop && (
             <Marker
               position={nextStop}


### PR DESCRIPTION
## Summary
- redesign car marker icon to mirror favicon styling
- scale map car marker for a subtler tracking display

## Testing
- `npm run lint`
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68b81abe828c8331ace72ffdf4671476