### PR TITLE
fix: surface place names in address search

### DIFF
--- a/frontend/src/components/AddressField.test.tsx
+++ b/frontend/src/components/AddressField.test.tsx
@@ -110,4 +110,34 @@ describe("AddressField", () => {
     await userEvent.type(input, "{arrowdown}");
     expect(await screen.findByText("LAX – 1 World Way, Los Angeles")).toBeInTheDocument();
   });
+
+  test("surfaces suggestion when query matches name", async () => {
+    const suggestions = [
+      {
+        name: "Union Station",
+        address: "800 N Alameda St, Los Angeles",
+        lat: 0,
+        lng: 0,
+        placeId: "u",
+      },
+    ];
+    render(
+      <AddressField
+        id="a"
+        label="A"
+        value=""
+        onChange={() => void 0}
+        suggestions={suggestions}
+        loading={false}
+      />
+    );
+    const input = screen.getByLabelText(/a/i);
+    await userEvent.type(input, "Union");
+    await userEvent.type(input, "{arrowdown}");
+    expect(
+      await screen.findByText(
+        "Union Station – 800 N Alameda St, Los Angeles"
+      )
+    ).toBeInTheDocument();
+  });
 });

--- a/frontend/src/components/AddressField.tsx
+++ b/frontend/src/components/AddressField.tsx
@@ -44,6 +44,7 @@ export function AddressField(props: {
     <Autocomplete<AddressSuggestion, false, false, true>
       freeSolo
       options={props.suggestions}
+      filterOptions={(opts) => opts}
       getOptionLabel={(option) =>
         typeof option === "string" ? option : option.address
       }

--- a/frontend/src/components/BookingWizard/PaymentStep.tsx
+++ b/frontend/src/components/BookingWizard/PaymentStep.tsx
@@ -19,9 +19,6 @@ import { useRouteMetrics } from '@/hooks/useRouteMetrics';
 import FareBreakdown from '@/components/FareBreakdown';
 import * as logger from '@/lib/logger';
 import { BookingFormData } from '@/types/BookingFormData';
-import { useAuth } from '@/contexts/AuthContext';
-import { apiFetch } from '@/services/apiFetch';
-import { CONFIG } from '@/config';
 
 const stripePromise = (async () => {
   try {


### PR DESCRIPTION
## Summary
- expose all suggestions in AddressField by bypassing default filtering
- add test confirming place-name matches surface suggestions

## Testing
- `npm run lint`
- `cd frontend && npm test run src/components/AddressField.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68b97208cadc83319897946062d6b55e