### PR TITLE
feat: log service worker state and push events

### DIFF
--- a/frontend/public/firebase-messaging-sw.js
+++ b/frontend/public/firebase-messaging-sw.js
@@ -1,4 +1,5 @@
 self.addEventListener('push', event => {
+  console.log('Push event:', event);
   const payload = event.data?.json() ?? {};
   const msg = payload.data || payload;
   const notificationMap = {

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1,0 +1,9 @@
+if ('serviceWorker' in navigator) {
+  navigator.serviceWorker
+    .register('/firebase-messaging-sw.js')
+    .then(() =>
+      navigator.serviceWorker.ready.then((sw) =>
+        console.log('SW active:', sw.active?.state),
+      ),
+    );
+}


### PR DESCRIPTION
## Summary
- log service worker activation state after registration
- trace push events in Firebase messaging service worker

## Testing
- `npm run lint`
- `cd frontend && npm test main -- --run --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68b8efcd4fc88331afa722f8571b2641