### PR TITLE
fix: hide billing detail fields in payment step

### DIFF
--- a/frontend/src/components/BookingWizard/PaymentStep.test.tsx
+++ b/frontend/src/components/BookingWizard/PaymentStep.test.tsx
@@ -93,9 +93,10 @@ test('handles new card flow', async () => {
       </DevFeaturesProvider>
     </MemoryRouter>,
   );
-
-  const phoneField = await screen.findByLabelText(/phone/i);
-  expect(phoneField).toHaveAttribute('readonly');
+  await screen.findByRole('button', { name: /submit/i });
+  expect(screen.queryByLabelText(/name/i)).not.toBeInTheDocument();
+  expect(screen.queryByLabelText(/email/i)).not.toBeInTheDocument();
+  expect(screen.queryByLabelText(/phone/i)).not.toBeInTheDocument();
   expect(mockCreateBooking).toHaveBeenCalledWith(
     expect.objectContaining({
       pickup_when: '2025-01-01T00:00:00Z',
@@ -121,6 +122,7 @@ test('handles new card flow', async () => {
           phone: '123',
         },
       },
+      return_url: window.location.href,
     },
     redirect: 'if_required',
   });

--- a/frontend/src/components/BookingWizard/PaymentStep.tsx
+++ b/frontend/src/components/BookingWizard/PaymentStep.tsx
@@ -1,4 +1,4 @@
-import { Stack, TextField, Button, Typography } from '@mui/material';
+import { Stack, Button, Typography } from '@mui/material';
 import {
   Elements,
   PaymentElement,
@@ -266,9 +266,6 @@ function PaymentInner({
 
   return (
     <Stack spacing={2}>
-      <TextField label="Name" value={name} InputProps={{ readOnly: true }} />
-      <TextField label="Email" value={email} InputProps={{ readOnly: true }} />
-      <TextField label="Phone" value={phone} InputProps={{ readOnly: true }} />
       {price != null && (
         <Typography>Estimated fare: ${price.toFixed(2)}</Typography>
       )}


### PR DESCRIPTION
## Summary
- hide name, email, and phone fields from the payment step UI while preserving programmatic billing details
- update payment step tests accordingly

## Testing
- `npm run lint` *(fails: Parsing error in ProfilePage.test.tsx)*
- `npx eslint src/components/BookingWizard/PaymentStep.tsx src/components/BookingWizard/PaymentStep.test.tsx`
- `npm test src/components/BookingWizard/PaymentStep.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68bfcb39f2f08331a30d2ad90f731244