### PR TITLE
fix: update confirmSetup signature in tests and components

### DIFF
--- a/frontend/src/components/BookingWizard/PaymentStep.test.tsx
+++ b/frontend/src/components/BookingWizard/PaymentStep.test.tsx
@@ -110,10 +110,16 @@ test('handles new card flow', async () => {
     screen.getByRole('button', { name: /submit/i })
   );
   expect(mockCreateBooking).toHaveBeenCalledTimes(1);
-  expect(mockConfirm).toHaveBeenCalledWith({
-    elements: mockElements,
-    clientSecret: 'sec',
-  });
+  expect(mockConfirm).toHaveBeenCalledWith(
+    expect.objectContaining({
+      elements: mockElements,
+      clientSecret: 'sec',
+      confirmParams: expect.objectContaining({
+        return_url: expect.any(String),
+      }),
+      redirect: 'if_required',
+    }),
+  );
   expect(mockSavePaymentMethod).toHaveBeenCalledWith('pm_123');
   const link = await screen.findByRole('link', { name: /track this ride/i });
   expect(link).toHaveAttribute('href', '/t/ABC123');
@@ -204,10 +210,16 @@ test('handles google pay flow', async () => {
   expect(mockStripe.paymentRequest).toHaveBeenCalled();
   expect(mockCreateBooking).toHaveBeenCalledTimes(1);
   expect(mockShow).toHaveBeenCalled();
-  expect(mockConfirm).toHaveBeenCalledWith({
-    clientSecret: 'sec',
-    payment_method: 'tok_123',
-  });
+  expect(mockConfirm).toHaveBeenCalledWith(
+    expect.objectContaining({
+      clientSecret: 'sec',
+      payment_method: 'tok_123',
+      confirmParams: expect.objectContaining({
+        return_url: expect.any(String),
+      }),
+      redirect: 'if_required',
+    }),
+  );
   expect(mockSavePaymentMethod).toHaveBeenCalledWith('pm_123');
   const link = await screen.findByRole('link', { name: /track this ride/i });
   expect(link).toHaveAttribute('href', '/t/ABC123');

--- a/frontend/src/components/BookingWizard/PaymentStep.tsx
+++ b/frontend/src/components/BookingWizard/PaymentStep.tsx
@@ -185,6 +185,8 @@ function PaymentInner({
       const setup = await stripe.confirmSetup({
         clientSecret,
         payment_method: token,
+        confirmParams: { return_url: window.location.href },
+        redirect: 'if_required',
       });
       logger.info(
         'components/BookingWizard/PaymentStep',
@@ -219,6 +221,8 @@ function PaymentInner({
       const setup = await stripe.confirmSetup({
         elements,
         clientSecret,
+        confirmParams: { return_url: window.location.href },
+        redirect: 'if_required',
       });
       logger.info(
         'components/BookingWizard/PaymentStep',

--- a/frontend/src/pages/Profile/ProfileForm.tsx
+++ b/frontend/src/pages/Profile/ProfileForm.tsx
@@ -177,6 +177,8 @@ const ProfileForm = ({
         const setup = await stripe.confirmSetup({
           elements,
           clientSecret,
+          confirmParams: { return_url: window.location.href },
+          redirect: 'if_required',
         });
         logger.info(
           'pages/Profile/ProfileForm',

--- a/frontend/src/pages/Profile/ProfilePage.test.tsx
+++ b/frontend/src/pages/Profile/ProfilePage.test.tsx
@@ -240,10 +240,16 @@ describe('ProfilePage', () => {
     await userEvent.click(screen.getByRole('button', { name: /add card/i }));
     await screen.findByTestId('payment-element');
     await userEvent.click(screen.getByRole('button', { name: /save card/i }));
-    expect(mockConfirm).toHaveBeenCalledWith({
-      elements: mockElements,
-      clientSecret: 'sec',
-    });
+    expect(mockConfirm).toHaveBeenCalledWith(
+      expect.objectContaining({
+        elements: mockElements,
+        clientSecret: 'sec',
+        confirmParams: expect.objectContaining({
+          return_url: expect.any(String),
+        }),
+        redirect: 'if_required',
+      }),
+    );
     const postCalls = fetch.mock.calls.filter(
       ([url, init]) =>
         typeof url === 'string' &&


### PR DESCRIPTION
## Summary
- add `confirmParams` and `redirect` to Stripe `confirmSetup` calls
- update tests and mocks to expect new signature

## Testing
- `npm run lint`
- `npm test -- --run src/components/BookingWizard/PaymentStep.test.tsx src/pages/Profile/ProfilePage.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68bfc26bcc3c8331981b70413ef975f3