### PR TITLE
feat: tune SQLite engine and enable WAL

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -48,6 +48,12 @@ alembic upgrade head
 You may need to drop or rename tables created outside Alembic before applying
 migrations.
 
+## SQLite Tuning
+
+The development SQLite database is configured with a 30-second timeout and
+enables Write-Ahead Logging (WAL) for improved concurrency. These settings are
+applied automatically by the application.
+
 > Scroll down for code samples, example requests and responses. Select a language for code samples from the tabs above or the mobile navigation menu.
 
 # Authentication


### PR DESCRIPTION
## Summary
- extend SQLite engine connect args with a 30s timeout
- enable WAL journaling for SQLite databases
- document SQLite tuning settings

## Testing
- `npm run lint`
- `cd backend && pytest -q --maxfail=1 --disable-warnings`

------
https://chatgpt.com/codex/tasks/task_e_68bfe356c7e483319a0ab8ae6362326a