### PR TITLE
feat: manage client secret for profile payment method

### DIFF
--- a/frontend/src/pages/Profile/ProfilePage.test.tsx
+++ b/frontend/src/pages/Profile/ProfilePage.test.tsx
@@ -238,11 +238,19 @@ describe('ProfilePage', () => {
     render(<ProfilePage />);
     await screen.findByRole('heading', { name: /payment method/i });
     await userEvent.click(screen.getByRole('button', { name: /add card/i }));
+    await screen.findByTestId('payment-element');
     await userEvent.click(screen.getByRole('button', { name: /save card/i }));
     expect(mockConfirm).toHaveBeenCalledWith({
       elements: mockElements,
       clientSecret: 'sec',
     });
+    const postCalls = fetch.mock.calls.filter(
+      ([url, init]) =>
+        typeof url === 'string' &&
+        url.endsWith('/users/me/payment-method') &&
+        (init as RequestInit)?.method === 'POST',
+    );
+    expect(postCalls).toHaveLength(1);
     const putCall = fetch.mock.calls.find(
       ([url, init]) =>
         typeof url === 'string' &&

--- a/frontend/src/pages/Profile/ProfilePage.tsx
+++ b/frontend/src/pages/Profile/ProfilePage.tsx
@@ -1,4 +1,3 @@
-import { Elements } from '@stripe/react-stripe-js';
 import { loadStripe } from '@stripe/stripe-js';
 import * as logger from '@/lib/logger';
 import ProfileForm from './ProfileForm';
@@ -14,10 +13,6 @@ const stripePromise = (async () => {
   }
 })();
 
-const ProfilePage = () => (
-  <Elements stripe={stripePromise}>
-    <ProfileForm />
-  </Elements>
-);
+const ProfilePage = () => <ProfileForm stripePromise={stripePromise} />;
 
 export default ProfilePage;


### PR DESCRIPTION
## Summary
- lazily create Stripe Elements with setup-intent client secret
- confirm card setup using existing Elements instance
- adjust profile tests for new payment lifecycle

## Testing
- `npm run lint`
- `cd frontend && npm test src/pages/Profile/ProfilePage.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68bfbd3b5c388331bd29f0b9acba4129