### PR TITLE
test: mock booking APIs for AccessControl tests

### DIFF
--- a/frontend/src/__tests__/AccessControl.test.tsx
+++ b/frontend/src/__tests__/AccessControl.test.tsx
@@ -7,6 +7,25 @@ import { DevFeaturesProvider } from '@/contexts/DevFeaturesContext';
 import { vi } from 'vitest';
 import { CONFIG } from '@/config';
 
+vi.mock('@/components/ApiConfig', async () => {
+  const actual = await vi.importActual<
+    typeof import('@/components/ApiConfig')
+  >('@/components/ApiConfig');
+  return {
+    ...actual,
+    driverBookingsApi: {
+      listBookingsApiV1DriverBookingsGet: vi
+        .fn()
+        .mockResolvedValue({ data: [] }),
+    },
+    customerBookingsApi: {
+      listMyBookingsApiV1CustomersMeBookingsGet: vi
+        .fn()
+        .mockResolvedValue({ data: [] }),
+    },
+  };
+});
+
 vi.mock('@/pages/Admin/AdminDashboard', () => ({ default: () => <div>Admin Page</div> }));
 vi.mock('@/pages/Driver/DriverDashboard', () => ({ default: () => <div>Driver Page</div> }));
 vi.mock('@/pages/Auth/LoginPage', () => ({ default: () => <div>Login Page</div> }));


### PR DESCRIPTION
## Summary
- mock ApiConfig in AccessControl tests to resolve booking requests without network calls

## Testing
- `npm run lint`
- `cd frontend && npm test src/__tests__/AccessControl.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68bab036900c8331b817cfbe92e7dfc5