### PR TITLE
feat: expose payment method retrieval

### DIFF
--- a/backend/app/api/users.py
+++ b/backend/app/api/users.py
@@ -10,12 +10,13 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.dependencies import get_current_user, get_db
 from app.models.user_v2 import User
-from app.schemas.api_booking import StripeSetupIntent
+from app.schemas.api_booking import StripePaymentMethod, StripeSetupIntent
 from app.schemas.user import UserCreate, UserRead, UserUpdate
 from app.services.user_service import (
     create_setup_intent_for_user,
     create_user,
     delete_user,
+    get_payment_method,
     get_user,
     list_users,
     remove_payment_method,
@@ -143,3 +144,8 @@ async def api_remove_payment_method(
     """Remove the saved payment method for the current user."""
 
     await remove_payment_method(db, current_user)
+
+
+@router.get("/me/payment-method", response_model=StripePaymentMethod)
+async def api_get_payment_method(current_user: User = Depends(get_current_user)):
+    return await get_payment_method(current_user)

--- a/backend/app/schemas/api_booking.py
+++ b/backend/app/schemas/api_booking.py
@@ -4,8 +4,9 @@ import uuid
 from datetime import datetime, timezone
 from typing import Optional
 
-from app.models.booking import BookingStatus
 from pydantic import BaseModel, Field, field_validator
+
+from app.models.booking import BookingStatus
 
 
 class Location(BaseModel):
@@ -42,6 +43,11 @@ class BookingPublic(BaseModel):
 
 class StripeSetupIntent(BaseModel):
     setup_intent_client_secret: str = Field(..., alias="setup_intent_client_secret")
+
+
+class StripePaymentMethod(BaseModel):
+    brand: str
+    last4: str
 
 
 class BookingCreateResponse(BaseModel):

--- a/backend/app/services/stripe_client.py
+++ b/backend/app/services/stripe_client.py
@@ -50,7 +50,9 @@ class _StubStripe:  # type: ignore
 
         @staticmethod
         def retrieve(payment_method):
-            return _StubIntent(id=payment_method)
+            return _StubIntent(
+                id=payment_method, card={"brand": "visa", "last4": "4242"}
+            )
 
         @staticmethod
         def detach(payment_method):
@@ -103,6 +105,14 @@ def detach_payment_method(payment_method: str) -> None:
     """Detach a payment method from any customer."""
 
     stripe.PaymentMethod.detach(payment_method)
+
+
+def get_payment_method_details(payment_method_id: str) -> dict:
+    """Retrieve basic card details for a payment method."""
+
+    payment_method = stripe.PaymentMethod.retrieve(payment_method_id)
+    card = getattr(payment_method, "card", {}) or {}
+    return {"brand": card.get("brand"), "last4": card.get("last4")}
 
 
 def charge_deposit(

--- a/frontend/src/api-client/api.ts
+++ b/frontend/src/api-client/api.ts
@@ -573,17 +573,17 @@ export interface RegisterRequest {
      */
     'password': string;
     /**
-     *
+     * 
      * @type {string}
      * @memberof RegisterRequest
      */
-    'phone'?: string;
+    'phone'?: string | null;
     /**
-     *
+     * 
      * @type {string}
      * @memberof RegisterRequest
      */
-    'stripe_payment_method_id'?: string;
+    'stripe_payment_method_id'?: string | null;
 }
 /**
  * 
@@ -683,6 +683,25 @@ export interface SetupPayload {
      * @memberof SetupPayload
      */
     'settings': SettingsPayload;
+}
+/**
+ * 
+ * @export
+ * @interface StripePaymentMethod
+ */
+export interface StripePaymentMethod {
+    /**
+     * 
+     * @type {string}
+     * @memberof StripePaymentMethod
+     */
+    'brand': string;
+    /**
+     * 
+     * @type {string}
+     * @memberof StripePaymentMethod
+     */
+    'last4': string;
 }
 /**
  * 
@@ -2430,10 +2449,12 @@ export const GeocodeApiAxiosParamCreator = function (configuration?: Configurati
          * @summary Api Geocode Search
          * @param {string} q 
          * @param {number} [limit] 
+         * @param {number | null} [lat] 
+         * @param {number | null} [lon] 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        apiGeocodeSearchGeocodeSearchGet: async (q: string, limit?: number, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+        apiGeocodeSearchGeocodeSearchGet: async (q: string, limit?: number, lat?: number | null, lon?: number | null, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'q' is not null or undefined
             assertParamExists('apiGeocodeSearchGeocodeSearchGet', 'q', q)
             const localVarPath = `/geocode/search`;
@@ -2454,6 +2475,14 @@ export const GeocodeApiAxiosParamCreator = function (configuration?: Configurati
 
             if (limit !== undefined) {
                 localVarQueryParameter['limit'] = limit;
+            }
+
+            if (lat !== undefined) {
+                localVarQueryParameter['lat'] = lat;
+            }
+
+            if (lon !== undefined) {
+                localVarQueryParameter['lon'] = lon;
             }
 
 
@@ -2526,11 +2555,13 @@ export const GeocodeApiFp = function(configuration?: Configuration) {
          * @summary Api Geocode Search
          * @param {string} q 
          * @param {number} [limit] 
+         * @param {number | null} [lat] 
+         * @param {number | null} [lon] 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async apiGeocodeSearchGeocodeSearchGet(q: string, limit?: number, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<GeocodeSearchResponse>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.apiGeocodeSearchGeocodeSearchGet(q, limit, options);
+        async apiGeocodeSearchGeocodeSearchGet(q: string, limit?: number, lat?: number | null, lon?: number | null, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<GeocodeSearchResponse>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.apiGeocodeSearchGeocodeSearchGet(q, limit, lat, lon, options);
             const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
             const localVarOperationServerBasePath = operationServerMap['GeocodeApi.apiGeocodeSearchGeocodeSearchGet']?.[localVarOperationServerIndex]?.url;
             return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
@@ -2564,11 +2595,13 @@ export const GeocodeApiFactory = function (configuration?: Configuration, basePa
          * @summary Api Geocode Search
          * @param {string} q 
          * @param {number} [limit] 
+         * @param {number | null} [lat] 
+         * @param {number | null} [lon] 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        apiGeocodeSearchGeocodeSearchGet(q: string, limit?: number, options?: RawAxiosRequestConfig): AxiosPromise<GeocodeSearchResponse> {
-            return localVarFp.apiGeocodeSearchGeocodeSearchGet(q, limit, options).then((request) => request(axios, basePath));
+        apiGeocodeSearchGeocodeSearchGet(q: string, limit?: number, lat?: number | null, lon?: number | null, options?: RawAxiosRequestConfig): AxiosPromise<GeocodeSearchResponse> {
+            return localVarFp.apiGeocodeSearchGeocodeSearchGet(q, limit, lat, lon, options).then((request) => request(axios, basePath));
         },
         /**
          * Look up an address from latitude and longitude.
@@ -2596,12 +2629,14 @@ export class GeocodeApi extends BaseAPI {
      * @summary Api Geocode Search
      * @param {string} q 
      * @param {number} [limit] 
+     * @param {number | null} [lat] 
+     * @param {number | null} [lon] 
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof GeocodeApi
      */
-    public apiGeocodeSearchGeocodeSearchGet(q: string, limit?: number, options?: RawAxiosRequestConfig) {
-        return GeocodeApiFp(this.configuration).apiGeocodeSearchGeocodeSearchGet(q, limit, options).then((request) => request(this.axios, this.basePath));
+    public apiGeocodeSearchGeocodeSearchGet(q: string, limit?: number, lat?: number | null, lon?: number | null, options?: RawAxiosRequestConfig) {
+        return GeocodeApiFp(this.configuration).apiGeocodeSearchGeocodeSearchGet(q, limit, lat, lon, options).then((request) => request(this.axios, this.basePath));
     }
 
     /**
@@ -3603,6 +3638,40 @@ export const UsersApiAxiosParamCreator = function (configuration?: Configuration
             };
         },
         /**
+         * 
+         * @summary Api Get Payment Method
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        apiGetPaymentMethodUsersMePaymentMethodGet: async (options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+            const localVarPath = `/users/me/payment-method`;
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            // authentication OAuth2PasswordBearer required
+            // oauth required
+            await setOAuthToObject(localVarHeaderParameter, "OAuth2PasswordBearer", [], configuration)
+
+
+    
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
          * Fetch a single user by ID.
          * @summary Api Get User
          * @param {string} userId 
@@ -3893,6 +3962,18 @@ export const UsersApiFp = function(configuration?: Configuration) {
             return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
         },
         /**
+         * 
+         * @summary Api Get Payment Method
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async apiGetPaymentMethodUsersMePaymentMethodGet(options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<StripePaymentMethod>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.apiGetPaymentMethodUsersMePaymentMethodGet(options);
+            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+            const localVarOperationServerBasePath = operationServerMap['UsersApi.apiGetPaymentMethodUsersMePaymentMethodGet']?.[localVarOperationServerIndex]?.url;
+            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
+        },
+        /**
          * Fetch a single user by ID.
          * @summary Api Get User
          * @param {string} userId 
@@ -4018,6 +4099,15 @@ export const UsersApiFactory = function (configuration?: Configuration, basePath
             return localVarFp.apiGetMeUsersMeGet(options).then((request) => request(axios, basePath));
         },
         /**
+         * 
+         * @summary Api Get Payment Method
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        apiGetPaymentMethodUsersMePaymentMethodGet(options?: RawAxiosRequestConfig): AxiosPromise<StripePaymentMethod> {
+            return localVarFp.apiGetPaymentMethodUsersMePaymentMethodGet(options).then((request) => request(axios, basePath));
+        },
+        /**
          * Fetch a single user by ID.
          * @summary Api Get User
          * @param {string} userId 
@@ -4130,6 +4220,17 @@ export class UsersApi extends BaseAPI {
      */
     public apiGetMeUsersMeGet(options?: RawAxiosRequestConfig) {
         return UsersApiFp(this.configuration).apiGetMeUsersMeGet(options).then((request) => request(this.axios, this.basePath));
+    }
+
+    /**
+     * 
+     * @summary Api Get Payment Method
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof UsersApi
+     */
+    public apiGetPaymentMethodUsersMePaymentMethodGet(options?: RawAxiosRequestConfig) {
+        return UsersApiFp(this.configuration).apiGetPaymentMethodUsersMePaymentMethodGet(options).then((request) => request(this.axios, this.basePath));
     }
 
     /**


### PR DESCRIPTION
## Summary
- add `StripePaymentMethod` schema and service to fetch stored card info
- expose `/users/me/payment-method` endpoint and client wrapper
- test retrieval of stored Stripe payment methods

## Testing
- `pytest tests/integration/test_users_api.py::test_get_payment_method_not_found tests/integration/test_users_api.py::test_get_payment_method_success -q --maxfail=1 --disable-warnings`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bab599d310833184f5044baabca348