### PR TITLE
feat: add bookings context and hook

### DIFF
--- a/frontend/src/hooks/useBookings.ts
+++ b/frontend/src/hooks/useBookings.ts
@@ -1,9 +1,11 @@
 import { useContext } from 'react';
-import { BookingsContext, type BookingsContextValue } from '@/contexts/BookingsContext';
+import { BookingsContext } from '@/contexts/BookingsContext';
 
-export function useBookings(): BookingsContextValue {
+export function useBookings() {
   const ctx = useContext(BookingsContext);
-  if (!ctx) throw new Error('useBookings must be used within a BookingsProvider');
+  if (!ctx) {
+    throw new Error('useBookings must be used within a BookingsProvider');
+  }
   return ctx;
 }
 


### PR DESCRIPTION
## Summary
- add BookingsContext with refresh, update, and websocket sync
- expose useBookings hook for accessing booking state

## Testing
- `npm run lint`
- `cd frontend && npm test -- --run useBookingChannel`


------
https://chatgpt.com/codex/tasks/task_e_68b903db96588331bd3e1dff86aec95d