### PR TITLE
feat: handle saved payment methods

### DIFF
--- a/frontend/src/components/BookingWizard/PaymentStep.test.tsx
+++ b/frontend/src/components/BookingWizard/PaymentStep.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
-import { vi, expect, test } from 'vitest';
+import { vi, expect, test, beforeEach } from 'vitest';
 import { DevFeaturesProvider } from '@/contexts/DevFeaturesContext';
 import PaymentStep from './PaymentStep';
 
@@ -9,12 +9,16 @@ const mockCreateBooking = vi.fn().mockResolvedValue({
   booking: { public_code: 'ABC123' },
   clientSecret: 'sec',
 });
-const mockConfirm = vi.fn().mockResolvedValue({});
+const mockConfirm = vi
+  .fn()
+  .mockResolvedValue({ setupIntent: { payment_method: 'pm_123' } });
 const mockCard = {};
 const mockGetMetrics = vi.fn().mockResolvedValue(null);
+const mockSavePaymentMethod = vi.fn();
+const mockUseStripeSetupIntent = vi.fn();
 
 vi.mock('@/hooks/useStripeSetupIntent', () => ({
-  useStripeSetupIntent: () => ({ createBooking: mockCreateBooking, loading: false }),
+  useStripeSetupIntent: () => mockUseStripeSetupIntent(),
 }));
 vi.mock('@/hooks/useSettings', () => ({
   useSettings: () => ({ data: {} }),
@@ -32,7 +36,20 @@ vi.mock('@stripe/stripe-js', () => ({
   loadStripe: () => Promise.resolve(null),
 }));
 
-test('shows tracking link after booking', async () => {
+beforeEach(() => {
+  mockCreateBooking.mockClear();
+  mockConfirm.mockClear();
+  mockSavePaymentMethod.mockClear();
+  mockGetMetrics.mockClear();
+  mockUseStripeSetupIntent.mockReturnValue({
+    createBooking: mockCreateBooking,
+    savePaymentMethod: mockSavePaymentMethod,
+    savedPaymentMethod: null,
+    loading: false,
+  });
+});
+
+test('handles new card flow', async () => {
   render(
     <MemoryRouter>
       <DevFeaturesProvider>
@@ -57,6 +74,47 @@ test('shows tracking link after booking', async () => {
   expect(mockCreateBooking).toHaveBeenCalledWith(
     expect.objectContaining({ pickup_when: '2025-01-01T00:00:00Z' }),
   );
+  expect(mockConfirm).toHaveBeenCalledWith('sec', {
+    payment_method: { card: mockCard },
+  });
+  expect(mockSavePaymentMethod).toHaveBeenCalledWith('pm_123');
+  const link = await screen.findByRole('link', { name: /track this ride/i });
+  expect(link).toHaveAttribute('href', '/t/ABC123');
+});
+
+test('uses saved card when available', async () => {
+  mockUseStripeSetupIntent.mockReturnValue({
+    createBooking: mockCreateBooking,
+    savePaymentMethod: mockSavePaymentMethod,
+    savedPaymentMethod: { brand: 'visa', last4: '4242' },
+    loading: false,
+  });
+
+  render(
+    <MemoryRouter>
+      <DevFeaturesProvider>
+        <PaymentStep
+          data={{
+            pickup_when: '2025-01-01T00:00:00Z',
+            pickup: { address: 'A', lat: 0, lng: 0 },
+            dropoff: { address: 'B', lat: 1, lng: 1 },
+            passengers: 1,
+            notes: '',
+            customer: { name: '', email: '', phone: '' },
+            pickupValid: true,
+            dropoffValid: true,
+          }}
+          onBack={() => {}}
+        />
+      </DevFeaturesProvider>
+    </MemoryRouter>,
+  );
+
+  expect(screen.queryByTestId('card')).not.toBeInTheDocument();
+  await userEvent.click(screen.getByRole('button', { name: /submit/i }));
+  expect(mockCreateBooking).toHaveBeenCalled();
+  expect(mockConfirm).not.toHaveBeenCalled();
+  expect(mockSavePaymentMethod).not.toHaveBeenCalled();
   const link = await screen.findByRole('link', { name: /track this ride/i });
   expect(link).toHaveAttribute('href', '/t/ABC123');
 });


### PR DESCRIPTION
## Summary
- fetch existing payment methods and allow saving new ones
- show saved card in payment step and skip card entry
- add tests for saved vs new card flows

## Testing
- `npm run lint`
- `pytest -q --maxfail=1 --disable-warnings` *(fails: Multiple head revisions are present for given argument 'head')*
- `npm test PaymentStep.test.tsx useStripeSetupIntent.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b958b493b08331a4e0ab6cd443842f