### PR TITLE
feat: expose phone in auth context

### DIFF
--- a/frontend/src/__tests__/AccessControl.test.tsx
+++ b/frontend/src/__tests__/AccessControl.test.tsx
@@ -20,6 +20,7 @@ const baseAuth: AuthContextType = {
   userID: null,
   role: null,
   adminID: CONFIG.ADMIN_USER_ID,
+  phone: null,
   loginWithPassword: vi.fn(),
   registerWithPassword: vi.fn(),
   loginWithOAuth: vi.fn(),

--- a/frontend/src/components/BookingWizard/PaymentStep.test.tsx
+++ b/frontend/src/components/BookingWizard/PaymentStep.test.tsx
@@ -82,7 +82,11 @@ test('handles new card flow', async () => {
   expect(mockCreateBooking).toHaveBeenCalledWith(
     expect.objectContaining({
       pickup_when: '2025-01-01T00:00:00Z',
-      customer: { name: '', email: '', phone: '123' },
+      customer: {
+        name: 'Test User',
+        email: 'test@example.com',
+        phone: '123',
+      },
     }),
   );
   expect(mockConfirm).toHaveBeenCalledWith('sec', {

--- a/frontend/src/components/BookingWizard/PaymentStep.tsx
+++ b/frontend/src/components/BookingWizard/PaymentStep.tsx
@@ -150,6 +150,13 @@ function PaymentInner({ data, onBack }: Props) {
       dropoff: data.dropoff,
       passengers: data.passengers,
       notes: data.notes,
+      customer: profile
+        ? {
+            name: profile.full_name ?? '',
+            email: profile.email ?? '',
+            phone: profile.phone ?? '',
+          }
+        : undefined,
     };
     logger.info(
       'components/BookingWizard/PaymentStep',

--- a/frontend/src/hooks/useStripeSetupIntent.ts
+++ b/frontend/src/hooks/useStripeSetupIntent.ts
@@ -8,6 +8,7 @@ interface CreateBookingData {
   dropoff: { address: string; lat: number; lng: number };
   passengers: number;
   notes?: string;
+  customer?: { name: string; email: string; phone: string };
 }
 
 interface SavedPaymentMethod {

--- a/frontend/src/types/AuthContextType.tsx
+++ b/frontend/src/types/AuthContextType.tsx
@@ -1,5 +1,11 @@
 // Type definitions for the authentication context values.
-export type UserShape = { email?: string; full_name?: string; role?: string; phone?: string } | null;
+export type UserShape = {
+  id?: number;
+  email?: string;
+  full_name?: string;
+  role?: string;
+  phone?: string;
+};
 
 export type AuthContextType = {
   accessToken: string | null;


### PR DESCRIPTION
## Summary
- add phone and id to `UserShape` and expose through auth context
- fetch `/users/me` to populate profile fields and persist them
- include customer contact details when creating bookings

## Testing
- `npm run lint`
- `pytest -q --maxfail=1 --disable-warnings`
- `npm test src/components/BookingWizard/PaymentStep.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b963d703148331994d9b45cd29d3c5