### PR TITLE
feat: track user phone numbers

### DIFF
--- a/backend/alembic/versions/c9a2f3e1d4b5_add_phone_to_users_v2.py
+++ b/backend/alembic/versions/c9a2f3e1d4b5_add_phone_to_users_v2.py
@@ -1,0 +1,25 @@
+"""add phone to users_v2
+
+Revision ID: c9a2f3e1d4b5
+Revises: 13b1cf856965
+Create Date: 2025-02-15 00:00:00.000000
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "c9a2f3e1d4b5"
+down_revision = "13b1cf856965"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("users_v2") as batch_op:
+        batch_op.add_column(sa.Column("phone", sa.String(), nullable=True))
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("users_v2") as batch_op:
+        batch_op.drop_column("phone")

--- a/backend/app/api/users.py
+++ b/backend/app/api/users.py
@@ -24,7 +24,7 @@ router = APIRouter(prefix="/users", tags=["users"])
 
 @router.post("", response_model=UserRead, status_code=status.HTTP_201_CREATED)
 async def api_create_user(data: UserCreate, db: AsyncSession = Depends(get_db)):
-    """Register a new user in the system."""
+    """Register a new user in the system, optionally capturing a phone number."""
     logger.info("creating user", extra={"email": data.email})
     user = await create_user(db, data)
     return user
@@ -52,7 +52,7 @@ async def api_update_me(
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
-    """Allow the current user to update their profile."""
+    """Allow the current user to update their profile, including phone."""
     user = await update_user(db, current_user.id, data)
     return user
 
@@ -79,7 +79,7 @@ async def api_update_user(
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
-    """Update selected fields of a user."""
+    """Update selected fields of a user, including phone."""
     logger.info(
         "updating user",
         extra={"user_id": current_user.id, "target_user_id": user_id},

--- a/backend/app/models/user_v2.py
+++ b/backend/app/models/user_v2.py
@@ -3,11 +3,10 @@ import uuid
 from datetime import datetime
 from typing import Optional
 
+from app.db.database import Base
 from sqlalchemy import UUID, DateTime, Enum, String, Text
 from sqlalchemy.orm import Mapped, mapped_column
 from sqlalchemy.sql import func
-
-from app.db.database import Base
 
 
 class UserRole(str, enum.Enum):
@@ -28,6 +27,7 @@ class User(Base):
     email: Mapped[str] = mapped_column(String, unique=True, index=True)
     full_name: Mapped[str] = mapped_column(String)
     hashed_password: Mapped[str] = mapped_column(Text, name="password_hash")
+    phone: Mapped[Optional[str]] = mapped_column(String, nullable=True)
     role: Mapped[UserRole] = mapped_column(Enum(UserRole), default=UserRole.CUSTOMER)
     fcm_token: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
     created_at: Mapped[datetime] = mapped_column(

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -12,6 +12,7 @@ class UserBase(BaseModel):
     email: EmailStr
     full_name: str
     default_pickup_address: Optional[str] = None
+    phone: Optional[str] = None
 
 
 class UserCreate(UserBase):
@@ -38,4 +39,5 @@ class UserUpdate(BaseModel):
     password: Optional[str] = None
     default_pickup_address: Optional[str] = None
     fcm_token: Optional[str] = None
+    phone: Optional[str] = None
     model_config = ConfigDict(from_attributes=True, extra="ignore")

--- a/backend/app/schemas/user_v2.py
+++ b/backend/app/schemas/user_v2.py
@@ -12,6 +12,7 @@ class UserBase(BaseModel):
     email: EmailStr
     full_name: str
     role: UserRole = UserRole.CUSTOMER
+    phone: Optional[str] = None
 
 
 class UserCreate(UserBase):

--- a/backend/app/services/booking_service.py
+++ b/backend/app/services/booking_service.py
@@ -38,9 +38,15 @@ async def create_booking(
             full_name=data.customer.name,
             hashed_password="",
             role=UserRole.CUSTOMER,
+            phone=data.customer.phone,
         )
         db.add(customer)
         await db.flush()
+    else:
+        if data.customer.phone is None:
+            data.customer.phone = customer.phone
+        else:
+            customer.phone = data.customer.phone
 
     settings = (await db.execute(select(AdminConfig))).scalar_one_or_none()
     if settings is None:

--- a/backend/app/services/user_service.py
+++ b/backend/app/services/user_service.py
@@ -6,13 +6,12 @@ import logging
 import uuid
 from typing import Optional
 
-from fastapi import HTTPException, status
-from sqlalchemy import select
-from sqlalchemy.ext.asyncio import AsyncSession
-
 from app.core.security import hash_password
 from app.models.user_v2 import User
 from app.schemas.user import UserCreate, UserRead, UserUpdate
+from fastapi import HTTPException, status
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 
 logger = logging.getLogger(__name__)
 
@@ -39,6 +38,7 @@ async def create_user(db: AsyncSession, data: UserCreate) -> UserRead:
         email=data.email,
         full_name=data.full_name,
         hashed_password=hash_password(data.password),
+        phone=data.phone,
     )
     db.add(user)
     await db.flush()


### PR DESCRIPTION
## Summary
- add nullable `phone` column to `users_v2` and migration
- expose optional `phone` on user schemas, services, and API
- propagate phone through booking creation with fallback
- test booking creation phone persistence and fallback

## Testing
- `npm run lint`
- `cd backend && pytest -q tests/integration/test_booking_create_api.py`

------
https://chatgpt.com/codex/tasks/task_e_68b9531f62c883318b0ba5c791c5fed5