### PR TITLE
feat: integrate firebase messaging service worker

### DIFF
--- a/frontend/public/firebase-messaging-sw.js
+++ b/frontend/public/firebase-messaging-sw.js
@@ -1,48 +1,11 @@
-self.addEventListener('push', event => {
-  console.log('Push event:', event);
-  const payload = event.data?.json() ?? {};
-  const msg = payload.data || payload;
-  const notificationMap = {
-    NEW_BOOKING: {
-      title: 'New booking',
-      body: 'You have a new booking',
-    },
-    CONFIRMATION: {
-      title: 'Booking confirmed',
-      body: 'Your booking has been confirmed',
-    },
-    LEAVE_NOW: {
-      title: 'Time to leave',
-      body: 'Please leave now for your ride',
-    },
-    ON_THE_WAY: {
-      title: 'Driver on the way',
-      body: 'Your driver is on the way',
-    },
-    ARRIVED_PICKUP: {
-      title: 'Driver arrived',
-      body: 'Your driver has arrived at the pickup location',
-    },
-    STARTED: {
-      title: 'Ride started',
-      body: 'Your ride has started',
-    },
-    ARRIVED_DROPOFF: {
-      title: 'Arrived at dropoff',
-      body: 'You have arrived at your destination',
-    },
-    COMPLETED: {
-      title: 'Ride completed',
-      body: 'Your ride is complete',
-    },
-  };
+importScripts('https://www.gstatic.com/firebasejs/11.0.2/firebase-app-compat.js');
+importScripts('https://www.gstatic.com/firebasejs/11.0.2/firebase-messaging-compat.js');
 
-  console.log(msg);
-
-  const lookup = msg.type ? notificationMap[msg.type] : undefined;
-  const title = msg.title || (lookup && lookup.title) || 'Notification';
-  const body = msg.body || (lookup && lookup.body);
-  const options = {};
-  if (body) options.body = body;
-  event.waitUntil(self.registration.showNotification(title, options));
+firebase.initializeApp({
+  apiKey: '${VITE_FCM_API_KEY}',
+  projectId: '${VITE_FCM_PROJECT_ID}',
+  appId: '${VITE_FCM_APP_ID}',
+  messagingSenderId: '${VITE_FCM_SENDER_ID}',
 });
+
+firebase.messaging();

--- a/frontend/src/services/push.ts
+++ b/frontend/src/services/push.ts
@@ -1,5 +1,5 @@
 import { initializeApp } from 'firebase/app';
-import { deleteToken, getMessaging, getToken, onMessage } from 'firebase/messaging';
+import { deleteToken, getMessaging, getToken } from 'firebase/messaging';
 import * as logger from '@/lib/logger';
 
 let messaging: ReturnType<typeof getMessaging> | null = null;
@@ -64,10 +64,6 @@ export async function subscribePush(): Promise<string | null> {
     });
     console.log('FCM token:', token);
     logger.info('services/push', 'FCM token acquired', { token });
-    logger.debug('services/push', 'Listening for foreground messages');
-    onMessage(messaging, (payload) => {
-      logger.info('services/push', 'FCM message', payload);
-    });
     return token;
   } catch (err) {
     logger.error('services/push', 'FCM init failed', err);


### PR DESCRIPTION
## Summary
- remove custom push listener and initialize Firebase in service worker
- streamline push subscription to rely on FCM without manual message handling

## Testing
- `npm run lint`
- `pytest -q --maxfail=1 --disable-warnings`
- `npm test src/components/PushToggle.test.tsx`
- `npm run build` *(fails: Type 'string | undefined' is not assignable to type 'string')*


------
https://chatgpt.com/codex/tasks/task_e_68b8f78f51248331b6f6735961867e92