### PR TITLE
fix: correct tracking destination and markers

### DIFF
--- a/frontend/src/pages/TrackingPage.tsx
+++ b/frontend/src/pages/TrackingPage.tsx
@@ -102,12 +102,13 @@ export default function TrackingPage() {
       const g = (window as { google?: GoogleLike }).google;
       if (!g?.maps) return;
       const svc = new g.maps.DirectionsService();
+      const effectiveStatus = (update.status ?? status) as BookingStatus;
       const goingToDropoff = [
         'ARRIVED_PICKUP',
         'IN_PROGRESS',
         'ARRIVED_DROPOFF',
         'COMPLETED',
-      ].includes(update.status as BookingStatus);
+      ].includes(effectiveStatus);
       const dest = goingToDropoff ? dropoff : pickup;
       try {
         const res = await svc.route({
@@ -127,7 +128,7 @@ export default function TrackingPage() {
       }
     }
     void calcEta();
-  }, [update, update?.status, pickup, dropoff]);
+  }, [update, update?.status, status, pickup, dropoff]);
 
   const pos = useMemo(
     () => (update ? { lat: update.lat, lng: update.lng } : null),
@@ -162,9 +163,6 @@ export default function TrackingPage() {
     };
     mapRef.current.setCenter(mid);
   }, [pos, nextStop]);
-  const nextStopIcon = isDropoff ? dropoffIcon : pickupIcon;
-  const nextStopTestId = isDropoff ? 'dropoff-marker' : 'pickup-marker';
-
   return (
     <div>
       {pos ? (
@@ -188,8 +186,8 @@ export default function TrackingPage() {
           {nextStop && (
             <Marker
               position={nextStop}
-              icon={nextStopIcon}
-              data-testid={nextStopTestId}
+              icon={isDropoff ? dropoffIcon : pickupIcon}
+              data-testid={isDropoff ? 'dropoff-marker' : 'pickup-marker'}
             />
           )}
           {route && (


### PR DESCRIPTION
## Summary
- fallback to last known status when computing directions
- inline next-stop marker properties and import SVG assets

## Testing
- `npm run lint`
- `pytest -q --maxfail=1 --disable-warnings` (fails: AssertionError in `test_confirm_booking_handles_stripe_error`)
- `npx vitest run src/pages/TrackingPage.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b814aa1e7483318160241969d8662f