### PR TITLE
fix: update tracking to switch to dropoff after pickup

### DIFF
--- a/frontend/src/pages/TrackingPage.test.tsx
+++ b/frontend/src/pages/TrackingPage.test.tsx
@@ -148,6 +148,7 @@ describe('TrackingPage', () => {
           }) as unknown as Response,
         ),
       );
+    endLocation = { lat: 5, lng: 6 };
     currentUpdate = { lat: 1, lng: 2, status: 'ARRIVED_PICKUP', ts: 0 };
     const wrapper2 = (
       <MemoryRouter initialEntries={['/t/abc']}>
@@ -160,6 +161,8 @@ describe('TrackingPage', () => {
     await waitFor(() =>
       expect(screen.getByTestId('dropoff-marker')).toBeInTheDocument(),
     );
+    expect(screen.getByTestId('dropoff-marker').textContent).toBe('5,6');
+    await screen.findByTestId('route');
     expect(screen.queryByTestId('pickup-marker')).toBeNull();
   });
 

--- a/frontend/src/pages/TrackingPage.tsx
+++ b/frontend/src/pages/TrackingPage.tsx
@@ -72,9 +72,9 @@ export default function TrackingPage() {
   const isDropoff = useMemo(
     () =>
       ['ARRIVED_PICKUP', 'IN_PROGRESS', 'ARRIVED_DROPOFF', 'COMPLETED'].includes(
-        status as BookingStatus,
+        (update?.status ?? status) as BookingStatus,
       ),
-    [status],
+    [update?.status, status],
   );
 
   useEffect(() => {
@@ -102,7 +102,7 @@ export default function TrackingPage() {
       const g = (window as { google?: GoogleLike }).google;
       if (!g?.maps) return;
       const svc = new g.maps.DirectionsService();
-      const effectiveStatus = (update.status ?? status) as BookingStatus;
+      const effectiveStatus = (update?.status ?? status) as BookingStatus;
       const goingToDropoff = [
         'ARRIVED_PICKUP',
         'IN_PROGRESS',


### PR DESCRIPTION
## Summary
- react to websocket status for determining dropoff vs pickup
- recalc route destination using live status updates
- test that arriving at pickup removes pickup marker and routes to dropoff

## Testing
- `npm run lint`
- `cd frontend && npm test src/pages/TrackingPage.test.tsx`
- `cd backend && pytest -q --maxfail=1 --disable-warnings` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b825f921e08331b4749cdeb37cb98f