### PR TITLE
feat: handle websocket connection errors

### DIFF
--- a/frontend/src/contexts/BookingsContext.tsx
+++ b/frontend/src/contexts/BookingsContext.tsx
@@ -144,9 +144,25 @@ export function BookingsProvider({ children }: { children: ReactNode }) {
           /* ignore */
         }
       };
+      ws.onerror = (e) => {
+        console.error('WebSocket error', e);
+        setError('Real-time connection error');
+        ws.close();
+      };
+      ws.onclose = () => {
+        console.warn(`WebSocket closed for booking ${b.id}`);
+        if (sockets[b.id] === ws) {
+          delete sockets[b.id];
+        }
+        setTimeout(() => {
+          if (accessToken) {
+            refresh();
+          }
+        }, 1000);
+      };
       sockets[b.id] = ws;
     });
-  }, [bookings, accessToken]);
+  }, [bookings, accessToken, refresh]);
 
   useEffect(
     () => () => {


### PR DESCRIPTION
## Summary
- add WebSocket error and close handlers for booking updates
- refresh bookings and report realtime connection errors on socket loss

## Testing
- `npm run lint`
- `cd frontend && npm test src/__tests__/useBookings.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68b9183f5d848331b9da960f9c9a2749