### PR TITLE
feat: capture phone and payment method on registration

### DIFF
--- a/backend/app/schemas/auth.py
+++ b/backend/app/schemas/auth.py
@@ -2,6 +2,7 @@
 """Pydantic schemas for authentication endpoints."""
 
 import uuid
+from typing import Optional
 
 from pydantic import BaseModel, ConfigDict, EmailStr
 
@@ -39,6 +40,8 @@ class RegisterRequest(BaseModel):
     email: EmailStr
     full_name: str
     password: str
+    phone: Optional[str] = None
+    stripe_payment_method_id: Optional[str] = None
 
 
 class TokenResponse(BaseModel):

--- a/backend/app/services/auth_service.py
+++ b/backend/app/services/auth_service.py
@@ -2,15 +2,16 @@
 
 import logging
 
+from fastapi import Depends, HTTPException, status
+from fastapi.security import OAuth2PasswordRequestForm
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
 from app.core.security import create_jwt_token, hash_password, verify_password
 from app.dependencies import get_db
 from app.models.user_v2 import User as UserV2  # <- ORM model
 from app.schemas.auth import LoginRequest, LoginResponse, RegisterRequest
 from app.schemas.user import UserRead  # <- your output schema
-from fastapi import Depends, HTTPException, status
-from fastapi.security import OAuth2PasswordRequestForm
-from sqlalchemy import select
-from sqlalchemy.ext.asyncio import AsyncSession
 
 logger = logging.getLogger(__name__)
 
@@ -53,6 +54,8 @@ async def register_user(db: AsyncSession, data: RegisterRequest) -> UserRead:
         email=data.email,
         full_name=data.full_name,
         hashed_password=hash_password(data.password),
+        phone=data.phone,
+        stripe_payment_method_id=data.stripe_payment_method_id,
     )
 
     # Persist to database

--- a/backend/tests/unit/services/test_auth_service.py
+++ b/backend/tests/unit/services/test_auth_service.py
@@ -1,11 +1,12 @@
 import pytest
+from fastapi import HTTPException
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
 from app.core.security import hash_password, verify_password
 from app.models.user_v2 import User
 from app.schemas.auth import LoginRequest, RegisterRequest
 from app.services import auth_service
-from fastapi import HTTPException
-from sqlalchemy import select
-from sqlalchemy.ext.asyncio import AsyncSession
 
 
 @pytest.mark.asyncio
@@ -58,7 +59,11 @@ async def test_authenticate_user_not_found(async_session: AsyncSession):
 @pytest.mark.asyncio
 async def test_register_user_success(async_session: AsyncSession):
     register_req = RegisterRequest(
-        email="new@async.com", full_name="New Async", password="newpass"
+        email="new@async.com",
+        full_name="New Async",
+        password="newpass",
+        phone="555-1234",
+        stripe_payment_method_id="pm_123",
     )
     result = await auth_service.register_user(async_session, register_req)
     # Should return a UserRead schema for the new user
@@ -78,6 +83,8 @@ async def test_register_user_success(async_session: AsyncSession):
     assert new_user is not None
     # Password should be stored hashed
     assert verify_password("newpass", new_user.hashed_password)
+    assert new_user.phone == "555-1234"
+    assert new_user.stripe_payment_method_id == "pm_123"
 
 
 @pytest.mark.asyncio

--- a/frontend/src/__tests__/setup/msw.handlers.ts
+++ b/frontend/src/__tests__/setup/msw.handlers.ts
@@ -3,7 +3,13 @@ import { http, HttpResponse } from "msw";
 import { CONFIG } from "@/config"
 
 type LoginBody = { email: string; password: string };
-type RegisterBody = { full_name: string; email: string; password: string };
+type RegisterBody = {
+  full_name: string;
+  email: string;
+  password: string;
+  phone?: string;
+  stripe_payment_method_id?: string;
+};
 type SettingsBody = {
   account_mode: boolean;
   flagfall: number;

--- a/frontend/src/api-client/api.ts
+++ b/frontend/src/api-client/api.ts
@@ -590,6 +590,18 @@ export interface RegisterRequest {
      * @memberof RegisterRequest
      */
     'password': string;
+    /**
+     *
+     * @type {string}
+     * @memberof RegisterRequest
+     */
+    'phone'?: string;
+    /**
+     *
+     * @type {string}
+     * @memberof RegisterRequest
+     */
+    'stripe_payment_method_id'?: string;
 }
 /**
  * 

--- a/frontend/src/pages/Auth/RegisterPage.tsx
+++ b/frontend/src/pages/Auth/RegisterPage.tsx
@@ -20,6 +20,8 @@ function RegisterPage() {
     const [email, setEmail] = useState("");
     const [full_name, setName] = useState("");
     const [password, setPassword] = useState("");
+    const [phone, setPhone] = useState("");
+    const [paymentMethodId, setPaymentMethodId] = useState("");
     const [error, setError] = useState("");
     const { loginWithPassword } = useAuth();
     const navigate = useNavigate();
@@ -33,6 +35,9 @@ function RegisterPage() {
             full_name,
             password,
         };
+        if (phone) registerRequest.phone = phone;
+        if (paymentMethodId)
+            registerRequest.stripe_payment_method_id = paymentMethodId;
 
         try {
             // Register the user
@@ -108,6 +113,22 @@ function RegisterPage() {
               onChange={(e) => setPassword(e.target.value)}
               fullWidth
               required
+              margin="normal"
+            />
+            <TextField
+              label="Phone"
+              type="tel"
+              value={phone}
+              onChange={(e) => setPhone(e.target.value)}
+              fullWidth
+              margin="normal"
+            />
+            <TextField
+              label="Default Payment Method ID"
+              type="text"
+              value={paymentMethodId}
+              onChange={(e) => setPaymentMethodId(e.target.value)}
+              fullWidth
               margin="normal"
             />
 

--- a/frontend/src/pages/Profile/ProfilePage.test.tsx
+++ b/frontend/src/pages/Profile/ProfilePage.test.tsx
@@ -231,7 +231,7 @@ describe('ProfilePage', () => {
     vi.stubGlobal('fetch', fetch);
 
     render(<ProfilePage />);
-    await screen.findByText(/payment method/i);
+    await screen.findByRole('heading', { name: /payment method/i });
     await userEvent.click(screen.getByRole('button', { name: /add card/i }));
     await userEvent.click(screen.getByRole('button', { name: /save card/i }));
     expect(mockConfirm).toHaveBeenCalledWith('sec', {

--- a/frontend/src/pages/Profile/ProfilePage.tsx
+++ b/frontend/src/pages/Profile/ProfilePage.tsx
@@ -6,6 +6,7 @@ import {
   Typography,
   Tooltip,
   Stack,
+  Alert,
 } from '@mui/material';
 import {
   Elements,
@@ -196,6 +197,14 @@ const ProfilePage = () => {
       <Typography variant="h5" gutterBottom>
         My Profile
       </Typography>
+      {(!phone || !paymentMethod) && (
+        <Alert severity="warning" sx={{ mb: 2 }}>
+          Please add your
+          {!phone ? ' phone number' : ''}
+          {!phone && !paymentMethod ? ' and' : ''}
+          {!paymentMethod ? ' payment method' : ''} before booking.
+        </Alert>
+      )}
       <TextField label="Full Name" value={fullName} onChange={e => setFullName(e.target.value)} margin="normal" fullWidth />
       <TextField label="Email" value={email} onChange={e => setEmail(e.target.value)} margin="normal" fullWidth />
       <TextField label="Phone" value={phone} onChange={e => setPhone(e.target.value)} margin="normal" fullWidth />


### PR DESCRIPTION
## Summary
- accept optional phone and default payment method during signup
- prompt users on profile page to provide phone and payment method before booking
- verify registration stores phone and payment method

## Testing
- `npm run lint`
- `cd backend && pytest -q --maxfail=1 --disable-warnings tests/unit/services/test_auth_service.py tests/unit/api/test_auth_router.py`
- `cd frontend && npm test src/pages/Auth/RegisterPage.test.tsx src/pages/Profile/ProfilePage.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b966568b48833198ca54555be55ccc