### PR TITLE
feat: broadcast booking progress from driver updates

### DIFF
--- a/backend/app/core/broadcast.py
+++ b/backend/app/core/broadcast.py
@@ -1,0 +1,3 @@
+from broadcaster import Broadcast
+
+broadcast = Broadcast("memory://")


### PR DESCRIPTION
## Summary
- add shared in-memory broadcast channel
- persist all driver GPS updates and update booking status as trip progresses

## Testing
- `npm run lint`
- `cd backend && pytest -q --maxfail=1 --disable-warnings`

------
https://chatgpt.com/codex/tasks/task_e_68b8fd1880548331b56e398af94e63e3