### PR TITLE
test: update geocode search mocks for optional coordinates

### DIFF
--- a/backend/tests/integration/test_geocode_api.py
+++ b/backend/tests/integration/test_geocode_api.py
@@ -1,9 +1,10 @@
-import pytest
 import httpx
-from httpx import AsyncClient
+import pytest
 from _pytest.monkeypatch import MonkeyPatch
+from httpx import AsyncClient
 
 pytestmark = pytest.mark.asyncio
+
 
 async def test_reverse_geocode_timeout(monkeypatch: MonkeyPatch, client: AsyncClient):
     from app.api import geocode as geocode_router
@@ -21,7 +22,9 @@ async def test_reverse_geocode_timeout(monkeypatch: MonkeyPatch, client: AsyncCl
 async def test_geocode_search_http_error(monkeypatch: MonkeyPatch, client: AsyncClient):
     from app.api import geocode as geocode_router
 
-    async def fake_search(q: str, limit: int = 5):
+    async def fake_search(
+        q: str, limit: int = 5, lat: float | None = None, lon: float | None = None
+    ):
         raise httpx.HTTPError("boom")
 
     monkeypatch.setattr(geocode_router, "search_geocode", fake_search)

--- a/backend/tests/unit/api/test_geocode_router.py
+++ b/backend/tests/unit/api/test_geocode_router.py
@@ -24,7 +24,12 @@ async def test_reverse_geocode_endpoint(monkeypatch: MonkeyPatch, client: AsyncC
 async def test_geocode_search_endpoint(monkeypatch: MonkeyPatch, client: AsyncClient):
     from app.api import geocode as geocode_router
 
-    async def fake_search(q: str, limit: int = 5):  # type: ignore
+    async def fake_search(
+        q: str,
+        limit: int = 5,
+        lat: float | None = None,
+        lon: float | None = None,
+    ):  # type: ignore
         assert q == "Main St"
         assert limit == 5
         return [


### PR DESCRIPTION
## Summary
- allow geocode search tests to accept optional `lat` and `lon` params
- keep assertions validating `q` and `limit`

## Testing
- `pytest -q --maxfail=1 --disable-warnings tests/integration/test_geocode_api.py::test_geocode_search_http_error tests/unit/api/test_geocode_router.py::test_geocode_search_endpoint`

------
https://chatgpt.com/codex/tasks/task_e_68b9cf80e4f083319e830bb8dbaa1c9f