### PR TITLE
fix: handle Stripe setup redirects in payment step

### DIFF
--- a/frontend/src/components/BookingWizard/PaymentStep.test.tsx
+++ b/frontend/src/components/BookingWizard/PaymentStep.test.tsx
@@ -113,6 +113,8 @@ test('handles new card flow', async () => {
   expect(mockConfirm).toHaveBeenCalledWith({
     elements: mockElements,
     clientSecret: 'sec',
+    confirmParams: { return_url: window.location.href },
+    redirect: 'if_required',
   });
   expect(mockSavePaymentMethod).toHaveBeenCalledWith('pm_123');
   const link = await screen.findByRole('link', { name: /track this ride/i });
@@ -207,6 +209,8 @@ test('handles google pay flow', async () => {
   expect(mockConfirm).toHaveBeenCalledWith({
     clientSecret: 'sec',
     payment_method: 'tok_123',
+    confirmParams: { return_url: window.location.href },
+    redirect: 'if_required',
   });
   expect(mockSavePaymentMethod).toHaveBeenCalledWith('pm_123');
   const link = await screen.findByRole('link', { name: /track this ride/i });

--- a/frontend/src/components/BookingWizard/PaymentStep.tsx
+++ b/frontend/src/components/BookingWizard/PaymentStep.tsx
@@ -185,6 +185,10 @@ function PaymentInner({
       const setup = await stripe.confirmSetup({
         clientSecret,
         payment_method: token,
+        confirmParams: {
+          return_url: window.location.href,
+        },
+        redirect: 'if_required',
       });
       logger.info(
         'components/BookingWizard/PaymentStep',
@@ -219,6 +223,10 @@ function PaymentInner({
       const setup = await stripe.confirmSetup({
         elements,
         clientSecret,
+        confirmParams: {
+          return_url: window.location.href,
+        },
+        redirect: 'if_required',
       });
       logger.info(
         'components/BookingWizard/PaymentStep',


### PR DESCRIPTION
## Summary
- add `confirmParams.return_url` and `redirect: 'if_required'` to Stripe `confirmSetup` in BookingWizard PaymentStep
- update PaymentStep tests to expect the new confirm options

## Testing
- `npm run lint`
- `cd frontend && npm test src/components/BookingWizard/PaymentStep.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68bfc26a70f083318ee62f97242daa5d