### PR TITLE
feat: attach payment method and surface errors

### DIFF
--- a/backend/app/services/user_service.py
+++ b/backend/app/services/user_service.py
@@ -120,6 +120,7 @@ async def create_setup_intent_for_user(db: AsyncSession, user: User) -> str:
         )
         user.stripe_customer_id = stripe_customer.id
         await db.flush()
+        await db.flush()
 
     setup_intent = stripe_client.create_setup_intent(
         user.stripe_customer_id, str(user.id)
@@ -137,6 +138,7 @@ async def save_payment_method(
             user.email, user.full_name, user.phone
         )
         user.stripe_customer_id = stripe_customer.id
+        await db.flush()
 
     stripe_client.set_default_payment_method(user.stripe_customer_id, payment_method_id)
     user.stripe_payment_method_id = payment_method_id

--- a/frontend/src/pages/Profile/ProfileForm.tsx
+++ b/frontend/src/pages/Profile/ProfileForm.tsx
@@ -30,6 +30,7 @@ const ProfileForm = () => {
   const [paymentMethod, setPaymentMethod] =
     useState<{ brand: string; last4: string } | null>(null);
   const [editingCard, setEditingCard] = useState(false);
+  const [cardError, setCardError] = useState<string | null>(null);
 
   const auto = useAddressAutocomplete(defaultPickup);
   const stripe = useStripe();
@@ -122,12 +123,17 @@ const ProfileForm = () => {
   const handleSaveCard = async () => {
     if (!stripe || !elements) return;
     await ensureFreshToken();
+    setCardError(null);
     try {
       const base = CONFIG.API_BASE_URL ?? '';
       const res = await apiFetch(`${base}/users/me/payment-method`, {
         method: 'POST',
       });
-      if (!res.ok) return;
+      if (!res.ok) {
+        logger.warn('pages/Profile/ProfileForm', 'setup intent request failed', res.status);
+        setCardError('Failed to initiate card setup.');
+        return;
+      }
       const json = await res.json();
       const card = elements.getElement(CardElement);
       if (!json.setup_intent_client_secret || !card) return;
@@ -135,27 +141,38 @@ const ProfileForm = () => {
         payment_method: { card },
       });
       const pm = setup?.setupIntent?.payment_method;
-      if (pm) {
-        await apiFetch(`${base}/users/me/payment-method`, {
-          method: 'PUT',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ payment_method_id: pm }),
-        });
-        setEditingCard(false);
-        const pmRes = await apiFetch(`${base}/users/me/payment-method`);
-        if (pmRes.ok) {
-          try {
-            const meta = await pmRes.json();
-            if (meta && meta.last4) {
-              setPaymentMethod({ brand: meta.brand, last4: meta.last4 });
-            }
-          } catch {
-            /* ignore */
+      if (!pm) {
+        const message = setup?.error?.message || 'Failed to confirm card.';
+        logger.warn('pages/Profile/ProfileForm', 'save card failed', message);
+        setCardError(message);
+        return;
+      }
+      const putRes = await apiFetch(`${base}/users/me/payment-method`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ payment_method_id: pm }),
+      });
+      if (!putRes.ok) {
+        const text = await putRes.text().catch(() => '');
+        logger.warn('pages/Profile/ProfileForm', 'save card failed', { status: putRes.status, body: text });
+        setCardError('Failed to save payment method.');
+        return;
+      }
+      setEditingCard(false);
+      const pmRes = await apiFetch(`${base}/users/me/payment-method`);
+      if (pmRes.ok) {
+        try {
+          const meta = await pmRes.json();
+          if (meta && meta.last4) {
+            setPaymentMethod({ brand: meta.brand, last4: meta.last4 });
           }
+        } catch {
+          /* ignore */
         }
       }
     } catch (err) {
       logger.warn('pages/Profile/ProfileForm', 'save card failed', err);
+      setCardError('Failed to save payment method.');
     }
   };
 
@@ -291,6 +308,7 @@ const ProfileForm = () => {
           </Stack>
         ) : editingCard ? (
           <Stack spacing={1}>
+            {cardError && <Alert severity="error">{cardError}</Alert>}
             <CardElement />
             <Stack direction="row" spacing={1}>
               <Button


### PR DESCRIPTION
## Summary
- handle card setup errors and persist payment method via API
- create Stripe customer if missing and save method IDs
- verify payment method storage through unit tests

## Testing
- `npm run lint`
- `pytest tests/unit/services/test_stripe_client.py::test_save_payment_method_stores_id -q --maxfail=1 --disable-warnings`
- `npm test src/pages/Profile/ProfilePage.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68bfb1a558708331a7604c62776de0ce