### PR TITLE
fix: use setup intent secret for card setup

### DIFF
--- a/frontend/src/pages/Profile/ProfileForm.tsx
+++ b/frontend/src/pages/Profile/ProfileForm.tsx
@@ -130,8 +130,8 @@ const ProfileForm = () => {
       if (!res.ok) return;
       const json = await res.json();
       const card = elements.getElement(CardElement);
-      if (!json.client_secret || !card) return;
-      const setup = await stripe.confirmCardSetup(json.client_secret, {
+      if (!json.setup_intent_client_secret || !card) return;
+      const setup = await stripe.confirmCardSetup(json.setup_intent_client_secret, {
         payment_method: { card },
       });
       const pm = setup?.setupIntent?.payment_method;

--- a/frontend/src/pages/Profile/ProfilePage.test.tsx
+++ b/frontend/src/pages/Profile/ProfilePage.test.tsx
@@ -224,7 +224,7 @@ describe('ProfilePage', () => {
         if (init?.method === 'POST') {
           return Promise.resolve({
             ok: true,
-            json: async () => ({ client_secret: 'sec' }),
+            json: async () => ({ setup_intent_client_secret: 'sec' }),
           } as Response);
         }
         if (init?.method === 'PUT') {


### PR DESCRIPTION
## Summary
- use `setup_intent_client_secret` when confirming saved cards
- adjust profile payment method test for new secret field

## Testing
- `npm run lint`
- `pytest -q --maxfail=1 --disable-warnings`
- `npm test -- --run src/pages/Profile/ProfilePage.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68bab06e0b108331b1be930f69367804