### PR TITLE
feat: handle status-only booking updates

### DIFF
--- a/frontend/src/__tests__/useBookingChannel.test.ts
+++ b/frontend/src/__tests__/useBookingChannel.test.ts
@@ -58,4 +58,21 @@ describe('useBookingChannel', () => {
     });
     expect(result.current).toBeNull();
   });
+
+  it('updates status on status-only message', () => {
+    const { result } = renderHook(() => useBookingChannel('44'));
+    const ws = WSStub.instances[2];
+    act(() => {
+      ws.onmessage?.({ data: JSON.stringify({ lat: 7, lng: 8, ts: 0 }) });
+    });
+    expect(result.current).toMatchObject({ lat: 7, lng: 8 });
+    act(() => {
+      ws.onmessage?.({ data: JSON.stringify({ status: 'ARRIVED_PICKUP' }) });
+    });
+    expect(result.current).toMatchObject({
+      lat: 7,
+      lng: 8,
+      status: 'ARRIVED_PICKUP',
+    });
+  });
 });

--- a/frontend/src/hooks/useBookingChannel.ts
+++ b/frontend/src/hooks/useBookingChannel.ts
@@ -31,6 +31,12 @@ export function useBookingChannel(bookingId: string | null) {
             const data = JSON.parse(e.data);
             if (typeof data.lat === "number" && typeof data.lng === "number") {
               setUpdate(data);
+            } else if (typeof data.status === "string") {
+              setUpdate((prev) =>
+                prev
+                  ? { ...prev, status: data.status }
+                  : { status: data.status, lat: 0, lng: 0, ts: Date.now() },
+              );
             }
           } catch {
             /* ignore */


### PR DESCRIPTION
## Summary
- handle booking channel messages that only contain status
- test status-only booking updates

## Testing
- `npm run lint`
- `npm test src/__tests__/useBookingChannel.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b926a4244c83318e7cd7b1fbe38653