### PR TITLE
feat: add phone field to user profile

### DIFF
--- a/frontend/src/api-client/api.ts
+++ b/frontend/src/api-client/api.ts
@@ -741,11 +741,17 @@ export interface UserCreate {
      */
     'full_name': string;
     /**
-     * 
+     *
      * @type {string}
      * @memberof UserCreate
      */
     'default_pickup_address'?: string | null;
+    /**
+     *
+     * @type {string}
+     * @memberof UserCreate
+     */
+    'phone'?: string | null;
     /**
      * 
      * @type {string}
@@ -772,11 +778,17 @@ export interface UserRead {
      */
     'full_name': string;
     /**
-     * 
+     *
      * @type {string}
      * @memberof UserRead
      */
     'default_pickup_address'?: string | null;
+    /**
+     *
+     * @type {string}
+     * @memberof UserRead
+     */
+    'phone'?: string | null;
     /**
      * 
      * @type {string}
@@ -809,23 +821,29 @@ export interface UserUpdate {
      */
     'full_name'?: string | null;
     /**
-     * 
+     *
      * @type {string}
      * @memberof UserUpdate
      */
     'password'?: string | null;
     /**
-     * 
+     *
      * @type {string}
      * @memberof UserUpdate
      */
     'default_pickup_address'?: string | null;
     /**
-     * 
+     *
      * @type {string}
      * @memberof UserUpdate
      */
     'fcm_token'?: string | null;
+    /**
+     *
+     * @type {string}
+     * @memberof UserUpdate
+     */
+    'phone'?: string | null;
 }
 /**
  * 

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -15,7 +15,7 @@ import * as logger from "@/lib/logger";
 initTokensFromStorage();
 logger.debug("contexts/AuthContext", "tokens initialized from storage");
 
-type UserShape = { email?: string; full_name?: string; role?: string } | null;
+type UserShape = { email?: string; full_name?: string; role?: string; phone?: string } | null;
 
 type LoginResponse = {
   access_token?: string;
@@ -35,6 +35,7 @@ type AuthState = {
   userName: string | null;
   role: string | null;
   adminID: string | null;
+  phone: string | null;
 };
 // eslint-disable-next-line react-refresh/only-export-components
 export const AuthContext = createContext<AuthContextType | undefined>(undefined);
@@ -65,7 +66,7 @@ async function maybeSubscribePush() {
 }
 
 export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
-  const [state, setState] = useState<AuthState>({ accessToken: null, user: null, loading: true, userID: null, userName: null, role: null, adminID: null });
+  const [state, setState] = useState<AuthState>({ accessToken: null, user: null, loading: true, userID: null, userName: null, role: null, adminID: null, phone: null });
   // const [userName, setUserName] = useState<string>('');
   // const [userID, setUserID] = useState<string|null>(null);
 
@@ -77,6 +78,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     const storeduserName = localStorage.getItem("userName");
     const storedRole = localStorage.getItem("role");
     const storedAdminID = localStorage.getItem("adminID");
+    const storedPhone = localStorage.getItem("phone");
     if (raw) {
       try {
         const { access_token, refresh_token, user, role } = JSON.parse(raw);
@@ -89,6 +91,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
           userName: storeduserName ?? null,
           role: storedRole ?? user?.role ?? null,
           adminID: storedAdminID ?? null,
+          phone: storedPhone ?? null,
         });
         logger.debug("contexts/AuthContext", "tokens loaded from storage");
         if (role ?? storedRole) {
@@ -103,6 +106,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
       ...s,
       loading: false,
       adminID: storedAdminID ?? null,
+      phone: storedPhone ?? null,
     }));
   }, []);
 
@@ -147,6 +151,11 @@ useEffect(() => {
         } else {
           localStorage.removeItem("userName");
         }
+        if (data.phone) {
+          localStorage.setItem("phone", data.phone ?? "");
+        } else {
+          localStorage.removeItem("phone");
+        }
         if (data.id) {
           localStorage.setItem("userID", String(data.id));
         } else {
@@ -157,6 +166,7 @@ useEffect(() => {
         role: data.role ?? s.role,
         userName: data.full_name ?? s.userName,
         userID: data.id ? String(data.id) : s.userID,
+        phone: data.phone ?? s.phone,
       }));
       } catch (err) {
         logger.error(
@@ -307,6 +317,7 @@ useEffect(() => {
     localStorage.removeItem("userName");
     localStorage.removeItem("role");
     localStorage.removeItem("adminID");
+    localStorage.removeItem("phone");
     setState((s): AuthState => ({
       ...s,
       accessToken: null,
@@ -315,6 +326,7 @@ useEffect(() => {
       userName: null,
       role: null,
       adminID: null,
+      phone: null,
     }));
   }, [persist, setState]);
 

--- a/frontend/src/pages/Profile/ProfilePage.test.tsx
+++ b/frontend/src/pages/Profile/ProfilePage.test.tsx
@@ -45,6 +45,7 @@ describe('ProfilePage', () => {
           json: async () => ({
             full_name: 'John Doe',
             email: 'john@example.com',
+            phone: '111-2222',
             default_pickup_address: 'Old St',
           }),
         } as Response);
@@ -59,10 +60,13 @@ describe('ProfilePage', () => {
     render(<ProfilePage />);
 
     await screen.findByDisplayValue('John Doe');
+    await screen.findByDisplayValue('111-2222');
     await userEvent.clear(screen.getByLabelText(/full name/i));
     await userEvent.type(screen.getByLabelText(/full name/i), 'Jane Doe');
     await userEvent.clear(screen.getByLabelText(/email/i));
     await userEvent.type(screen.getByLabelText(/email/i), 'jane@example.com');
+    await userEvent.clear(screen.getByLabelText(/phone/i));
+    await userEvent.type(screen.getByLabelText(/phone/i), '999-8888');
     const addr = screen.getByLabelText(/default pickup address/i);
     await userEvent.clear(addr);
     await userEvent.type(addr, '123 New St');
@@ -88,6 +92,7 @@ describe('ProfilePage', () => {
     expect(JSON.parse(options.body as string)).toEqual({
       full_name: 'Jane Doe',
       email: 'jane@example.com',
+      phone: '999-8888',
       default_pickup_address: '123 New St',
       password: 'newpw',
     });
@@ -102,6 +107,7 @@ describe('ProfilePage', () => {
           json: async () => ({
             full_name: 'John Doe',
             email: 'john@example.com',
+            phone: '',
             default_pickup_address: '',
           }),
         } as Response),
@@ -129,6 +135,7 @@ describe('ProfilePage', () => {
           json: async () => ({
             full_name: 'John Doe',
             email: 'john@example.com',
+            phone: '',
             default_pickup_address: '',
           }),
         } as Response),

--- a/frontend/src/pages/Profile/ProfilePage.tsx
+++ b/frontend/src/pages/Profile/ProfilePage.tsx
@@ -11,6 +11,7 @@ const ProfilePage = () => {
   const { ensureFreshToken } = useAuth();
   const [fullName, setFullName] = useState('');
   const [email, setEmail] = useState('');
+  const [phone, setPhone] = useState('');
   const [defaultPickup, setDefaultPickup] = useState('');
   const [oldPassword, setOldPassword] = useState('');
   const [oldPasswordValid, setOldPasswordValid] = useState(false);
@@ -29,6 +30,7 @@ const ProfilePage = () => {
         const data = await res.json();
         setFullName(data.full_name || '');
         setEmail(data.email || '');
+        setPhone(data.phone || '');
         setDefaultPickup(data.default_pickup_address || '');
       }
     };
@@ -63,6 +65,7 @@ const ProfilePage = () => {
     const body: Record<string, unknown> = {
       full_name: fullName,
       email,
+      phone,
       default_pickup_address: defaultPickup,
     };
     if (newPassword && newPassword === confirmPassword && oldPasswordValid) {
@@ -94,6 +97,7 @@ const ProfilePage = () => {
       </Typography>
       <TextField label="Full Name" value={fullName} onChange={e => setFullName(e.target.value)} margin="normal" fullWidth />
       <TextField label="Email" value={email} onChange={e => setEmail(e.target.value)} margin="normal" fullWidth />
+      <TextField label="Phone" value={phone} onChange={e => setPhone(e.target.value)} margin="normal" fullWidth />
       <AddressField
         id="defaultPickup"
         label="Default Pickup Address"

--- a/frontend/src/types/AuthContextType.tsx
+++ b/frontend/src/types/AuthContextType.tsx
@@ -1,5 +1,5 @@
 // Type definitions for the authentication context values.
-export type UserShape = { email?: string; full_name?: string; role?: string } | null;
+export type UserShape = { email?: string; full_name?: string; role?: string; phone?: string } | null;
 
 export type AuthContextType = {
   accessToken: string | null;
@@ -10,6 +10,7 @@ export type AuthContextType = {
   userID: string | null;
   role: string | null;
   adminID: string | null;
+  phone: string | null;
 
   loginWithPassword: (email: string, password: string) => Promise<string | null>;
   registerWithPassword: (fullName: string, email: string, password: string) => Promise<void>;


### PR DESCRIPTION
## Summary
- include optional phone on AuthContext state and user types
- allow Profile page to edit and submit phone number
- cover phone field in user API types and tests

## Testing
- `npm run lint`
- `npm test src/pages/Profile/ProfilePage.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68b95494a84c833190a960f1c48d6e80