### PR TITLE
feat: centralize driver bookings with live updates

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,6 +4,7 @@ import LoginPage from "@/pages/Auth/LoginPage";
 import BookingWizardPage from "@/pages/Booking/BookingWizardPage";
 import AdminDashboard from "@/pages/Admin/AdminDashboard";
 import DriverDashboard from "@/pages/Driver/DriverDashboard";
+import { BookingsProvider } from "@/contexts/BookingsContext";
 import AvailabilityPage from "@/pages/Driver/AvailabilityPage";
 import TrackingPage from "@/pages/TrackingPage";
 import RideHistoryPage from "@/pages/Booking/RideHistoryPage";
@@ -52,7 +53,16 @@ function App() {
 
       {/* Protected admin-only routes */}
       <Route path="/admin" element={<RequireAdmin><AdminDashboard /></RequireAdmin>} />
-      <Route path="/driver" element={<RequireAdmin><DriverDashboard /></RequireAdmin>} />
+      <Route
+        path="/driver"
+        element={
+          <RequireAdmin>
+            <BookingsProvider>
+              <DriverDashboard />
+            </BookingsProvider>
+          </RequireAdmin>
+        }
+      />
       <Route path="/driver/availability" element={<RequireAdmin><AvailabilityPage /></RequireAdmin>} />
       <Route
         path="/t/:code"

--- a/frontend/src/__tests__/DriverDashboard.test.tsx
+++ b/frontend/src/__tests__/DriverDashboard.test.tsx
@@ -12,6 +12,8 @@ vi.mock('@/components/ApiConfig', () => ({
 import DriverDashboard from '@/pages/Driver/DriverDashboard';
 import { driverBookingsApi } from '@/components/ApiConfig';
 import { CONFIG } from '@/config';
+import { BookingsProvider } from '@/contexts/BookingsContext';
+import { setTokens } from '@/services/tokenStore';
 
 describe('DriverDashboard', () => {
   it.skip('loads and confirms booking', async () => {
@@ -59,9 +61,19 @@ describe('DriverDashboard', () => {
       }) as unknown as Response,
     );
 
+    class WSStub {
+      close() {}
+      onmessage: ((event: { data: string }) => void) | null = null;
+      constructor(public url: string) {}
+      send() {}
+    }
+    vi.stubGlobal('WebSocket', WSStub as unknown as typeof WebSocket);
+
     render(
       <MemoryRouter>
-        <DriverDashboard />
+        <BookingsProvider>
+          <DriverDashboard />
+        </BookingsProvider>
       </MemoryRouter>,
     );
     expect(await screen.findByText('A → B')).toBeInTheDocument();
@@ -92,9 +104,20 @@ describe('DriverDashboard', () => {
       } as unknown as Response);
     vi.stubGlobal('fetch', fetchMock);
 
+    class WSStub {
+      close() {}
+      onmessage: ((event: { data: string }) => void) | null = null;
+      constructor(public url: string) {}
+      send() {}
+    }
+    vi.stubGlobal('WebSocket', WSStub as unknown as typeof WebSocket);
+    setTokens('test-token');
+
     render(
       <MemoryRouter>
-        <DriverDashboard />
+        <BookingsProvider>
+          <DriverDashboard />
+        </BookingsProvider>
       </MemoryRouter>,
     );
 

--- a/frontend/src/contexts/BookingsContext.tsx
+++ b/frontend/src/contexts/BookingsContext.tsx
@@ -1,0 +1,131 @@
+import { createContext, useEffect, useRef, useState } from 'react';
+import type { ReactNode } from 'react';
+import { driverBookingsApi as bookingsApi } from '@/components/ApiConfig';
+import type { BookingRead as Booking } from '@/api-client';
+import { apiFetch } from '@/services/apiFetch';
+import { CONFIG } from '@/config';
+import { getAccessToken, onTokenChange } from '@/services/tokenStore';
+
+export type DriverAction =
+  | 'confirm'
+  | 'decline'
+  | 'leave'
+  | 'arrive-pickup'
+  | 'start-trip'
+  | 'arrive-dropoff'
+  | 'complete'
+  | 'retry-deposit';
+
+export interface BookingsContextValue {
+  bookings: Booking[];
+  updateBooking: (id: string, action: DriverAction) => Promise<void>;
+}
+
+// eslint-disable-next-line react-refresh/only-export-components
+export const BookingsContext = createContext<BookingsContextValue | undefined>(
+  undefined,
+);
+
+export function BookingsProvider({ children }: { children: ReactNode }) {
+  const [bookings, setBookings] = useState<Booking[]>([]);
+  const [token, setToken] = useState<string | null>(() => getAccessToken());
+  const socketsRef = useRef<Record<string, WebSocket>>({});
+
+  useEffect(() => {
+    const unsubscribe = onTokenChange(() => {
+      setToken(getAccessToken());
+    });
+    return unsubscribe;
+  }, []);
+
+  useEffect(() => {
+    if (!token) {
+      setBookings([]);
+      return;
+    }
+    (async () => {
+      try {
+        const { data } = await bookingsApi.listBookingsApiV1DriverBookingsGet(
+          undefined,
+          { headers: { Authorization: `Bearer ${token}` } },
+        );
+        setBookings(data as Booking[]);
+      } catch {
+        // ignore
+      }
+    })();
+  }, [token]);
+
+  useEffect(() => {
+    const t = token;
+    if (!t) return;
+    const wsBase = (CONFIG.API_BASE_URL || window.location.origin).replace(
+      'http',
+      'ws',
+    );
+    const ids = new Set(bookings.map((b) => b.id));
+    Object.entries(socketsRef.current).forEach(([id, ws]) => {
+      if (!ids.has(id)) {
+        ws.close();
+        delete socketsRef.current[id];
+      }
+    });
+    bookings.forEach((b) => {
+      if (socketsRef.current[b.id]) return;
+      const ws = new WebSocket(
+        `${wsBase}/ws/bookings/${b.id}?token=${t}`,
+      );
+      ws.onmessage = (e) => {
+        try {
+          const data = JSON.parse(e.data) as Partial<Booking> & { id: string };
+          setBookings((prev) =>
+            prev.map((item) =>
+              item.id === data.id ? { ...item, ...data } : item,
+            ),
+          );
+        } catch {
+          // ignore
+        }
+      };
+      socketsRef.current[b.id] = ws;
+    });
+  }, [bookings, token]);
+
+  useEffect(() => () => {
+    Object.values(socketsRef.current).forEach((ws) => ws.close());
+  }, []);
+
+  async function updateBooking(id: string, action: DriverAction) {
+    const res = await apiFetch(
+      `${CONFIG.API_BASE_URL}/api/v1/driver/bookings/${id}/${action}`,
+      { method: 'POST' },
+    );
+    const data = await res.json().catch(() => ({}));
+    if (!res.ok) {
+      throw new Error(
+        `${res.status} ${data.message ?? data.detail ?? res.statusText}`,
+      );
+    }
+    setBookings((prev) =>
+      prev.map((item) =>
+        item.id === id
+          ? {
+              ...item,
+              status: data.status,
+              final_price_cents:
+                data.final_price_cents ?? item.final_price_cents,
+            }
+          : item,
+      ),
+    );
+  }
+
+  return (
+    <BookingsContext.Provider value={{ bookings, updateBooking }}>
+      {children}
+    </BookingsContext.Provider>
+  );
+}
+
+export default BookingsProvider;
+

--- a/frontend/src/hooks/useBookings.ts
+++ b/frontend/src/hooks/useBookings.ts
@@ -1,0 +1,11 @@
+import { useContext } from 'react';
+import { BookingsContext, type BookingsContextValue } from '@/contexts/BookingsContext';
+
+export function useBookings(): BookingsContextValue {
+  const ctx = useContext(BookingsContext);
+  if (!ctx) throw new Error('useBookings must be used within a BookingsProvider');
+  return ctx;
+}
+
+export default useBookings;
+


### PR DESCRIPTION
## Summary
- add BookingsContext with websocket listeners for driver bookings
- refactor DriverDashboard to use context via `useBookings` hook
- wrap driver route with BookingsProvider and adjust tests

## Testing
- `npm run lint`
- `cd frontend && npm test src/__tests__/DriverDashboard.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68b8fc8efbc8833189d949063d0bd369