### PR TITLE
feat: capture phone numbers on user profiles

### DIFF
--- a/backend/alembic/versions/c9a2f3e1d4b5_add_phone_to_users_v2.py
+++ b/backend/alembic/versions/c9a2f3e1d4b5_add_phone_to_users_v2.py
@@ -1,4 +1,4 @@
-"""add phone to users_v2
+"""add nullable phone to users_v2
 
 Revision ID: c9a2f3e1d4b5
 Revises: 13b1cf856965
@@ -6,6 +6,7 @@ Create Date: 2025-02-15 00:00:00.000000
 """
 
 import sqlalchemy as sa
+
 from alembic import op
 
 # revision identifiers, used by Alembic.

--- a/backend/alembic/versions/fa3de645ec11_add_stripe_ids_to_users_v2.py
+++ b/backend/alembic/versions/fa3de645ec11_add_stripe_ids_to_users_v2.py
@@ -1,16 +1,17 @@
 """add stripe identifiers to users_v2
 
 Revision ID: fa3de645ec11
-Revises: 13b1cf856965
+Revises: c9a2f3e1d4b5
 Create Date: 2025-09-02 13:00:00.000000
 """
 
 import sqlalchemy as sa
+
 from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "fa3de645ec11"
-down_revision = "13b1cf856965"
+down_revision = "c9a2f3e1d4b5"
 branch_labels = None
 depends_on = None
 

--- a/backend/app/api/users.py
+++ b/backend/app/api/users.py
@@ -1,8 +1,11 @@
-"""User management API routes."""
+"""User management API routes, including phone support."""
 
 import logging
 import uuid
 from typing import List
+
+from fastapi import APIRouter, Depends, status
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.dependencies import get_current_user, get_db
 from app.models.user_v2 import User
@@ -14,8 +17,6 @@ from app.services.user_service import (
     list_users,
     update_user,
 )
-from fastapi import APIRouter, Depends, status
-from sqlalchemy.ext.asyncio import AsyncSession
 
 logger = logging.getLogger(__name__)
 

--- a/backend/app/models/user_v2.py
+++ b/backend/app/models/user_v2.py
@@ -3,10 +3,11 @@ import uuid
 from datetime import datetime
 from typing import Optional
 
-from app.db.database import Base
 from sqlalchemy import UUID, DateTime, Enum, String, Text
 from sqlalchemy.orm import Mapped, mapped_column
 from sqlalchemy.sql import func
+
+from app.db.database import Base
 
 
 class UserRole(str, enum.Enum):
@@ -27,7 +28,9 @@ class User(Base):
     email: Mapped[str] = mapped_column(String, unique=True, index=True)
     full_name: Mapped[str] = mapped_column(String)
     hashed_password: Mapped[str] = mapped_column(Text, name="password_hash")
-    phone: Mapped[Optional[str]] = mapped_column(String, nullable=True)
+    phone: Mapped[Optional[str]] = mapped_column(
+        String, nullable=True
+    )  # Optional contact number
     role: Mapped[UserRole] = mapped_column(Enum(UserRole), default=UserRole.CUSTOMER)
     fcm_token: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
     stripe_customer_id: Mapped[Optional[str]] = mapped_column(String, nullable=True)

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -12,7 +12,7 @@ class UserBase(BaseModel):
     email: EmailStr
     full_name: str
     default_pickup_address: Optional[str] = None
-    phone: Optional[str] = None
+    phone: Optional[str] = None  # Optional contact number
 
 
 class UserCreate(UserBase):

--- a/backend/app/schemas/user_v2.py
+++ b/backend/app/schemas/user_v2.py
@@ -4,8 +4,9 @@ import uuid
 from datetime import datetime
 from typing import Optional
 
-from app.models.user_v2 import UserRole
 from pydantic import BaseModel, EmailStr
+
+from app.models.user_v2 import UserRole
 
 
 class UserBase(BaseModel):
@@ -16,7 +17,7 @@ class UserBase(BaseModel):
 
 
 class UserCreate(UserBase):
-    pass
+    password: str
 
 
 class UserRead(UserBase):
@@ -26,3 +27,18 @@ class UserRead(UserBase):
 
     class Config:
         from_attributes = True
+
+
+class UserUpdate(BaseModel):
+    email: Optional[EmailStr] = None
+    full_name: Optional[str] = None
+    password: Optional[str] = None
+    phone: Optional[str] = None
+    role: Optional[UserRole] = None
+    fcm_token: Optional[str] = None
+    stripe_customer_id: Optional[str] = None
+    stripe_payment_method_id: Optional[str] = None
+
+    class Config:
+        from_attributes = True
+        extra = "ignore"

--- a/backend/app/services/user_service.py
+++ b/backend/app/services/user_service.py
@@ -6,12 +6,13 @@ import logging
 import uuid
 from typing import Optional
 
-from app.core.security import hash_password
-from app.models.user_v2 import User
-from app.schemas.user import UserCreate, UserRead, UserUpdate
 from fastapi import HTTPException, status
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.security import hash_password
+from app.models.user_v2 import User
+from app.schemas.user import UserCreate, UserRead, UserUpdate
 
 logger = logging.getLogger(__name__)
 
@@ -38,7 +39,7 @@ async def create_user(db: AsyncSession, data: UserCreate) -> UserRead:
         email=data.email,
         full_name=data.full_name,
         hashed_password=hash_password(data.password),
-        phone=data.phone,
+        phone=data.phone,  # Store phone when provided
     )
     db.add(user)
     await db.flush()

--- a/frontend/src/api-client/api.ts
+++ b/frontend/src/api-client/api.ts
@@ -747,6 +747,12 @@ export interface UserCreate {
      */
     'default_pickup_address'?: string | null;
     /**
+     *
+     * @type {string}
+     * @memberof UserCreate
+     */
+    'phone'?: string | null;
+    /**
      * 
      * @type {string}
      * @memberof UserCreate
@@ -777,6 +783,12 @@ export interface UserRead {
      * @memberof UserRead
      */
     'default_pickup_address'?: string | null;
+    /**
+     *
+     * @type {string}
+     * @memberof UserRead
+     */
+    'phone'?: string | null;
     /**
      * 
      * @type {string}
@@ -821,11 +833,17 @@ export interface UserUpdate {
      */
     'default_pickup_address'?: string | null;
     /**
-     * 
+     *
      * @type {string}
      * @memberof UserUpdate
      */
     'fcm_token'?: string | null;
+    /**
+     *
+     * @type {string}
+     * @memberof UserUpdate
+     */
+    'phone'?: string | null;
 }
 /**
  * 

--- a/frontend/src/pages/Profile/ProfilePage.tsx
+++ b/frontend/src/pages/Profile/ProfilePage.tsx
@@ -11,6 +11,7 @@ const ProfilePage = () => {
   const { ensureFreshToken } = useAuth();
   const [fullName, setFullName] = useState('');
   const [email, setEmail] = useState('');
+  const [phone, setPhone] = useState('');
   const [defaultPickup, setDefaultPickup] = useState('');
   const [oldPassword, setOldPassword] = useState('');
   const [oldPasswordValid, setOldPasswordValid] = useState(false);
@@ -29,6 +30,7 @@ const ProfilePage = () => {
         const data = await res.json();
         setFullName(data.full_name || '');
         setEmail(data.email || '');
+        setPhone(data.phone || '');
         setDefaultPickup(data.default_pickup_address || '');
       }
     };
@@ -65,6 +67,9 @@ const ProfilePage = () => {
       email,
       default_pickup_address: defaultPickup,
     };
+    if (phone) {
+      body.phone = phone;
+    }
     if (newPassword && newPassword === confirmPassword && oldPasswordValid) {
       body.password = newPassword;
     }
@@ -94,6 +99,7 @@ const ProfilePage = () => {
       </Typography>
       <TextField label="Full Name" value={fullName} onChange={e => setFullName(e.target.value)} margin="normal" fullWidth />
       <TextField label="Email" value={email} onChange={e => setEmail(e.target.value)} margin="normal" fullWidth />
+      <TextField label="Phone" value={phone} onChange={e => setPhone(e.target.value)} margin="normal" fullWidth />
       <AddressField
         id="defaultPickup"
         label="Default Pickup Address"


### PR DESCRIPTION
## Summary
- add nullable phone column to user schema and database
- allow API and services to persist phone
- surface phone field in profile page and API client types

## Testing
- `npm run lint`
- `cd backend && pytest -q --maxfail=1 --disable-warnings`
- `cd frontend && npm test ProfilePage`


------
https://chatgpt.com/codex/tasks/task_e_68b95558eddc8331a6887a406d3cf515