### PR TITLE
fix: sanitize address autocomplete query

### DIFF
--- a/frontend/src/hooks/useAddressAutocomplete.test.tsx
+++ b/frontend/src/hooks/useAddressAutocomplete.test.tsx
@@ -32,7 +32,7 @@ describe("useAddressAutocomplete", () => {
     vi.stubGlobal("fetch", fetchMock);
 
     const { result } = renderHook(() =>
-      useAddressAutocomplete('  sFo ', { debounceMs: 0 })
+      useAddressAutocomplete(' s F O ', { debounceMs: 0 })
     );
 
     await waitFor(() => {

--- a/frontend/src/hooks/useAddressAutocomplete.ts
+++ b/frontend/src/hooks/useAddressAutocomplete.ts
@@ -30,10 +30,10 @@ export function useAddressAutocomplete(
 ) {
   const [suggestions, setSuggestions] = useState<AddressSuggestion[]>([]);
   const [loading, setLoading] = useState(false);
-  const [sessionToken, setSessionToken] = useState<string | null>(null);
+  const [, setSessionToken] = useState<string | null>(null);
   const debounceMs = options?.debounceMs ?? 300;
   const minLength = options?.minLength ?? 3;
-  const normalizedQuery = query.trim().toLowerCase();
+  const normalizedQuery = query.replace(/\s+/g, "").toLowerCase();
 
   useEffect(() => {
     logger.debug("hooks/useAddressAutocomplete", "query", normalizedQuery);
@@ -50,7 +50,7 @@ export function useAddressAutocomplete(
       try {
         setLoading(true);
         const base = CONFIG.API_BASE_URL || "";
-        const params = new URLSearchParams({ q: query });
+        const params = new URLSearchParams({ q: normalizedQuery });
         if (options?.coords) {
           params.set("lat", String(options.coords.lat));
           params.set("lon", String(options.coords.lon));


### PR DESCRIPTION
## Summary
- sanitize address autocomplete query before API call
- test normalized address lookup URL

## Testing
- `npm run lint`
- `cd frontend && npm test src/hooks/useAddressAutocomplete.test.tsx -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68b9d06478a483318792fbf925791b95