### PR TITLE
fix: use car icon for tracking marker

### DIFF
--- a/frontend/src/pages/TrackingPage.tsx
+++ b/frontend/src/pages/TrackingPage.tsx
@@ -182,7 +182,7 @@ export default function TrackingPage() {
             gestureHandling: 'none',
           }}
         >
-          <Marker position={pos} icon={carMarkerIcon} />
+          <Marker position={pos} icon={carIcon} />
           {nextStop && (
             <Marker
               position={nextStop}


### PR DESCRIPTION
## Summary
- use `carIcon` in TrackingPage vehicle marker

## Testing
- `npm run lint`
- `cd frontend && npm test src/pages/TrackingPage.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b824b4637c8331817c44c28dc8bcd3