### PR TITLE
test: stub stripe customer creation in save payment method test

### DIFF
--- a/backend/tests/unit/services/test_stripe_client.py
+++ b/backend/tests/unit/services/test_stripe_client.py
@@ -32,6 +32,10 @@ async def test_save_payment_method_stores_id(async_session, mocker):
     )
     async_session.add(user)
     await async_session.flush()
+    mocker.patch(
+        "app.services.stripe_client.create_customer",
+        return_value=stripe_client._StubIntent(id="cus_test"),
+    )
 
     mock_set_default = mocker.patch(
         "app.services.stripe_client.set_default_payment_method"


### PR DESCRIPTION
## Summary
- stub out stripe customer creation in save payment method test to prevent real network calls and verify default payment method

## Testing
- `pytest tests/unit/services/test_stripe_client.py::test_save_payment_method_stores_id -q --maxfail=1 --disable-warnings`

------
https://chatgpt.com/codex/tasks/task_e_68b9cf906dbc833189a19663aee10105