### PR TITLE
feat: prefill phone from auth

### DIFF
--- a/frontend/src/components/BookingWizard/BookingWizard.tsx
+++ b/frontend/src/components/BookingWizard/BookingWizard.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { Stepper, Step, StepLabel, Box } from '@mui/material';
 import SelectTimeStep from './SelectTimeStep';
 import TripDetailsStep from './TripDetailsStep';
@@ -6,18 +6,35 @@ import PaymentStep from './PaymentStep';
 import { MapProvider } from '@/components/MapProvider';
 import { MapRoute } from '@/components/MapRoute';
 import { BookingFormData } from '@/types/BookingFormData';
+import { useAuth } from '@/contexts/AuthContext';
 
 const steps = ['Select time', 'Trip details', 'Payment'];
 
 export default function BookingWizard() {
+  const { userName, user, phone } = useAuth();
   const [active, setActive] = useState(0);
   const [form, setForm] = useState<BookingFormData>({
     passengers: 1,
     notes: '',
-    customer: {},
+    customer: {
+      name: userName ?? undefined,
+      email: user?.email ?? undefined,
+      phone: phone ?? user?.phone ?? undefined,
+    },
     pickupValid: false,
     dropoffValid: false,
   });
+  useEffect(() => {
+    setForm((f) => ({
+      ...f,
+      customer: {
+        ...f.customer,
+        name: userName ?? undefined,
+        email: user?.email ?? undefined,
+        phone: phone ?? user?.phone ?? undefined,
+      },
+    }));
+  }, [userName, user?.email, phone, user?.phone]);
   const update = (data: Partial<BookingFormData>) => {
     setForm((f) => ({ ...f, ...data }));
   };

--- a/frontend/src/components/BookingWizard/PaymentStep.test.tsx
+++ b/frontend/src/components/BookingWizard/PaymentStep.test.tsx
@@ -43,7 +43,7 @@ test('shows tracking link after booking', async () => {
             dropoff: { address: 'B', lat: 1, lng: 1 },
             passengers: 1,
             notes: '',
-            customer: { name: '', email: '', phone: '' },
+            customer: { name: '', email: '', phone: '123' },
             pickupValid: true,
             dropoffValid: true,
           }}
@@ -53,9 +53,14 @@ test('shows tracking link after booking', async () => {
     </MemoryRouter>,
   );
 
+  const phoneField = screen.getByLabelText(/phone/i);
+  expect(phoneField).toHaveAttribute('readonly');
   await userEvent.click(screen.getByRole('button', { name: /submit/i }));
   expect(mockCreateBooking).toHaveBeenCalledWith(
-    expect.objectContaining({ pickup_when: '2025-01-01T00:00:00Z' }),
+    expect.objectContaining({
+      pickup_when: '2025-01-01T00:00:00Z',
+      customer: { name: '', email: '', phone: '123' },
+    }),
   );
   const link = await screen.findByRole('link', { name: /track this ride/i });
   expect(link).toHaveAttribute('href', '/t/ABC123');
@@ -73,7 +78,7 @@ test('updates metrics from route service', async () => {
             dropoff: { address: 'B', lat: 1, lng: 1 },
             passengers: 1,
             notes: '',
-            customer: { name: '', email: '', phone: '' },
+            customer: { name: '', email: '', phone: '123' },
             pickupValid: true,
             dropoffValid: true,
           }}
@@ -100,7 +105,7 @@ test('renders fare breakdown when dev features enabled', () => {
             dropoff: { address: 'B', lat: 1, lng: 1 },
             passengers: 1,
             notes: '',
-            customer: { name: '', email: '', phone: '' },
+            customer: { name: '', email: '', phone: '123' },
             pickupValid: true,
             dropoffValid: true,
           }}
@@ -126,7 +131,7 @@ test('hides fare breakdown when dev features disabled', () => {
             dropoff: { address: 'B', lat: 1, lng: 1 },
             passengers: 1,
             notes: '',
-            customer: { name: '', email: '', phone: '' },
+            customer: { name: '', email: '', phone: '123' },
             pickupValid: true,
             dropoffValid: true,
           }}

--- a/frontend/src/components/BookingWizard/PaymentStep.tsx
+++ b/frontend/src/components/BookingWizard/PaymentStep.tsx
@@ -116,7 +116,7 @@ function PaymentInner({ data, onBack }: Props) {
   ]);
   const [name, setName] = useState(data.customer?.name || '');
   const [email, setEmail] = useState(data.customer?.email || '');
-  const [phone, setPhone] = useState(data.customer?.phone || '');
+  const phone = data.customer?.phone;
   const [booking, setBooking] = useState<{ public_code: string } | null>(null);
 
   async function handleSubmit() {
@@ -180,7 +180,7 @@ function PaymentInner({ data, onBack }: Props) {
     <Stack spacing={2}>
       <TextField label="Name" value={name} onChange={(e) => setName(e.target.value)} />
       <TextField label="Email" value={email} onChange={(e) => setEmail(e.target.value)} />
-      <TextField label="Phone" value={phone} onChange={(e) => setPhone(e.target.value)} />
+      <TextField label="Phone" value={phone ?? ''} InputProps={{ readOnly: true }} />
       {price != null && (
         <Typography>Estimated fare: ${price.toFixed(2)}</Typography>
       )}

--- a/frontend/src/pages/Booking/BookingWizardPage.test.tsx
+++ b/frontend/src/pages/Booking/BookingWizardPage.test.tsx
@@ -54,6 +54,7 @@ beforeAll(() => {
 });
 
 test('advances through steps and aggregates form data', async () => {
+  localStorage.setItem('phone', '000');
   renderWithProviders(<BookingWizardPage />);
   const input = (re: RegExp) => screen.getByLabelText(re, { selector: 'input' });
 
@@ -83,6 +84,7 @@ test('advances through steps and aggregates form data', async () => {
     dropoff: { address: '456 B St', lat: 0, lng: 0 },
     passengers: 2,
     notes: 'Be quick',
-    customer: { name: 'John Doe', email: 'john@example.com', phone: '' },
+    customer: { name: 'John Doe', email: 'john@example.com', phone: '000' },
   });
+  localStorage.clear();
 });


### PR DESCRIPTION
## Summary
- prefill booking wizard customer data from authenticated user
- make phone field read-only in payment step and auto-submit profile number
- update tests and e2e specs for auto-filled phone behavior

## Testing
- `npm run lint`
- `npx vitest run src/components/BookingWizard/PaymentStep.test.tsx src/pages/Booking/BookingWizardPage.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b956cc330c833194e61199102d539c