### PR TITLE
chore: log FCM token to console

### DIFF
--- a/frontend/src/services/push.ts
+++ b/frontend/src/services/push.ts
@@ -62,6 +62,7 @@ export async function subscribePush(): Promise<string | null> {
       vapidKey: vapid,
       serviceWorkerRegistration: registration,
     });
+    console.log('FCM token:', token);
     logger.info('services/push', 'FCM token acquired', { token });
     logger.debug('services/push', 'Listening for foreground messages');
     onMessage(messaging, (payload) => {


### PR DESCRIPTION
## Summary
- log FCM token to the browser console when subscribing to push notifications

## Testing
- `npm run lint`
- `CI=1 npm test src/__tests__/useBookingChannel.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b8efd499a08331ba5795607afd2f3c