### PR TITLE
feat: normalize address autocomplete input

### DIFF
--- a/frontend/src/components/AddressField.tsx
+++ b/frontend/src/components/AddressField.tsx
@@ -10,6 +10,7 @@ export function AddressField(props: {
   label: string;
   value: string;
   onChange: (v: string) => void;
+  onFocus?: () => void;
   onBlur?: (v: string) => void;
   onSelect?: (s: AddressSuggestion) => void;
   onUseLocation?: () => void;
@@ -63,6 +64,10 @@ export function AddressField(props: {
       onInputChange={(_e, val) => {
         logger.debug("components/AddressField", "Input change", val);
         props.onChange(val);
+      }}
+      onFocus={() => {
+        logger.debug("components/AddressField", "Focus", props.value);
+        props.onFocus?.();
       }}
       onBlur={() => {
         logger.debug("components/AddressField", "Blur", props.value);

--- a/frontend/src/components/BookingWizard/PaymentStep.tsx
+++ b/frontend/src/components/BookingWizard/PaymentStep.tsx
@@ -20,8 +20,6 @@ import FareBreakdown from '@/components/FareBreakdown';
 import * as logger from '@/lib/logger';
 import { BookingFormData } from '@/types/BookingFormData';
 import { useAuth } from '@/contexts/AuthContext';
-import { apiFetch } from '@/services/apiFetch';
-import { CONFIG } from '@/config';
 
 const stripePromise = (async () => {
   try {
@@ -49,6 +47,7 @@ function PaymentInner({ data, onBack }: Props) {
   const { createBooking, savePaymentMethod, savedPaymentMethod } =
     useStripeSetupIntent();
   const { data: settings } = useSettings();
+  const { profile } = useAuth();
   interface SettingsAliases {
     flagfall?: number;
     per_km_rate?: number;

--- a/frontend/src/components/BookingWizard/TripDetailsStep.tsx
+++ b/frontend/src/components/BookingWizard/TripDetailsStep.tsx
@@ -54,7 +54,11 @@ export default function TripDetailsStep({ data, onNext, onBack, onChange }: Prop
             pickupValid: true,
           });
         }}
-        onBlur={() => setPickupTouched(true)}
+        onFocus={pickupAuto.onFocus}
+        onBlur={() => {
+          pickupAuto.onBlur();
+          setPickupTouched(true);
+        }}
         errorText={!pickupValid && pickupTouched ? 'Select a pickup address' : undefined}
         suggestions={pickupAuto.suggestions}
         loading={pickupAuto.loading}
@@ -83,7 +87,11 @@ export default function TripDetailsStep({ data, onNext, onBack, onChange }: Prop
             dropoffValid: true,
           });
         }}
-        onBlur={() => setDropoffTouched(true)}
+        onFocus={dropoffAuto.onFocus}
+        onBlur={() => {
+          dropoffAuto.onBlur();
+          setDropoffTouched(true);
+        }}
         errorText={!dropoffValid && dropoffTouched ? 'Select a dropoff address' : undefined}
         suggestions={dropoffAuto.suggestions}
         loading={dropoffAuto.loading}

--- a/frontend/src/hooks/useAddressAutocomplete.test.tsx
+++ b/frontend/src/hooks/useAddressAutocomplete.test.tsx
@@ -12,7 +12,7 @@ describe('useAddressAutocomplete', () => {
   test('resolves SFO to full address with coordinates', async () => {
     vi.mock('@/config', () => ({ CONFIG: { API_BASE_URL: 'http://api' } }));
     const fetchMock = vi.fn(async (url: string) => {
-      expect(url).toBe('http://api/geocode/search?q=SFO');
+      expect(url).toBe('http://api/geocode/search?q=sfo');
       return {
         ok: true,
         json: async () => ({
@@ -32,7 +32,7 @@ describe('useAddressAutocomplete', () => {
     vi.stubGlobal('fetch', fetchMock);
 
     const { result } = renderHook(() =>
-      useAddressAutocomplete('SFO', { debounceMs: 0 })
+      useAddressAutocomplete('  sFo ', { debounceMs: 0 })
     );
 
     await waitFor(() => {
@@ -46,5 +46,17 @@ describe('useAddressAutocomplete', () => {
       });
     });
     expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  test('skips search when below minimum length', async () => {
+    vi.mock('@/config', () => ({ CONFIG: { API_BASE_URL: 'http://api' } }));
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    renderHook(() => useAddressAutocomplete(' a ', { debounceMs: 0, minLength: 2 }));
+
+    await waitFor(() => {
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
   });
 });

--- a/frontend/src/pages/Booking/BookingWizardPage.test.tsx
+++ b/frontend/src/pages/Booking/BookingWizardPage.test.tsx
@@ -12,7 +12,13 @@ import { apiUrl } from '@/__tests__/setup/msw.handlers';
 vi.mock('@stripe/react-stripe-js', () => ({
   Elements: ({ children }: { children: React.ReactNode }) => <>{children}</>,
   CardElement: () => <div data-testid="card-element" />,
-  useStripe: () => ({ confirmCardSetup: vi.fn() }),
+  useStripe: () => ({
+    confirmCardSetup: vi.fn(),
+    paymentRequest: vi.fn(() => ({
+      canMakePayment: vi.fn(),
+      on: vi.fn(),
+    })),
+  }),
   useElements: () => ({ getElement: vi.fn().mockReturnValue({}) }),
 }));
 vi.mock('@stripe/stripe-js', () => ({ loadStripe: vi.fn() }));
@@ -35,6 +41,8 @@ vi.mock('@/hooks/useAddressAutocomplete', () => ({
   useAddressAutocomplete: (input: string) => ({
     suggestions: input ? [{ address: input, lat: 0, lng: 0 }] : [],
     loading: false,
+    onFocus: vi.fn(),
+    onBlur: vi.fn(),
   }),
 }));
 vi.mock('@/components/MapProvider', () => ({

--- a/frontend/src/pages/Profile/ProfilePage.test.tsx
+++ b/frontend/src/pages/Profile/ProfilePage.test.tsx
@@ -13,7 +13,12 @@ vi.mock('@/contexts/AuthContext', () => ({
 
 // Mock address autocomplete to avoid network activity
 vi.mock('@/hooks/useAddressAutocomplete', () => ({
-  useAddressAutocomplete: () => ({ suggestions: [], loading: false }),
+  useAddressAutocomplete: () => ({
+    suggestions: [],
+    loading: false,
+    onFocus: vi.fn(),
+    onBlur: vi.fn(),
+  }),
 }));
 
 const mockConfirm = vi

--- a/frontend/src/pages/Profile/ProfilePage.tsx
+++ b/frontend/src/pages/Profile/ProfilePage.tsx
@@ -213,6 +213,8 @@ const ProfilePage = () => {
         label="Default Pickup Address"
         value={defaultPickup}
         onChange={setDefaultPickup}
+        onFocus={auto.onFocus}
+        onBlur={() => auto.onBlur()}
         suggestions={auto.suggestions}
         loading={auto.loading}
       />


### PR DESCRIPTION
## Summary
- normalize address autocomplete query and enforce minimum length
- track per-session token for address search requests
- test address normalization and min-length behavior

## Testing
- `npm run lint`
- `npx vitest run src/hooks/useAddressAutocomplete.test.tsx src/pages/Booking/BookingWizardPage.test.tsx src/pages/Profile/ProfilePage.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b97232a36c8331bf0ed28adee98400