### PR TITLE
chore: regenerate API client and update customer phone tests

### DIFF
--- a/frontend/src/__tests__/setup/msw.handlers.ts
+++ b/frontend/src/__tests__/setup/msw.handlers.ts
@@ -61,6 +61,7 @@ export const handlers = [
         full_name: 'Test User',
         email: body.email,
         role: 'CUSTOMER',
+        phone: '123-4567',
       },
     });
   }),
@@ -71,6 +72,7 @@ export const handlers = [
       id: CONFIG.ADMIN_USER_ID,
       full_name: 'Test User',
       email: 'test@example.com',
+      phone: '123-4567',
       default_pickup_address: '123 Street',
     });
   }),
@@ -81,6 +83,7 @@ export const handlers = [
       id: CONFIG.ADMIN_USER_ID,
       full_name: body.full_name ?? 'Test User',
       email: body.email ?? 'test@example.com',
+      phone: body.phone ?? '123-4567',
       default_pickup_address:
         body.default_pickup_address ?? '123 Street',
     });

--- a/frontend/src/api-client/.openapi-generator/FILES
+++ b/frontend/src/api-client/.openapi-generator/FILES
@@ -18,7 +18,6 @@ docs/BookingStatus.md
 docs/BookingStatusResponse.md
 docs/BookingsApi.md
 docs/CustomerBookingsApi.md
-docs/CustomerInfo.md
 docs/DriverBookingsApi.md
 docs/GeocodeApi.md
 docs/GeocodeResponse.md
@@ -29,6 +28,7 @@ docs/HealthApi.md
 docs/Location.md
 docs/LoginRequest.md
 docs/OAuth2Token.md
+docs/PaymentMethodPayload.md
 docs/RegisterRequest.md
 docs/RouteMetricsApi.md
 docs/RouteMetricsRequest.md

--- a/frontend/src/api-client/api.ts
+++ b/frontend/src/api-client/api.ts
@@ -106,12 +106,6 @@ export interface AvailabilitySlotRead {
 export interface BookingCreateRequest {
     /**
      * 
-     * @type {CustomerInfo}
-     * @memberof BookingCreateRequest
-     */
-    'customer': CustomerInfo;
-    /**
-     * 
      * @type {string}
      * @memberof BookingCreateRequest
      */
@@ -361,9 +355,9 @@ export interface BookingSlot {
 
 export const BookingStatus = {
     Pending: 'PENDING',
+    DepositFailed: 'DEPOSIT_FAILED',
     DriverConfirmed: 'DRIVER_CONFIRMED',
     Declined: 'DECLINED',
-    DepositFailed: 'DEPOSIT_FAILED',
     OnTheWay: 'ON_THE_WAY',
     ArrivedPickup: 'ARRIVED_PICKUP',
     InProgress: 'IN_PROGRESS',
@@ -402,31 +396,6 @@ export interface BookingStatusResponse {
 }
 
 
-/**
- * 
- * @export
- * @interface CustomerInfo
- */
-export interface CustomerInfo {
-    /**
-     * 
-     * @type {string}
-     * @memberof CustomerInfo
-     */
-    'name': string;
-    /**
-     * 
-     * @type {string}
-     * @memberof CustomerInfo
-     */
-    'email': string;
-    /**
-     * 
-     * @type {string}
-     * @memberof CustomerInfo
-     */
-    'phone'?: string | null;
-}
 /**
  * Single address lookup result.
  * @export
@@ -565,6 +534,19 @@ export interface OAuth2Token {
      * @memberof OAuth2Token
      */
     'token_type'?: string;
+}
+/**
+ * 
+ * @export
+ * @interface PaymentMethodPayload
+ */
+export interface PaymentMethodPayload {
+    /**
+     * 
+     * @type {string}
+     * @memberof PaymentMethodPayload
+     */
+    'payment_method_id': string;
 }
 /**
  * Payload required to create a new user.
@@ -741,13 +723,13 @@ export interface UserCreate {
      */
     'full_name': string;
     /**
-     *
+     * 
      * @type {string}
      * @memberof UserCreate
      */
     'default_pickup_address'?: string | null;
     /**
-     *
+     * 
      * @type {string}
      * @memberof UserCreate
      */
@@ -778,13 +760,13 @@ export interface UserRead {
      */
     'full_name': string;
     /**
-     *
+     * 
      * @type {string}
      * @memberof UserRead
      */
     'default_pickup_address'?: string | null;
     /**
-     *
+     * 
      * @type {string}
      * @memberof UserRead
      */
@@ -801,6 +783,18 @@ export interface UserRead {
      * @memberof UserRead
      */
     'fcm_token'?: string | null;
+    /**
+     * 
+     * @type {string}
+     * @memberof UserRead
+     */
+    'stripe_customer_id'?: string | null;
+    /**
+     * 
+     * @type {string}
+     * @memberof UserRead
+     */
+    'stripe_payment_method_id'?: string | null;
 }
 /**
  * Optional fields for updating a user.
@@ -821,25 +815,37 @@ export interface UserUpdate {
      */
     'full_name'?: string | null;
     /**
-     *
+     * 
      * @type {string}
      * @memberof UserUpdate
      */
     'password'?: string | null;
     /**
-     *
+     * 
      * @type {string}
      * @memberof UserUpdate
      */
     'default_pickup_address'?: string | null;
     /**
-     *
+     * 
      * @type {string}
      * @memberof UserUpdate
      */
     'fcm_token'?: string | null;
     /**
-     *
+     * 
+     * @type {string}
+     * @memberof UserUpdate
+     */
+    'stripe_customer_id'?: string | null;
+    /**
+     * 
+     * @type {string}
+     * @memberof UserUpdate
+     */
+    'stripe_payment_method_id'?: string | null;
+    /**
+     * 
      * @type {string}
      * @memberof UserUpdate
      */
@@ -1513,6 +1519,10 @@ export const BookingsApiAxiosParamCreator = function (configuration?: Configurat
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
+            // authentication OAuth2PasswordBearer required
+            // oauth required
+            await setOAuthToObject(localVarHeaderParameter, "OAuth2PasswordBearer", [], configuration)
+
 
     
             localVarHeaderParameter['Content-Type'] = 'application/json';
@@ -1975,6 +1985,44 @@ export const DriverBookingsApiAxiosParamCreator = function (configuration?: Conf
         },
         /**
          * 
+         * @summary Retry Deposit
+         * @param {string} bookingId 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        retryDepositApiV1DriverBookingsBookingIdRetryDepositPost: async (bookingId: string, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+            // verify required parameter 'bookingId' is not null or undefined
+            assertParamExists('retryDepositApiV1DriverBookingsBookingIdRetryDepositPost', 'bookingId', bookingId)
+            const localVarPath = `/api/v1/driver/bookings/{booking_id}/retry-deposit`
+                .replace(`{${"booking_id"}}`, encodeURIComponent(String(bookingId)));
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            // authentication OAuth2PasswordBearer required
+            // oauth required
+            await setOAuthToObject(localVarHeaderParameter, "OAuth2PasswordBearer", [], configuration)
+
+
+    
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         * 
          * @summary Start Trip
          * @param {string} bookingId 
          * @param {*} [options] Override http request option.
@@ -2114,6 +2162,19 @@ export const DriverBookingsApiFp = function(configuration?: Configuration) {
         },
         /**
          * 
+         * @summary Retry Deposit
+         * @param {string} bookingId 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async retryDepositApiV1DriverBookingsBookingIdRetryDepositPost(bookingId: string, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<BookingStatusResponse>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.retryDepositApiV1DriverBookingsBookingIdRetryDepositPost(bookingId, options);
+            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+            const localVarOperationServerBasePath = operationServerMap['DriverBookingsApi.retryDepositApiV1DriverBookingsBookingIdRetryDepositPost']?.[localVarOperationServerIndex]?.url;
+            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
+        },
+        /**
+         * 
          * @summary Start Trip
          * @param {string} bookingId 
          * @param {*} [options] Override http request option.
@@ -2204,6 +2265,16 @@ export const DriverBookingsApiFactory = function (configuration?: Configuration,
          */
         listBookingsApiV1DriverBookingsGet(status?: BookingStatus | null, options?: RawAxiosRequestConfig): AxiosPromise<Array<BookingRead>> {
             return localVarFp.listBookingsApiV1DriverBookingsGet(status, options).then((request) => request(axios, basePath));
+        },
+        /**
+         * 
+         * @summary Retry Deposit
+         * @param {string} bookingId 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        retryDepositApiV1DriverBookingsBookingIdRetryDepositPost(bookingId: string, options?: RawAxiosRequestConfig): AxiosPromise<BookingStatusResponse> {
+            return localVarFp.retryDepositApiV1DriverBookingsBookingIdRetryDepositPost(bookingId, options).then((request) => request(axios, basePath));
         },
         /**
          * 
@@ -2307,6 +2378,18 @@ export class DriverBookingsApi extends BaseAPI {
      */
     public listBookingsApiV1DriverBookingsGet(status?: BookingStatus | null, options?: RawAxiosRequestConfig) {
         return DriverBookingsApiFp(this.configuration).listBookingsApiV1DriverBookingsGet(status, options).then((request) => request(this.axios, this.basePath));
+    }
+
+    /**
+     * 
+     * @summary Retry Deposit
+     * @param {string} bookingId 
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof DriverBookingsApi
+     */
+    public retryDepositApiV1DriverBookingsBookingIdRetryDepositPost(bookingId: string, options?: RawAxiosRequestConfig) {
+        return DriverBookingsApiFp(this.configuration).retryDepositApiV1DriverBookingsBookingIdRetryDepositPost(bookingId, options).then((request) => request(this.axios, this.basePath));
     }
 
     /**
@@ -2644,15 +2727,15 @@ export const RouteMetricsApiAxiosParamCreator = function (configuration?: Config
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        apiRouteMetricsRouteMetricsPost: async (pickupLat: number, pickupLon: number, dropoffLat: number, dropoffLon: number, rideTime?: string | null, routeMetricsRequest?: RouteMetricsRequest, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+        apiRouteMetricsRouteMetricsGet: async (pickupLat: number, pickupLon: number, dropoffLat: number, dropoffLon: number, rideTime?: string | null, routeMetricsRequest?: RouteMetricsRequest, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'pickupLat' is not null or undefined
-            assertParamExists('apiRouteMetricsRouteMetricsPost', 'pickupLat', pickupLat)
+            assertParamExists('apiRouteMetricsRouteMetricsGet', 'pickupLat', pickupLat)
             // verify required parameter 'pickupLon' is not null or undefined
-            assertParamExists('apiRouteMetricsRouteMetricsPost', 'pickupLon', pickupLon)
+            assertParamExists('apiRouteMetricsRouteMetricsGet', 'pickupLon', pickupLon)
             // verify required parameter 'dropoffLat' is not null or undefined
-            assertParamExists('apiRouteMetricsRouteMetricsPost', 'dropoffLat', dropoffLat)
+            assertParamExists('apiRouteMetricsRouteMetricsGet', 'dropoffLat', dropoffLat)
             // verify required parameter 'dropoffLon' is not null or undefined
-            assertParamExists('apiRouteMetricsRouteMetricsPost', 'dropoffLon', dropoffLon)
+            assertParamExists('apiRouteMetricsRouteMetricsGet', 'dropoffLon', dropoffLon)
             const localVarPath = `/route-metrics`;
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
@@ -2713,15 +2796,15 @@ export const RouteMetricsApiAxiosParamCreator = function (configuration?: Config
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        apiRouteMetricsRouteMetricsPost_1: async (pickupLat: number, pickupLon: number, dropoffLat: number, dropoffLon: number, rideTime?: string | null, routeMetricsRequest?: RouteMetricsRequest, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+        apiRouteMetricsRouteMetricsGet_1: async (pickupLat: number, pickupLon: number, dropoffLat: number, dropoffLon: number, rideTime?: string | null, routeMetricsRequest?: RouteMetricsRequest, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'pickupLat' is not null or undefined
-            assertParamExists('apiRouteMetricsRouteMetricsPost_1', 'pickupLat', pickupLat)
+            assertParamExists('apiRouteMetricsRouteMetricsGet_1', 'pickupLat', pickupLat)
             // verify required parameter 'pickupLon' is not null or undefined
-            assertParamExists('apiRouteMetricsRouteMetricsPost_1', 'pickupLon', pickupLon)
+            assertParamExists('apiRouteMetricsRouteMetricsGet_1', 'pickupLon', pickupLon)
             // verify required parameter 'dropoffLat' is not null or undefined
-            assertParamExists('apiRouteMetricsRouteMetricsPost_1', 'dropoffLat', dropoffLat)
+            assertParamExists('apiRouteMetricsRouteMetricsGet_1', 'dropoffLat', dropoffLat)
             // verify required parameter 'dropoffLon' is not null or undefined
-            assertParamExists('apiRouteMetricsRouteMetricsPost_1', 'dropoffLon', dropoffLon)
+            assertParamExists('apiRouteMetricsRouteMetricsGet_1', 'dropoffLon', dropoffLon)
             const localVarPath = `/route-metrics`;
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
@@ -2792,10 +2875,10 @@ export const RouteMetricsApiFp = function(configuration?: Configuration) {
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async apiRouteMetricsRouteMetricsPost(pickupLat: number, pickupLon: number, dropoffLat: number, dropoffLon: number, rideTime?: string | null, routeMetricsRequest?: RouteMetricsRequest, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<any>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.apiRouteMetricsRouteMetricsPost(pickupLat, pickupLon, dropoffLat, dropoffLon, rideTime, routeMetricsRequest, options);
+        async apiRouteMetricsRouteMetricsGet(pickupLat: number, pickupLon: number, dropoffLat: number, dropoffLon: number, rideTime?: string | null, routeMetricsRequest?: RouteMetricsRequest, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<any>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.apiRouteMetricsRouteMetricsGet(pickupLat, pickupLon, dropoffLat, dropoffLon, rideTime, routeMetricsRequest, options);
             const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
-            const localVarOperationServerBasePath = operationServerMap['RouteMetricsApi.apiRouteMetricsRouteMetricsPost']?.[localVarOperationServerIndex]?.url;
+            const localVarOperationServerBasePath = operationServerMap['RouteMetricsApi.apiRouteMetricsRouteMetricsGet']?.[localVarOperationServerIndex]?.url;
             return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
         },
         /**
@@ -2810,10 +2893,10 @@ export const RouteMetricsApiFp = function(configuration?: Configuration) {
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async apiRouteMetricsRouteMetricsPost_1(pickupLat: number, pickupLon: number, dropoffLat: number, dropoffLon: number, rideTime?: string | null, routeMetricsRequest?: RouteMetricsRequest, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<any>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.apiRouteMetricsRouteMetricsPost_1(pickupLat, pickupLon, dropoffLat, dropoffLon, rideTime, routeMetricsRequest, options);
+        async apiRouteMetricsRouteMetricsGet_1(pickupLat: number, pickupLon: number, dropoffLat: number, dropoffLon: number, rideTime?: string | null, routeMetricsRequest?: RouteMetricsRequest, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<any>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.apiRouteMetricsRouteMetricsGet_1(pickupLat, pickupLon, dropoffLat, dropoffLon, rideTime, routeMetricsRequest, options);
             const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
-            const localVarOperationServerBasePath = operationServerMap['RouteMetricsApi.apiRouteMetricsRouteMetricsPost_1']?.[localVarOperationServerIndex]?.url;
+            const localVarOperationServerBasePath = operationServerMap['RouteMetricsApi.apiRouteMetricsRouteMetricsGet_1']?.[localVarOperationServerIndex]?.url;
             return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
         },
     }
@@ -2838,8 +2921,8 @@ export const RouteMetricsApiFactory = function (configuration?: Configuration, b
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        apiRouteMetricsRouteMetricsPost(pickupLat: number, pickupLon: number, dropoffLat: number, dropoffLon: number, rideTime?: string | null, routeMetricsRequest?: RouteMetricsRequest, options?: RawAxiosRequestConfig): AxiosPromise<any> {
-            return localVarFp.apiRouteMetricsRouteMetricsPost(pickupLat, pickupLon, dropoffLat, dropoffLon, rideTime, routeMetricsRequest, options).then((request) => request(axios, basePath));
+        apiRouteMetricsRouteMetricsGet(pickupLat: number, pickupLon: number, dropoffLat: number, dropoffLon: number, rideTime?: string | null, routeMetricsRequest?: RouteMetricsRequest, options?: RawAxiosRequestConfig): AxiosPromise<any> {
+            return localVarFp.apiRouteMetricsRouteMetricsGet(pickupLat, pickupLon, dropoffLat, dropoffLon, rideTime, routeMetricsRequest, options).then((request) => request(axios, basePath));
         },
         /**
          * Return travel metrics between pickup and dropoff coordinates.
@@ -2853,8 +2936,8 @@ export const RouteMetricsApiFactory = function (configuration?: Configuration, b
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        apiRouteMetricsRouteMetricsPost_1(pickupLat: number, pickupLon: number, dropoffLat: number, dropoffLon: number, rideTime?: string | null, routeMetricsRequest?: RouteMetricsRequest, options?: RawAxiosRequestConfig): AxiosPromise<any> {
-            return localVarFp.apiRouteMetricsRouteMetricsPost_1(pickupLat, pickupLon, dropoffLat, dropoffLon, rideTime, routeMetricsRequest, options).then((request) => request(axios, basePath));
+        apiRouteMetricsRouteMetricsGet_1(pickupLat: number, pickupLon: number, dropoffLat: number, dropoffLon: number, rideTime?: string | null, routeMetricsRequest?: RouteMetricsRequest, options?: RawAxiosRequestConfig): AxiosPromise<any> {
+            return localVarFp.apiRouteMetricsRouteMetricsGet_1(pickupLat, pickupLon, dropoffLat, dropoffLon, rideTime, routeMetricsRequest, options).then((request) => request(axios, basePath));
         },
     };
 };
@@ -2879,8 +2962,8 @@ export class RouteMetricsApi extends BaseAPI {
      * @throws {RequiredError}
      * @memberof RouteMetricsApi
      */
-    public apiRouteMetricsRouteMetricsPost(pickupLat: number, pickupLon: number, dropoffLat: number, dropoffLon: number, rideTime?: string | null, routeMetricsRequest?: RouteMetricsRequest, options?: RawAxiosRequestConfig) {
-        return RouteMetricsApiFp(this.configuration).apiRouteMetricsRouteMetricsPost(pickupLat, pickupLon, dropoffLat, dropoffLon, rideTime, routeMetricsRequest, options).then((request) => request(this.axios, this.basePath));
+    public apiRouteMetricsRouteMetricsGet(pickupLat: number, pickupLon: number, dropoffLat: number, dropoffLon: number, rideTime?: string | null, routeMetricsRequest?: RouteMetricsRequest, options?: RawAxiosRequestConfig) {
+        return RouteMetricsApiFp(this.configuration).apiRouteMetricsRouteMetricsGet(pickupLat, pickupLon, dropoffLat, dropoffLon, rideTime, routeMetricsRequest, options).then((request) => request(this.axios, this.basePath));
     }
 
     /**
@@ -2896,8 +2979,8 @@ export class RouteMetricsApi extends BaseAPI {
      * @throws {RequiredError}
      * @memberof RouteMetricsApi
      */
-    public apiRouteMetricsRouteMetricsPost_1(pickupLat: number, pickupLon: number, dropoffLat: number, dropoffLon: number, rideTime?: string | null, routeMetricsRequest?: RouteMetricsRequest, options?: RawAxiosRequestConfig) {
-        return RouteMetricsApiFp(this.configuration).apiRouteMetricsRouteMetricsPost_1(pickupLat, pickupLon, dropoffLat, dropoffLon, rideTime, routeMetricsRequest, options).then((request) => request(this.axios, this.basePath));
+    public apiRouteMetricsRouteMetricsGet_1(pickupLat: number, pickupLon: number, dropoffLat: number, dropoffLon: number, rideTime?: string | null, routeMetricsRequest?: RouteMetricsRequest, options?: RawAxiosRequestConfig) {
+        return RouteMetricsApiFp(this.configuration).apiRouteMetricsRouteMetricsGet_1(pickupLat, pickupLon, dropoffLat, dropoffLon, rideTime, routeMetricsRequest, options).then((request) => request(this.axios, this.basePath));
     }
 }
 
@@ -3366,7 +3449,41 @@ export class TrackApi extends BaseAPI {
 export const UsersApiAxiosParamCreator = function (configuration?: Configuration) {
     return {
         /**
-         * Register a new user in the system.
+         * Return a SetupIntent client secret for the current user.
+         * @summary Api Create Payment Method
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        apiCreatePaymentMethodUsersMePaymentMethodPost: async (options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+            const localVarPath = `/users/me/payment-method`;
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            // authentication OAuth2PasswordBearer required
+            // oauth required
+            await setOAuthToObject(localVarHeaderParameter, "OAuth2PasswordBearer", [], configuration)
+
+
+    
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         * Register a new user in the system, optionally capturing a phone number.
          * @summary Api Create User
          * @param {UserCreate} userCreate 
          * @param {*} [options] Override http request option.
@@ -3546,7 +3663,81 @@ export const UsersApiAxiosParamCreator = function (configuration?: Configuration
             };
         },
         /**
-         * Allow the current user to update their profile.
+         * Remove the saved payment method for the current user.
+         * @summary Api Remove Payment Method
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        apiRemovePaymentMethodUsersMePaymentMethodDelete: async (options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+            const localVarPath = `/users/me/payment-method`;
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'DELETE', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            // authentication OAuth2PasswordBearer required
+            // oauth required
+            await setOAuthToObject(localVarHeaderParameter, "OAuth2PasswordBearer", [], configuration)
+
+
+    
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         * Persist a confirmed payment method to the user\'s profile.
+         * @summary Api Save Payment Method
+         * @param {PaymentMethodPayload} paymentMethodPayload 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        apiSavePaymentMethodUsersMePaymentMethodPut: async (paymentMethodPayload: PaymentMethodPayload, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+            // verify required parameter 'paymentMethodPayload' is not null or undefined
+            assertParamExists('apiSavePaymentMethodUsersMePaymentMethodPut', 'paymentMethodPayload', paymentMethodPayload)
+            const localVarPath = `/users/me/payment-method`;
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'PUT', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            // authentication OAuth2PasswordBearer required
+            // oauth required
+            await setOAuthToObject(localVarHeaderParameter, "OAuth2PasswordBearer", [], configuration)
+
+
+    
+            localVarHeaderParameter['Content-Type'] = 'application/json';
+
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.data = serializeDataIfNeeded(paymentMethodPayload, localVarRequestOptions, configuration)
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         * Allow the current user to update their profile, including phone.
          * @summary Api Update Me
          * @param {UserUpdate} userUpdate 
          * @param {*} [options] Override http request option.
@@ -3586,7 +3777,7 @@ export const UsersApiAxiosParamCreator = function (configuration?: Configuration
             };
         },
         /**
-         * Update selected fields of a user.
+         * Update selected fields of a user, including phone.
          * @summary Api Update User
          * @param {string} userId 
          * @param {UserUpdate} userUpdate 
@@ -3640,7 +3831,19 @@ export const UsersApiFp = function(configuration?: Configuration) {
     const localVarAxiosParamCreator = UsersApiAxiosParamCreator(configuration)
     return {
         /**
-         * Register a new user in the system.
+         * Return a SetupIntent client secret for the current user.
+         * @summary Api Create Payment Method
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async apiCreatePaymentMethodUsersMePaymentMethodPost(options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<StripeSetupIntent>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.apiCreatePaymentMethodUsersMePaymentMethodPost(options);
+            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+            const localVarOperationServerBasePath = operationServerMap['UsersApi.apiCreatePaymentMethodUsersMePaymentMethodPost']?.[localVarOperationServerIndex]?.url;
+            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
+        },
+        /**
+         * Register a new user in the system, optionally capturing a phone number.
          * @summary Api Create User
          * @param {UserCreate} userCreate 
          * @param {*} [options] Override http request option.
@@ -3703,7 +3906,32 @@ export const UsersApiFp = function(configuration?: Configuration) {
             return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
         },
         /**
-         * Allow the current user to update their profile.
+         * Remove the saved payment method for the current user.
+         * @summary Api Remove Payment Method
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async apiRemovePaymentMethodUsersMePaymentMethodDelete(options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.apiRemovePaymentMethodUsersMePaymentMethodDelete(options);
+            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+            const localVarOperationServerBasePath = operationServerMap['UsersApi.apiRemovePaymentMethodUsersMePaymentMethodDelete']?.[localVarOperationServerIndex]?.url;
+            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
+        },
+        /**
+         * Persist a confirmed payment method to the user\'s profile.
+         * @summary Api Save Payment Method
+         * @param {PaymentMethodPayload} paymentMethodPayload 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async apiSavePaymentMethodUsersMePaymentMethodPut(paymentMethodPayload: PaymentMethodPayload, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<UserRead>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.apiSavePaymentMethodUsersMePaymentMethodPut(paymentMethodPayload, options);
+            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+            const localVarOperationServerBasePath = operationServerMap['UsersApi.apiSavePaymentMethodUsersMePaymentMethodPut']?.[localVarOperationServerIndex]?.url;
+            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
+        },
+        /**
+         * Allow the current user to update their profile, including phone.
          * @summary Api Update Me
          * @param {UserUpdate} userUpdate 
          * @param {*} [options] Override http request option.
@@ -3716,7 +3944,7 @@ export const UsersApiFp = function(configuration?: Configuration) {
             return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
         },
         /**
-         * Update selected fields of a user.
+         * Update selected fields of a user, including phone.
          * @summary Api Update User
          * @param {string} userId 
          * @param {UserUpdate} userUpdate 
@@ -3740,7 +3968,16 @@ export const UsersApiFactory = function (configuration?: Configuration, basePath
     const localVarFp = UsersApiFp(configuration)
     return {
         /**
-         * Register a new user in the system.
+         * Return a SetupIntent client secret for the current user.
+         * @summary Api Create Payment Method
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        apiCreatePaymentMethodUsersMePaymentMethodPost(options?: RawAxiosRequestConfig): AxiosPromise<StripeSetupIntent> {
+            return localVarFp.apiCreatePaymentMethodUsersMePaymentMethodPost(options).then((request) => request(axios, basePath));
+        },
+        /**
+         * Register a new user in the system, optionally capturing a phone number.
          * @summary Api Create User
          * @param {UserCreate} userCreate 
          * @param {*} [options] Override http request option.
@@ -3788,7 +4025,26 @@ export const UsersApiFactory = function (configuration?: Configuration, basePath
             return localVarFp.apiListUsersUsersGet(options).then((request) => request(axios, basePath));
         },
         /**
-         * Allow the current user to update their profile.
+         * Remove the saved payment method for the current user.
+         * @summary Api Remove Payment Method
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        apiRemovePaymentMethodUsersMePaymentMethodDelete(options?: RawAxiosRequestConfig): AxiosPromise<void> {
+            return localVarFp.apiRemovePaymentMethodUsersMePaymentMethodDelete(options).then((request) => request(axios, basePath));
+        },
+        /**
+         * Persist a confirmed payment method to the user\'s profile.
+         * @summary Api Save Payment Method
+         * @param {PaymentMethodPayload} paymentMethodPayload 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        apiSavePaymentMethodUsersMePaymentMethodPut(paymentMethodPayload: PaymentMethodPayload, options?: RawAxiosRequestConfig): AxiosPromise<UserRead> {
+            return localVarFp.apiSavePaymentMethodUsersMePaymentMethodPut(paymentMethodPayload, options).then((request) => request(axios, basePath));
+        },
+        /**
+         * Allow the current user to update their profile, including phone.
          * @summary Api Update Me
          * @param {UserUpdate} userUpdate 
          * @param {*} [options] Override http request option.
@@ -3798,7 +4054,7 @@ export const UsersApiFactory = function (configuration?: Configuration, basePath
             return localVarFp.apiUpdateMeUsersMePatch(userUpdate, options).then((request) => request(axios, basePath));
         },
         /**
-         * Update selected fields of a user.
+         * Update selected fields of a user, including phone.
          * @summary Api Update User
          * @param {string} userId 
          * @param {UserUpdate} userUpdate 
@@ -3819,7 +4075,18 @@ export const UsersApiFactory = function (configuration?: Configuration, basePath
  */
 export class UsersApi extends BaseAPI {
     /**
-     * Register a new user in the system.
+     * Return a SetupIntent client secret for the current user.
+     * @summary Api Create Payment Method
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof UsersApi
+     */
+    public apiCreatePaymentMethodUsersMePaymentMethodPost(options?: RawAxiosRequestConfig) {
+        return UsersApiFp(this.configuration).apiCreatePaymentMethodUsersMePaymentMethodPost(options).then((request) => request(this.axios, this.basePath));
+    }
+
+    /**
+     * Register a new user in the system, optionally capturing a phone number.
      * @summary Api Create User
      * @param {UserCreate} userCreate 
      * @param {*} [options] Override http request option.
@@ -3877,7 +4144,30 @@ export class UsersApi extends BaseAPI {
     }
 
     /**
-     * Allow the current user to update their profile.
+     * Remove the saved payment method for the current user.
+     * @summary Api Remove Payment Method
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof UsersApi
+     */
+    public apiRemovePaymentMethodUsersMePaymentMethodDelete(options?: RawAxiosRequestConfig) {
+        return UsersApiFp(this.configuration).apiRemovePaymentMethodUsersMePaymentMethodDelete(options).then((request) => request(this.axios, this.basePath));
+    }
+
+    /**
+     * Persist a confirmed payment method to the user\'s profile.
+     * @summary Api Save Payment Method
+     * @param {PaymentMethodPayload} paymentMethodPayload 
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof UsersApi
+     */
+    public apiSavePaymentMethodUsersMePaymentMethodPut(paymentMethodPayload: PaymentMethodPayload, options?: RawAxiosRequestConfig) {
+        return UsersApiFp(this.configuration).apiSavePaymentMethodUsersMePaymentMethodPut(paymentMethodPayload, options).then((request) => request(this.axios, this.basePath));
+    }
+
+    /**
+     * Allow the current user to update their profile, including phone.
      * @summary Api Update Me
      * @param {UserUpdate} userUpdate 
      * @param {*} [options] Override http request option.
@@ -3889,7 +4179,7 @@ export class UsersApi extends BaseAPI {
     }
 
     /**
-     * Update selected fields of a user.
+     * Update selected fields of a user, including phone.
      * @summary Api Update User
      * @param {string} userId 
      * @param {UserUpdate} userUpdate 

--- a/frontend/src/components/BookingWizard/PaymentStep.tsx
+++ b/frontend/src/components/BookingWizard/PaymentStep.tsx
@@ -20,8 +20,6 @@ import FareBreakdown from '@/components/FareBreakdown';
 import * as logger from '@/lib/logger';
 import { BookingFormData } from '@/types/BookingFormData';
 import { useAuth } from '@/contexts/AuthContext';
-import { apiFetch } from '@/services/apiFetch';
-import { CONFIG } from '@/config';
 
 const stripePromise = (async () => {
   try {
@@ -48,6 +46,10 @@ function PaymentInner({ data, onBack }: Props) {
   const elements = useElements();
   const { createBooking, savePaymentMethod, savedPaymentMethod } =
     useStripeSetupIntent();
+  const { user: profile } = useAuth();
+  const name = profile?.full_name ?? '';
+  const email = profile?.email ?? '';
+  const phone = profile?.phone ?? '';
   const { data: settings } = useSettings();
   interface SettingsAliases {
     flagfall?: number;

--- a/frontend/src/components/NavBar.test.tsx
+++ b/frontend/src/components/NavBar.test.tsx
@@ -9,12 +9,22 @@ import type { ReactNode } from 'react';
 import { CONFIG } from '@/config';
 
 function seedAuth({ id, name, role }: { id: string; name: string; role: string }) {
-  localStorage.setItem('auth_tokens', JSON.stringify({ access_token: 't', refresh_token: 'r', user: { email: 'x' }, role }));
+  localStorage.clear();
+  localStorage.setItem(
+    'auth_tokens',
+    JSON.stringify({
+      access_token: 't',
+      refresh_token: 'r',
+      user: { email: 'x', phone: '123', full_name: name },
+      role,
+    })
+  );
   localStorage.setItem('userID', id);
   localStorage.setItem('userName', name);
   localStorage.setItem('userRole', role);
   localStorage.setItem('role', role);
   localStorage.setItem('adminID', CONFIG.ADMIN_USER_ID);
+  localStorage.setItem('phone', '123');
 }
 
 function renderWithAuth(initialPath = '/book', extraRoutes?: ReactNode) {

--- a/frontend/src/pages/Booking/BookingWizardPage.test.tsx
+++ b/frontend/src/pages/Booking/BookingWizardPage.test.tsx
@@ -12,7 +12,10 @@ import { apiUrl } from '@/__tests__/setup/msw.handlers';
 vi.mock('@stripe/react-stripe-js', () => ({
   Elements: ({ children }: { children: React.ReactNode }) => <>{children}</>,
   CardElement: () => <div data-testid="card-element" />,
-  useStripe: () => ({ confirmCardSetup: vi.fn() }),
+  useStripe: () => ({
+    confirmCardSetup: vi.fn(),
+    paymentRequest: vi.fn(() => ({ canMakePayment: vi.fn(), show: vi.fn() })),
+  }),
   useElements: () => ({ getElement: vi.fn().mockReturnValue({}) }),
 }));
 vi.mock('@stripe/stripe-js', () => ({ loadStripe: vi.fn() }));
@@ -69,7 +72,6 @@ afterEach(() => {
 });
 
 test('advances through steps and aggregates form data', async () => {
-  localStorage.setItem('phone', '000');
   renderWithProviders(<BookingWizardPage />);
   const input = (re: RegExp) => screen.getByLabelText(re, { selector: 'input' });
 
@@ -97,6 +99,11 @@ test('advances through steps and aggregates form data', async () => {
     dropoff: { address: '456 B St', lat: 0, lng: 0 },
     passengers: 2,
     notes: 'Be quick',
+    customer: {
+      name: 'Test User',
+      email: 'test@example.com',
+      phone: '123-4567',
+    },
   });
   localStorage.clear();
 });

--- a/frontend/src/pages/Dashboard/HomePage.test.tsx
+++ b/frontend/src/pages/Dashboard/HomePage.test.tsx
@@ -8,12 +8,18 @@ import { CONFIG } from '@/config';
 function seedAuth(id: string, role = 'CUSTOMER') {
   localStorage.setItem(
     'auth_tokens',
-    JSON.stringify({ access_token: 't', refresh_token: 'r', user: { email: 'x', role }, role })
+    JSON.stringify({
+      access_token: 't',
+      refresh_token: 'r',
+      user: { email: 'x', phone: '123', role },
+      role,
+    })
   );
   localStorage.setItem('userID', id);
   localStorage.setItem('userName', 'Test User');
   localStorage.setItem('role', role);
   localStorage.setItem('adminID', CONFIG.ADMIN_USER_ID);
+  localStorage.setItem('phone', '123');
 }
 
 describe('HomePage', () => {


### PR DESCRIPTION
## Summary
- regenerate OpenAPI client so schemas include customer phone
- add phone to MSW handlers and test auth seeds
- fix booking wizard tests for new customer shape

## Testing
- `npm run lint`
- `npm test pages/Booking/BookingWizardPage.test.tsx components/NavBar.test.tsx pages/Dashboard/HomePage.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b9684f40a48331b5405b88142d70b7