### PR TITLE
feat: enrich Stripe payments with booking metadata

### DIFF
--- a/backend/app/services/stripe_client.py
+++ b/backend/app/services/stripe_client.py
@@ -1,5 +1,8 @@
 """Stripe API convenience helpers."""
 
+import uuid
+from datetime import datetime
+
 from app.core.config import get_settings
 
 try:  # pragma: no cover - runtime import
@@ -33,26 +36,33 @@ else:
     stripe.api_key = settings.stripe_secret_key or ""
 
 
-def create_setup_intent(customer_email: str):
+def create_setup_intent(
+    customer_email: str, customer_name: str, booking_reference: str
+):
     """Create a Stripe SetupIntent for the provided customer email."""
     return stripe.SetupIntent.create(
         payment_method_types=["card"],
         usage="off_session",
-        metadata={"customer_email": customer_email},
+        metadata={
+            "customer_email": customer_email,
+            "customer_name": customer_name,
+            "booking_reference": booking_reference,
+        },
     )
 
 
-def charge_deposit(amount_cents: int, payment_method: str = "pm_card_visa"):
-    """Charge a deposit using a stored payment method.
-
-    Parameters
-    ----------
-    amount_cents: int
-        The amount to charge in cents.
-    payment_method: str
-        The Stripe payment method identifier to use. Defaults to Stripe's test
-        card so unit tests can run without real card details.
-    """
+def charge_deposit(
+    amount_cents: int,
+    booking_id: uuid.UUID,
+    *,
+    public_code: str | None = None,
+    customer_email: str | None = None,
+    pickup_address: str | None = None,
+    dropoff_address: str | None = None,
+    pickup_time: datetime | None = None,
+    payment_method: str = "pm_card_visa",
+):
+    """Charge a deposit using a stored payment method."""
 
     params = {
         "amount": amount_cents,
@@ -65,13 +75,39 @@ def charge_deposit(amount_cents: int, payment_method: str = "pm_card_visa"):
         },
     }
 
+    metadata = {
+        "booking_id": str(booking_id),
+        "payment_type": "deposit",
+    }
+    if public_code:
+        metadata["public_code"] = public_code
+    if customer_email:
+        metadata["customer_email"] = customer_email
+    if pickup_address:
+        metadata["pickup_address"] = pickup_address
+    if dropoff_address:
+        metadata["dropoff_address"] = dropoff_address
+    if pickup_time:
+        metadata["pickup_time"] = pickup_time.isoformat()
+    params["metadata"] = metadata
+
     if settings.stripe_return_url:
         params["return_url"] = settings.stripe_return_url
 
     return stripe.PaymentIntent.create(**params)
 
 
-def charge_final(amount_cents: int, payment_method: str = "pm_card_visa"):
+def charge_final(
+    amount_cents: int,
+    booking_id: uuid.UUID,
+    *,
+    public_code: str | None = None,
+    customer_email: str | None = None,
+    pickup_address: str | None = None,
+    dropoff_address: str | None = None,
+    pickup_time: datetime | None = None,
+    payment_method: str = "pm_card_visa",
+):
     """Charge the remaining fare amount."""
     params = {
         "amount": amount_cents,
@@ -83,6 +119,22 @@ def charge_final(amount_cents: int, payment_method: str = "pm_card_visa"):
             "allow_redirects": "never",
         },
     }
+
+    metadata = {
+        "booking_id": str(booking_id),
+        "payment_type": "final",
+    }
+    if public_code:
+        metadata["public_code"] = public_code
+    if customer_email:
+        metadata["customer_email"] = customer_email
+    if pickup_address:
+        metadata["pickup_address"] = pickup_address
+    if dropoff_address:
+        metadata["dropoff_address"] = dropoff_address
+    if pickup_time:
+        metadata["pickup_time"] = pickup_time.isoformat()
+    params["metadata"] = metadata
 
     if settings.stripe_return_url:
         params["return_url"] = settings.stripe_return_url

--- a/backend/tests/integration/test_availability_api.py
+++ b/backend/tests/integration/test_availability_api.py
@@ -3,11 +3,10 @@ from datetime import datetime, timedelta, timezone
 
 import pytest
 from _pytest.monkeypatch import MonkeyPatch
-from httpx import AsyncClient
-
 from app.core.security import hash_password
 from app.models.booking import Booking, BookingStatus
 from app.models.user_v2 import User, UserRole
+from httpx import AsyncClient
 
 pytestmark = pytest.mark.asyncio
 
@@ -117,7 +116,8 @@ async def test_double_booking_blocked(
         id = "pi"
 
     monkeypatch.setattr(
-        "app.services.stripe_client.charge_deposit", lambda amount: FakePI()
+        "app.services.stripe_client.charge_deposit",
+        lambda amount, booking_id, **kwargs: FakePI(),
     )
 
     async def fake_route(*args, **kwargs):

--- a/backend/tests/integration/test_booking_create_api.py
+++ b/backend/tests/integration/test_booking_create_api.py
@@ -27,7 +27,7 @@ async def test_create_booking_success(
     class FakeSI:
         client_secret = "sec_test"
 
-    def fake_si(email: str):
+    def fake_si(email: str, name: str, booking_reference: str):
         return FakeSI()
 
     monkeypatch.setattr("app.services.stripe_client.create_setup_intent", fake_si)

--- a/backend/tests/integration/test_driver_booking_actions_api.py
+++ b/backend/tests/integration/test_driver_booking_actions_api.py
@@ -3,11 +3,10 @@ from datetime import datetime, timedelta, timezone
 
 import pytest
 from _pytest.monkeypatch import MonkeyPatch
-from httpx import AsyncClient
-
 from app.core.security import hash_password
 from app.models.booking import Booking, BookingStatus
 from app.models.user_v2 import User, UserRole
+from httpx import AsyncClient
 
 pytestmark = pytest.mark.asyncio
 
@@ -51,7 +50,8 @@ async def test_driver_confirm_booking(
         id = "pi_test"
 
     monkeypatch.setattr(
-        "app.services.stripe_client.charge_deposit", lambda amount: FakePI()
+        "app.services.stripe_client.charge_deposit",
+        lambda amount, booking_id, **kwargs: FakePI(),
     )
 
     async def fake_route(*args, **kwargs):

--- a/backend/tests/integration/test_driver_complete_api.py
+++ b/backend/tests/integration/test_driver_complete_api.py
@@ -2,13 +2,12 @@ import uuid
 from datetime import datetime, timedelta, timezone
 
 import pytest
-from httpx import AsyncClient
-
 from app.core.security import hash_password
 from app.models.booking import Booking, BookingStatus
 from app.models.route_point import RoutePoint
 from app.models.settings import AdminConfig
 from app.models.user_v2 import User, UserRole
+from httpx import AsyncClient
 
 pytestmark = pytest.mark.asyncio
 
@@ -57,10 +56,12 @@ async def test_driver_complete_booking(
             self.id = id
 
     monkeypatch.setattr(
-        "app.services.stripe_client.charge_deposit", lambda amount: FakePI("pi_dep")
+        "app.services.stripe_client.charge_deposit",
+        lambda amount, booking_id, **kwargs: FakePI("pi_dep"),
     )
     monkeypatch.setattr(
-        "app.services.stripe_client.charge_final", lambda amount: FakePI("pi_final")
+        "app.services.stripe_client.charge_final",
+        lambda amount, booking_id, **kwargs: FakePI("pi_final"),
     )
 
     async def fake_route(*args, **kwargs):

--- a/backend/tests/integration/test_driver_retry_deposit_api.py
+++ b/backend/tests/integration/test_driver_retry_deposit_api.py
@@ -4,12 +4,11 @@ from datetime import datetime, timedelta, timezone
 import pytest
 import stripe
 from _pytest.monkeypatch import MonkeyPatch
-from httpx import AsyncClient
-from sqlalchemy import text
-
 from app.core.security import hash_password
 from app.models.booking import Booking, BookingStatus
 from app.models.user_v2 import User, UserRole
+from httpx import AsyncClient
+from sqlalchemy import text
 
 pytestmark = pytest.mark.asyncio
 
@@ -51,7 +50,7 @@ async def test_retry_deposit_creates_new_intent(
 ):
     booking = await _create_booking(async_session)
 
-    def fail(_amount):
+    def fail(_amount, _booking_id, **kwargs):
         raise stripe.error.StripeError("fail")
 
     monkeypatch.setattr("app.services.stripe_client.charge_deposit", fail)
@@ -68,7 +67,8 @@ async def test_retry_deposit_creates_new_intent(
         id = "pi_retry"
 
     monkeypatch.setattr(
-        "app.services.stripe_client.charge_deposit", lambda amount: FakePI()
+        "app.services.stripe_client.charge_deposit",
+        lambda amount, booking_id, **kwargs: FakePI(),
     )
 
     async def fake_route(*args, **kwargs):


### PR DESCRIPTION
## Summary
- include booking and trip details in Stripe PaymentIntent metadata
- tag deposits and final payments with purpose identifiers
- extend SetupIntent metadata to capture customer and booking reference

## Testing
- `npm run lint`
- `cd backend && pytest -q --maxfail=1 --disable-warnings tests/unit/services/test_booking_service.py tests/integration/test_booking_create_api.py tests/integration/test_availability_api.py tests/integration/test_driver_booking_actions_api.py tests/integration/test_driver_complete_api.py tests/integration/test_driver_retry_deposit_api.py`


------
https://chatgpt.com/codex/tasks/task_e_68b826cdfd8c8331b6cd670fdf5db93a