### PR TITLE
fix: merge confirm params in stripe setup

### DIFF
--- a/frontend/src/pages/Profile/ProfileForm.tsx
+++ b/frontend/src/pages/Profile/ProfileForm.tsx
@@ -185,8 +185,8 @@ const ProfileForm = ({
                 phone,
               },
             },
+            return_url: window.location.href,
           },
-          confirmParams: { return_url: window.location.href },
           redirect: 'if_required',
         });
         logger.info(

--- a/frontend/src/pages/Profile/ProfilePage.test.tsx
+++ b/frontend/src/pages/Profile/ProfilePage.test.tsx
@@ -238,23 +238,22 @@ describe('ProfilePage', () => {
     await screen.findByRole('heading', { name: /payment method/i });
     await userEvent.click(screen.getByRole('button', { name: /add card/i }));
     await screen.findByTestId('payment-element');
-    await userEvent.click(screen.getByRole('button', { name: /save card/i }));
-    expect(mockConfirm).toHaveBeenCalledWith({
-      elements: mockElements,
-      clientSecret: 'sec',
-      confirmParams: {
-        payment_method_data: {
-          billing_details: {
-            name: 'John Doe',
-            email: 'john@example.com',
-            phone: '',
+      await userEvent.click(screen.getByRole('button', { name: /save card/i }));
+      expect(mockConfirm).toHaveBeenCalledWith({
+        elements: mockElements,
+        clientSecret: 'sec',
+        confirmParams: {
+          payment_method_data: {
+            billing_details: {
+              name: 'John Doe',
+              email: 'john@example.com',
+              phone: '',
+            },
           },
-        },
           return_url: expect.any(String),
-        }),
+        },
         redirect: 'if_required',
-      }),
-    );
+      });
     const postCalls = fetch.mock.calls.filter(
       ([url, init]) =>
         typeof url === 'string' &&


### PR DESCRIPTION
## Summary
- merge Stripe confirmSetup parameters into single object and include return URL
- adjust profile page test for unified confirmSetup parameters

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bfcb501e008331a4b2cc4eb82c968f