### PR TITLE
test: add bookings hook and live update tests

### DIFF
--- a/frontend/src/__tests__/useBookings.test.tsx
+++ b/frontend/src/__tests__/useBookings.test.tsx
@@ -1,0 +1,81 @@
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { vi, type Mock } from 'vitest';
+import { BookingsProvider } from '@/contexts/BookingsContext';
+import { useBookings } from '@/hooks/useBookings';
+import { driverBookingsApi } from '@/components/ApiConfig';
+import type { ReactNode } from 'react';
+
+vi.mock('@/components/ApiConfig', () => ({
+  driverBookingsApi: {
+    listBookingsApiV1DriverBookingsGet: vi.fn(),
+  },
+  customerBookingsApi: {
+    listMyBookingsApiV1CustomersMeBookingsGet: vi.fn(),
+  },
+}));
+
+vi.mock('@/contexts/AuthContext', () => ({
+  useAuth: () => ({ accessToken: 'test-token', role: 'driver' }),
+}));
+
+class WSStub {
+  static instances: WSStub[] = [];
+  onmessage: ((event: { data: string }) => void) | null = null;
+  constructor(public url: string) {
+    WSStub.instances.push(this);
+  }
+  close() {}
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+  vi.unstubAllGlobals();
+  WSStub.instances = [];
+});
+
+function wrapper({ children }: { children: ReactNode }) {
+  return <BookingsProvider>{children}</BookingsProvider>;
+}
+
+describe('useBookings', () => {
+  it('initial fetch populates state', async () => {
+    const bookings = [
+      {
+        id: '1',
+        pickup_address: 'A',
+        dropoff_address: 'B',
+        pickup_when: new Date().toISOString(),
+        status: 'PENDING',
+      },
+    ];
+    (driverBookingsApi.listBookingsApiV1DriverBookingsGet as Mock).mockResolvedValue({ data: bookings });
+    vi.stubGlobal('WebSocket', WSStub as unknown as typeof WebSocket);
+
+    const { result } = renderHook(() => useBookings(), { wrapper });
+    await waitFor(() => expect(result.current.bookings).toEqual(bookings));
+  });
+
+  it('websocket message updates a booking\'s status', async () => {
+    const booking = {
+      id: '1',
+      pickup_address: 'A',
+      dropoff_address: 'B',
+      pickup_when: new Date().toISOString(),
+      status: 'PENDING',
+    };
+    (driverBookingsApi.listBookingsApiV1DriverBookingsGet as Mock).mockResolvedValue({ data: [booking] });
+    vi.stubGlobal('WebSocket', WSStub as unknown as typeof WebSocket);
+
+    const { result } = renderHook(() => useBookings(), { wrapper });
+    await waitFor(() => expect(result.current.bookings[0].status).toBe('PENDING'));
+
+    act(() => {
+      WSStub.instances[0].onmessage?.({
+        data: JSON.stringify({ id: '1', status: 'COMPLETED' }),
+      });
+    });
+
+    expect(result.current.bookings[0].status).toBe('COMPLETED');
+  });
+});
+

--- a/frontend/src/pages/Booking/RideHistoryPage.test.tsx
+++ b/frontend/src/pages/Booking/RideHistoryPage.test.tsx
@@ -1,10 +1,38 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter, Routes, Route } from 'react-router-dom';
 import RideHistoryPage from './RideHistoryPage';
-import { AuthProvider } from '@/contexts/AuthContext';
-import { BookingsContext, type BookingsContextValue } from '@/contexts/BookingsContext';
-import { vi } from 'vitest';
+import { BookingsProvider } from '@/contexts/BookingsContext';
+import { driverBookingsApi } from '@/components/ApiConfig';
+import { vi, type Mock } from 'vitest';
+
+vi.mock('@/components/ApiConfig', () => ({
+  driverBookingsApi: {
+    listBookingsApiV1DriverBookingsGet: vi.fn(),
+  },
+  customerBookingsApi: {
+    listMyBookingsApiV1CustomersMeBookingsGet: vi.fn(),
+  },
+}));
+
+vi.mock('@/contexts/AuthContext', () => ({
+  useAuth: () => ({ accessToken: 'test-token', role: 'driver' }),
+}));
+
+class WSStub {
+  static instances: WSStub[] = [];
+  onmessage: ((event: { data: string }) => void) | null = null;
+  constructor(public url: string) {
+    WSStub.instances.push(this);
+  }
+  close() {}
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+  vi.unstubAllGlobals();
+  WSStub.instances = [];
+});
 
 test('shows track link for trackable bookings', async () => {
   const bookings = [
@@ -13,7 +41,7 @@ test('shows track link for trackable bookings', async () => {
       pickup_address: 'A',
       dropoff_address: 'B',
       pickup_when: new Date().toISOString(),
-      status: 'on_the_way',
+      status: 'ON_THE_WAY',
       estimated_price_cents: 1000,
       public_code: 'abc123',
     },
@@ -22,31 +50,23 @@ test('shows track link for trackable bookings', async () => {
       pickup_address: 'C',
       dropoff_address: 'D',
       pickup_when: new Date().toISOString(),
-      status: 'completed',
+      status: 'COMPLETED',
       estimated_price_cents: 2000,
       public_code: 'def456',
     },
   ];
-
-  const context: BookingsContextValue = {
-    bookings,
-    loading: false,
-    error: null,
-    updateBooking: vi.fn(),
-  };
+  (driverBookingsApi.listBookingsApiV1DriverBookingsGet as Mock).mockResolvedValue({ data: bookings });
+  vi.stubGlobal('WebSocket', WSStub as unknown as typeof WebSocket);
 
   render(
-    <AuthProvider>
-      <BookingsContext.Provider value={context}>
-        <MemoryRouter initialEntries={['/history']}>
-          <RideHistoryPage />
-        </MemoryRouter>
-      </BookingsContext.Provider>
-    </AuthProvider>,
+    <MemoryRouter initialEntries={['/history']}>
+      <BookingsProvider>
+        <RideHistoryPage />
+      </BookingsProvider>
+    </MemoryRouter>,
   );
 
   expect(await screen.findByText(/Ride History/i)).toBeInTheDocument();
-
   const trackLinks = screen.getAllByRole('link', { name: /track/i });
   expect(trackLinks).toHaveLength(1);
   expect(trackLinks[0]).toHaveAttribute('href', '/t/abc123');
@@ -59,35 +79,61 @@ test('track link navigates to tracking page', async () => {
       pickup_address: 'A',
       dropoff_address: 'B',
       pickup_when: new Date().toISOString(),
-      status: 'on_the_way',
+      status: 'ON_THE_WAY',
       estimated_price_cents: 1000,
       public_code: 'abc123',
     },
   ];
-
-  const context: BookingsContextValue = {
-    bookings,
-    loading: false,
-    error: null,
-    updateBooking: vi.fn(),
-  };
+  (driverBookingsApi.listBookingsApiV1DriverBookingsGet as Mock).mockResolvedValue({ data: bookings });
+  vi.stubGlobal('WebSocket', WSStub as unknown as typeof WebSocket);
 
   render(
-    <AuthProvider>
-      <BookingsContext.Provider value={context}>
-        <MemoryRouter initialEntries={['/history']}>
-          <Routes>
-            <Route path="/history" element={<RideHistoryPage />} />
-            <Route path="/t/:code" element={<h1>Tracking</h1>} />
-          </Routes>
-        </MemoryRouter>
-      </BookingsContext.Provider>
-    </AuthProvider>,
+    <MemoryRouter initialEntries={['/history']}>
+      <BookingsProvider>
+        <Routes>
+          <Route path="/history" element={<RideHistoryPage />} />
+          <Route path="/t/:code" element={<h1>Tracking</h1>} />
+        </Routes>
+      </BookingsProvider>
+    </MemoryRouter>,
   );
 
   const link = await screen.findByRole('link', { name: /track/i });
   await userEvent.click(link);
   expect(
-    await screen.findByRole('heading', { name: /tracking/i })
+    await screen.findByRole('heading', { name: /tracking/i }),
   ).toBeInTheDocument();
 });
+
+test('updates status when websocket message received', async () => {
+  const booking = {
+    id: '1',
+    pickup_address: 'A',
+    dropoff_address: 'B',
+    pickup_when: new Date().toISOString(),
+    status: 'PENDING',
+    estimated_price_cents: 1000,
+    public_code: 'abc123',
+  };
+  (driverBookingsApi.listBookingsApiV1DriverBookingsGet as Mock).mockResolvedValue({ data: [booking] });
+  vi.stubGlobal('WebSocket', WSStub as unknown as typeof WebSocket);
+
+  render(
+    <MemoryRouter initialEntries={['/history']}>
+      <BookingsProvider>
+        <RideHistoryPage />
+      </BookingsProvider>
+    </MemoryRouter>,
+  );
+
+  expect(await screen.findByText('PENDING')).toBeInTheDocument();
+
+  act(() => {
+    WSStub.instances[0].onmessage?.({
+      data: JSON.stringify({ id: '1', status: 'COMPLETED' }),
+    });
+  });
+
+  expect(await screen.findByText('COMPLETED')).toBeInTheDocument();
+});
+


### PR DESCRIPTION
## Summary
- add useBookings hook tests for initial fetch and websocket updates
- mount DriverDashboard and RideHistoryPage with BookingsProvider and verify live updates

## Testing
- `npm run lint`
- `cd frontend && npm test src/__tests__/useBookings.test.tsx src/__tests__/DriverDashboard.test.tsx src/pages/Booking/RideHistoryPage.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68b9066a7e08833189935c4281a75ec9