### PR TITLE
feat: add Google Pay support

### DIFF
--- a/frontend/src/components/BookingWizard/PaymentStep.test.tsx
+++ b/frontend/src/components/BookingWizard/PaymentStep.test.tsx
@@ -16,6 +16,16 @@ const mockCard = {};
 const mockGetMetrics = vi.fn().mockResolvedValue(null);
 const mockSavePaymentMethod = vi.fn();
 const mockUseStripeSetupIntent = vi.fn();
+const mockCanMakePayment = vi.fn().mockResolvedValue(null);
+const mockShow = vi.fn();
+const mockPaymentRequest = {
+  canMakePayment: mockCanMakePayment,
+  show: mockShow,
+};
+const mockStripe = {
+  confirmCardSetup: mockConfirm,
+  paymentRequest: vi.fn(() => mockPaymentRequest),
+};
 
 vi.mock('@/hooks/useStripeSetupIntent', () => ({
   useStripeSetupIntent: () => mockUseStripeSetupIntent(),
@@ -29,7 +39,12 @@ vi.mock('@/hooks/useRouteMetrics', () => ({
 vi.mock('@stripe/react-stripe-js', () => ({
   Elements: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
   CardElement: () => <div data-testid="card" />,
-  useStripe: () => ({ confirmCardSetup: mockConfirm }),
+  PaymentRequestButtonElement: ({
+    onClick,
+  }: {
+    onClick: () => void;
+  }) => <button data-testid="google-pay" onClick={onClick} />,
+  useStripe: () => mockStripe,
   useElements: () => ({ getElement: () => mockCard }),
 }));
 vi.mock('@stripe/stripe-js', () => ({
@@ -41,6 +56,9 @@ beforeEach(() => {
   mockConfirm.mockClear();
   mockSavePaymentMethod.mockClear();
   mockGetMetrics.mockClear();
+  mockCanMakePayment.mockClear();
+  mockShow.mockClear();
+  mockStripe.paymentRequest.mockClear();
   mockUseStripeSetupIntent.mockReturnValue({
     createBooking: mockCreateBooking,
     savePaymentMethod: mockSavePaymentMethod,
@@ -77,6 +95,42 @@ test('handles new card flow', async () => {
   expect(mockConfirm).toHaveBeenCalledWith('sec', {
     payment_method: { card: mockCard },
   });
+  expect(mockSavePaymentMethod).toHaveBeenCalledWith('pm_123');
+  const link = await screen.findByRole('link', { name: /track this ride/i });
+  expect(link).toHaveAttribute('href', '/t/ABC123');
+});
+
+test('handles google pay flow', async () => {
+  mockCanMakePayment.mockResolvedValueOnce({ googlePay: true });
+  mockShow.mockResolvedValueOnce({ token: { id: 'tok_123' }, complete: vi.fn() });
+
+  render(
+    <MemoryRouter>
+      <DevFeaturesProvider>
+        <PaymentStep
+          data={{
+            pickup_when: '2025-01-01T00:00:00Z',
+            pickup: { address: 'A', lat: 0, lng: 0 },
+            dropoff: { address: 'B', lat: 1, lng: 1 },
+            passengers: 1,
+            notes: '',
+            customer: { name: '', email: '', phone: '' },
+            pickupValid: true,
+            dropoffValid: true,
+          }}
+          onBack={() => {}}
+        />
+      </DevFeaturesProvider>
+    </MemoryRouter>,
+  );
+
+  const gpButton = await screen.findByTestId('google-pay');
+  await userEvent.click(gpButton);
+
+  expect(mockStripe.paymentRequest).toHaveBeenCalled();
+  expect(mockCreateBooking).toHaveBeenCalled();
+  expect(mockShow).toHaveBeenCalled();
+  expect(mockConfirm).toHaveBeenCalledWith('sec', { payment_method: 'tok_123' });
   expect(mockSavePaymentMethod).toHaveBeenCalledWith('pm_123');
   const link = await screen.findByRole('link', { name: /track this ride/i });
   expect(link).toHaveAttribute('href', '/t/ABC123');

--- a/frontend/src/components/BookingWizard/PaymentStep.tsx
+++ b/frontend/src/components/BookingWizard/PaymentStep.tsx
@@ -2,10 +2,15 @@ import { Stack, TextField, Button, Typography } from '@mui/material';
 import {
   Elements,
   CardElement,
+  PaymentRequestButtonElement,
   useStripe,
   useElements,
 } from '@stripe/react-stripe-js';
-import { loadStripe } from '@stripe/stripe-js';
+import {
+  loadStripe,
+  PaymentRequest as StripePaymentRequest,
+  PaymentRequestCanMakePaymentResult,
+} from '@stripe/stripe-js';
 import { useState, useEffect } from 'react';
 import { Link as RouterLink } from 'react-router-dom';
 import { useStripeSetupIntent } from '@/hooks/useStripeSetupIntent';
@@ -58,6 +63,8 @@ function PaymentInner({ data, onBack }: Props) {
   const [price, setPrice] = useState<number | null>(null);
   const [distanceKm, setDistanceKm] = useState<number>(0);
   const [durationMin, setDurationMin] = useState<number>(0);
+  const [paymentRequest, setPaymentRequest] =
+    useState<StripePaymentRequest | null>(null);
 
   useEffect(() => {
     let ignore = false;
@@ -119,6 +126,82 @@ function PaymentInner({ data, onBack }: Props) {
   const [email, setEmail] = useState(data.customer?.email || '');
   const [phone, setPhone] = useState(data.customer?.phone || '');
   const [booking, setBooking] = useState<{ public_code: string } | null>(null);
+
+  useEffect(() => {
+    async function initPaymentRequest() {
+      if (!stripe || savedPaymentMethod) return;
+      const pr = stripe.paymentRequest({
+        country: 'US',
+        currency: 'usd',
+        total: { label: 'Deposit', amount: 0 },
+        requestPayerName: true,
+        requestPayerEmail: true,
+        requestPayerPhone: true,
+      });
+      const result = (await pr.canMakePayment()) as
+        | PaymentRequestCanMakePaymentResult
+        | null;
+      if (result?.googlePay) {
+        setPaymentRequest(pr);
+      }
+    }
+    initPaymentRequest();
+  }, [stripe, savedPaymentMethod]);
+
+  async function handleGooglePay() {
+    const payload = {
+      pickup_when: data.pickup_when,
+      pickup: data.pickup,
+      dropoff: data.dropoff,
+      passengers: data.passengers,
+      notes: data.notes,
+      customer: { name, email, phone },
+    };
+    logger.info(
+      'components/BookingWizard/PaymentStep',
+      'Submitting booking with Google Pay',
+      payload,
+    );
+    const res = await createBooking(payload);
+    if (!stripe || !paymentRequest) {
+      logger.warn(
+        'components/BookingWizard/PaymentStep',
+        'Stripe or payment request not ready',
+      );
+      return;
+    }
+    if (res.clientSecret) {
+      const tokenRes = (await paymentRequest.show()) as {
+        token?: { id: string };
+        complete: (status: string) => Promise<void>;
+      };
+      const token = tokenRes.token?.id;
+      if (token) {
+        const setup = await stripe.confirmCardSetup(res.clientSecret, {
+          payment_method: token,
+        });
+        const pm = setup?.setupIntent?.payment_method;
+        if (pm) {
+          await savePaymentMethod(pm as string);
+        }
+        if (typeof tokenRes.complete === 'function') {
+          await tokenRes.complete('success');
+        }
+        setBooking(res.booking);
+        logger.info(
+          'components/BookingWizard/PaymentStep',
+          'Booking confirmed via Google Pay',
+          res.booking,
+        );
+      }
+    } else {
+      logger.error(
+        'components/BookingWizard/PaymentStep',
+        'Booking creation failed',
+        res,
+      );
+    }
+  }
 
   async function handleSubmit() {
     const payload = {
@@ -206,6 +289,12 @@ function PaymentInner({ data, onBack }: Props) {
         50% deposit{price != null ? ` ($${(price * 0.5).toFixed(2)})` : ''} charged on
         confirmation
       </Typography>
+      {paymentRequest && !savedPaymentMethod && (
+        <PaymentRequestButtonElement
+          options={{ paymentRequest }}
+          onClick={handleGooglePay}
+        />
+      )}
       {savedPaymentMethod ? (
         <Typography>
           Using saved card {savedPaymentMethod.brand} ending in {savedPaymentMethod.last4}


### PR DESCRIPTION
## Summary
- show Google Pay button when supported using Stripe Payment Request API
- handle Google Pay tokenization and card setup
- test Google Pay flow and existing card workflows

## Testing
- `npm run lint`
- `npm test -- --run src/components/BookingWizard/PaymentStep.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b95bfa148883318212671dd0a246ed