### PR TITLE
test: ensure ride history test waits for websocket

### DIFF
--- a/frontend/src/pages/Booking/RideHistoryPage.test.tsx
+++ b/frontend/src/pages/Booking/RideHistoryPage.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, act } from '@testing-library/react';
+import { render, screen, waitFor, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter, Routes, Route } from 'react-router-dom';
 import RideHistoryPage from './RideHistoryPage';
@@ -140,6 +140,7 @@ test('updates status when websocket message received', async () => {
       </BookingsProvider>
     </MemoryRouter>,
   );
+  await waitFor(() => expect(WSStub.instances.length).toBeGreaterThan(0));
   expect(await screen.findByText('PENDING')).toBeInTheDocument();
   expect(
     driverBookingsApi.listBookingsApiV1DriverBookingsGet,


### PR DESCRIPTION
## Summary
- wait for WebSocket stub initialization in ride history status update test
- trigger WebSocket message after stub appears to verify UI update

## Testing
- `npm run lint`
- `cd backend && pytest -q --maxfail=1 --disable-warnings`
- `cd frontend && npm test RideHistoryPage.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68bfd2ffcd94833193a84ac79ef20ea0