### PR TITLE
feat: manage user payment methods

### DIFF
--- a/backend/app/api/users.py
+++ b/backend/app/api/users.py
@@ -4,18 +4,24 @@ import logging
 import uuid
 from typing import List
 
+from fastapi import APIRouter, Depends, status
+from pydantic import BaseModel
+from sqlalchemy.ext.asyncio import AsyncSession
+
 from app.dependencies import get_current_user, get_db
 from app.models.user_v2 import User
+from app.schemas.api_booking import StripeSetupIntent
 from app.schemas.user import UserCreate, UserRead, UserUpdate
 from app.services.user_service import (
+    create_setup_intent_for_user,
     create_user,
     delete_user,
     get_user,
     list_users,
+    remove_payment_method,
+    save_payment_method,
     update_user,
 )
-from fastapi import APIRouter, Depends, status
-from sqlalchemy.ext.asyncio import AsyncSession
 
 logger = logging.getLogger(__name__)
 
@@ -100,3 +106,40 @@ async def api_delete_user(
         extra={"user_id": current_user.id, "target_user_id": user_id},
     )
     await delete_user(db, user_id)
+
+
+class PaymentMethodPayload(BaseModel):
+    payment_method_id: str
+
+
+@router.post("/me/payment-method", response_model=StripeSetupIntent)
+async def api_create_payment_method(
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """Return a SetupIntent client secret for the current user."""
+
+    client_secret = await create_setup_intent_for_user(db, current_user)
+    return StripeSetupIntent(setup_intent_client_secret=client_secret)
+
+
+@router.put("/me/payment-method", response_model=UserRead)
+async def api_save_payment_method(
+    data: PaymentMethodPayload,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """Persist a confirmed payment method to the user's profile."""
+
+    user = await save_payment_method(db, current_user, data.payment_method_id)
+    return user
+
+
+@router.delete("/me/payment-method", status_code=status.HTTP_204_NO_CONTENT)
+async def api_remove_payment_method(
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """Remove the saved payment method for the current user."""
+
+    await remove_payment_method(db, current_user)

--- a/backend/app/services/stripe_client.py
+++ b/backend/app/services/stripe_client.py
@@ -52,6 +52,10 @@ class _StubStripe:  # type: ignore
         def retrieve(payment_method):
             return _StubIntent(id=payment_method)
 
+        @staticmethod
+        def detach(payment_method):
+            return _StubIntent(id=payment_method)
+
 
 settings = get_settings()
 if settings.env == "test" or not settings.stripe_secret_key or real_stripe is None:
@@ -94,6 +98,12 @@ def set_default_payment_method(customer_id: str, payment_method: str) -> None:
         customer_id,
         invoice_settings={"default_payment_method": payment_method},
     )
+
+
+def detach_payment_method(payment_method: str) -> None:
+    """Detach a payment method from any customer."""
+
+    stripe.PaymentMethod.detach(payment_method)
 
 
 def charge_deposit(


### PR DESCRIPTION
## Summary
- add API endpoints for managing current user's Stripe payment method
- implement service helpers to create customers, save and remove payment methods
- extend Stripe client stub to detach payment methods

## Testing
- `npm run lint`
- `pytest tests/unit -q --maxfail=1 --disable-warnings` (fails: Multiple head revisions are present for given argument 'head')

------
https://chatgpt.com/codex/tasks/task_e_68b957458ed0833191cf2329e79109f3