### PR TITLE
feat: use bookings context on ride history

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -47,7 +47,16 @@ function App() {
 
       {/* Protected user routes */}
       <Route path="/book" element={<RequireAuth><BookingWizardPage /></RequireAuth>} />
-      <Route path="/history" element={<RequireAuth><RideHistoryPage /></RequireAuth>} />
+      <Route
+        path="/history"
+        element={
+          <RequireAuth>
+            <BookingsProvider>
+              <RideHistoryPage />
+            </BookingsProvider>
+          </RequireAuth>
+        }
+      />
       <Route path="/history/:id" element={<RequireAuth><RideDetailsPage /></RequireAuth>} />
       <Route path="/me" element={<RequireAuth><ProfilePage /></RequireAuth>} />
 

--- a/frontend/src/pages/Booking/RideHistoryPage.test.tsx
+++ b/frontend/src/pages/Booking/RideHistoryPage.test.tsx
@@ -3,11 +3,8 @@ import userEvent from '@testing-library/user-event';
 import { MemoryRouter, Routes, Route } from 'react-router-dom';
 import RideHistoryPage from './RideHistoryPage';
 import { AuthProvider } from '@/contexts/AuthContext';
-import { customerBookingsApi } from '@/components/ApiConfig';
+import { BookingsContext, type BookingsContextValue } from '@/contexts/BookingsContext';
 import { vi } from 'vitest';
-import { server } from '@/__tests__/setup/msw.server';
-import { http, HttpResponse } from 'msw';
-import { apiUrl } from '@/__tests__/setup/msw.handlers';
 
 test('shows track link for trackable bookings', async () => {
   const bookings = [
@@ -31,15 +28,20 @@ test('shows track link for trackable bookings', async () => {
     },
   ];
 
-  vi
-    .spyOn(customerBookingsApi, 'listMyBookingsApiV1CustomersMeBookingsGet')
-    .mockResolvedValue({ data: bookings } as never);
+  const context: BookingsContextValue = {
+    bookings,
+    loading: false,
+    error: null,
+    updateBooking: vi.fn(),
+  };
 
   render(
     <AuthProvider>
-      <MemoryRouter initialEntries={['/history']}>
-        <RideHistoryPage />
-      </MemoryRouter>
+      <BookingsContext.Provider value={context}>
+        <MemoryRouter initialEntries={['/history']}>
+          <RideHistoryPage />
+        </MemoryRouter>
+      </BookingsContext.Provider>
     </AuthProvider>,
   );
 
@@ -63,20 +65,23 @@ test('track link navigates to tracking page', async () => {
     },
   ];
 
-  server.use(
-    http.get(apiUrl('/api/v1/customers/me/bookings'), () =>
-      HttpResponse.json(bookings),
-    ),
-  );
+  const context: BookingsContextValue = {
+    bookings,
+    loading: false,
+    error: null,
+    updateBooking: vi.fn(),
+  };
 
   render(
     <AuthProvider>
-      <MemoryRouter initialEntries={['/history']}>
-        <Routes>
-          <Route path="/history" element={<RideHistoryPage />} />
-          <Route path="/t/:code" element={<h1>Tracking</h1>} />
-        </Routes>
-      </MemoryRouter>
+      <BookingsContext.Provider value={context}>
+        <MemoryRouter initialEntries={['/history']}>
+          <Routes>
+            <Route path="/history" element={<RideHistoryPage />} />
+            <Route path="/t/:code" element={<h1>Tracking</h1>} />
+          </Routes>
+        </MemoryRouter>
+      </BookingsContext.Provider>
     </AuthProvider>,
   );
 

--- a/frontend/src/pages/Booking/RideHistoryPage.tsx
+++ b/frontend/src/pages/Booking/RideHistoryPage.tsx
@@ -1,4 +1,3 @@
-import { useEffect, useState } from 'react';
 import { Link as RouterLink, useNavigate } from 'react-router-dom';
 import {
   Box,
@@ -11,38 +10,11 @@ import {
   TableRow,
   Typography,
 } from '@mui/material';
-
-import { customerBookingsApi } from '@/components/ApiConfig';
-import type { BookingRead as Booking } from '@/api-client';
+import { useBookings } from '@/hooks/useBookings';
 
 function RideHistoryPage() {
   const navigate = useNavigate();
-
-  const [bookings, setBookings] = useState<Booking[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-
-  useEffect(() => {
-    let alive = true;
-
-    (async () => {
-      try {
-        const res = await customerBookingsApi.listMyBookingsApiV1CustomersMeBookingsGet();
-        if (alive) setBookings(res.data as Booking[]);
-      } catch (e: unknown) {
-        if (alive)
-          setError(
-            e instanceof Error ? e.message : 'Failed to load bookings',
-          );
-      } finally {
-        if (alive) setLoading(false);
-      }
-    })();
-
-    return () => {
-      alive = false;
-    };
-  }, []);
+  const { bookings, loading, error } = useBookings();
 
   if (loading) {
     return (


### PR DESCRIPTION
## Summary
- use global bookings context in RideHistoryPage
- expose loading and error from BookingsContext
- wrap history route with BookingsProvider

## Testing
- `npm run lint`
- `cd frontend && npm test src/pages/Booking/RideHistoryPage.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68b900b9be108331aedeae8ba43ed988