### PR TITLE
feat: constrain geocode autocomplete to AU

### DIFF
--- a/backend/app/services/geocode_service.py
+++ b/backend/app/services/geocode_service.py
@@ -97,9 +97,13 @@ async def search_geocode(query: str, limit: int = 5) -> list[dict]:
             "google autocomplete request",
             extra={"url": autocomplete_url, "query": query, "limit": limit},
         )
-        auto_res = await client.get(
-            autocomplete_url, params={"input": query, "key": api_key}
-        )
+        auto_params = {
+            "input": query,
+            "key": api_key,
+            "components": "country:AU",
+            "types": "address",
+        }
+        auto_res = await client.get(autocomplete_url, params=auto_params)
         auto_res.raise_for_status()
         predictions = auto_res.json().get("predictions", [])[:limit]
 

--- a/backend/tests/unit/services/test_geocode_service.py
+++ b/backend/tests/unit/services/test_geocode_service.py
@@ -87,6 +87,8 @@ async def test_search_geocode_returns_details(monkeypatch: MonkeyPatch):
         async def get(self, url, params=None):  # type: ignore[override]
             if "autocomplete" in url:
                 assert params["input"] == "SFO"
+                assert params["components"] == "country:AU"
+                assert params["types"] == "address"
                 return AutoResp()
             assert params["place_id"] == "sfo1"
             return DetailsResp()


### PR DESCRIPTION
## Summary
- restrict Google Places autocomplete to Australian addresses
- test ensures country component is passed

## Testing
- `pytest -q --maxfail=1 --disable-warnings tests/unit/services/test_geocode_service.py`


------
https://chatgpt.com/codex/tasks/task_e_68b9720f704c8331bd907bab328e4063