### PR TITLE
fix: handle notification body fallback

### DIFF
--- a/frontend/public/firebase-messaging-sw.js
+++ b/frontend/public/firebase-messaging-sw.js
@@ -38,6 +38,8 @@ self.addEventListener('push', event => {
 
   const lookup = msg.type ? notificationMap[msg.type] : undefined;
   const title = msg.title || (lookup && lookup.title) || 'Notification';
-  const options = { body: msg.body || (lookup && lookup.body) };
+  const body = msg.body || (lookup && lookup.body);
+  const options = {};
+  if (body) options.body = body;
   event.waitUntil(self.registration.showNotification(title, options));
 });


### PR DESCRIPTION
## Summary
- avoid building notification body when missing in push events

## Testing
- `npm run lint`
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b8273d4ddc833190fbefa0ef0186dc