### PR TITLE
fix: guard tracking updates against invalid coordinates

### DIFF
--- a/frontend/src/hooks/useBookingChannel.ts
+++ b/frontend/src/hooks/useBookingChannel.ts
@@ -25,18 +25,21 @@ export function useBookingChannel(bookingId: string | null) {
   useEffect(() => {
     if (!bookingId || !token) return;
     const wsUrl = `${import.meta.env.VITE_BACKEND_URL.replace("http", "ws")}/ws/bookings/${bookingId}/watch?token=${token}`;
-    return createReconnectingWebSocket(wsUrl, {
-      onMessage: (e) => {
-        try {
-          setUpdate(JSON.parse(e.data));
-        } catch {
-          /* ignore */
-        }
-      },
-      onError: () => setUpdate(null),
-      onClose: () => setUpdate(null),
-    });
-  }, [bookingId, token]);
+      return createReconnectingWebSocket(wsUrl, {
+        onMessage: (e) => {
+          try {
+            const data = JSON.parse(e.data);
+            if (typeof data.lat === "number" && typeof data.lng === "number") {
+              setUpdate(data);
+            }
+          } catch {
+            /* ignore */
+          }
+        },
+        onError: () => setUpdate(null),
+        onClose: () => setUpdate(null),
+      });
+    }, [bookingId, token]);
 
   return update;
 }

--- a/frontend/src/pages/TrackingPage.tsx
+++ b/frontend/src/pages/TrackingPage.tsx
@@ -116,6 +116,7 @@ export default function TrackingPage() {
   useEffect(() => {
     async function calcEta() {
       if (!update || !pickupCoords || !dropoffCoords) return;
+      if (typeof update.lat !== 'number' || typeof update.lng !== 'number') return;
       const g = (window as { google?: GoogleLike }).google;
       if (!g?.maps) return;
       const svc = new g.maps.DirectionsService();
@@ -155,7 +156,10 @@ export default function TrackingPage() {
   }, [update, update?.status, status, pickupCoords, dropoffCoords]);
 
   const pos = useMemo(
-    () => (update ? { lat: update.lat, lng: update.lng } : null),
+    () =>
+      typeof update?.lat === 'number' && typeof update?.lng === 'number'
+        ? { lat: update.lat, lng: update.lng }
+        : null,
     [update],
   );
 


### PR DESCRIPTION
## Summary
- prevent invalid coordinates from triggering route calculations or map updates
- ignore websocket messages missing numeric position data

## Testing
- `npm run lint`
- `cd frontend && npm test src/pages/TrackingPage.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68b92182c8b48331a2c426ac9760ba95