### PR TITLE
refactor: require payment method for bookings

### DIFF
--- a/backend/app/api/users.py
+++ b/backend/app/api/users.py
@@ -2,15 +2,11 @@
 
 import logging
 import uuid
-from typing import List
-
-from fastapi import APIRouter, Depends, status
-from pydantic import BaseModel
-from sqlalchemy.ext.asyncio import AsyncSession
+from typing import List, Optional
 
 from app.dependencies import get_current_user, get_db
 from app.models.user_v2 import User
-from app.schemas.api_booking import StripePaymentMethod, StripeSetupIntent
+from app.schemas.api_booking import StripePaymentMethod
 from app.schemas.user import UserCreate, UserRead, UserUpdate
 from app.services.user_service import (
     create_setup_intent_for_user,
@@ -23,6 +19,9 @@ from app.services.user_service import (
     save_payment_method,
     update_user,
 )
+from fastapi import APIRouter, Depends, status
+from pydantic import BaseModel, Field
+from sqlalchemy.ext.asyncio import AsyncSession
 
 logger = logging.getLogger(__name__)
 
@@ -111,6 +110,12 @@ async def api_delete_user(
 
 class PaymentMethodPayload(BaseModel):
     payment_method_id: str
+
+
+class StripeSetupIntent(BaseModel):
+    setup_intent_client_secret: Optional[str] = Field(
+        default=None, alias="setup_intent_client_secret"
+    )
 
 
 @router.post("/me/payment-method", response_model=StripeSetupIntent)

--- a/backend/app/api/v1/bookings.py
+++ b/backend/app/api/v1/bookings.py
@@ -6,7 +6,6 @@ from app.schemas.api_booking import (
     BookingCreateRequest,
     BookingCreateResponse,
     BookingPublic,
-    StripeSetupIntent,
 )
 from app.services import booking_service
 from fastapi import APIRouter, Depends, HTTPException, status
@@ -24,11 +23,8 @@ async def create_booking_endpoint(
     user: User = Depends(get_current_user_v2),
 ) -> BookingCreateResponse:
     try:
-        booking, client_secret = await booking_service.create_booking(db, payload, user)
+        booking = await booking_service.create_booking(db, payload, user)
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     booking_public = BookingPublic.model_validate(booking)
-    return BookingCreateResponse(
-        booking=booking_public,
-        stripe=StripeSetupIntent(setup_intent_client_secret=client_secret),
-    )
+    return BookingCreateResponse(booking=booking_public)

--- a/backend/app/schemas/api_booking.py
+++ b/backend/app/schemas/api_booking.py
@@ -5,7 +5,7 @@ from datetime import datetime, timezone
 from typing import Optional
 
 from app.models.booking import BookingStatus
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, field_validator
 
 
 class Location(BaseModel):
@@ -40,12 +40,6 @@ class BookingPublic(BaseModel):
         from_attributes = True
 
 
-class StripeSetupIntent(BaseModel):
-    setup_intent_client_secret: Optional[str] = Field(
-        default=None, alias="setup_intent_client_secret"
-    )
-
-
 class StripePaymentMethod(BaseModel):
     brand: str
     last4: str
@@ -53,7 +47,6 @@ class StripePaymentMethod(BaseModel):
 
 class BookingCreateResponse(BaseModel):
     booking: BookingPublic
-    stripe: StripeSetupIntent
 
 
 class BookingStatusResponse(BaseModel):


### PR DESCRIPTION
## Summary
- require a saved payment method when creating bookings and drop setup intent generation
- simplify booking creation schema and endpoint to return only booking data
- adjust booking tests for new behaviour and error cases

## Testing
- `cd backend && pytest tests/unit/services/test_booking_service.py tests/integration/test_booking_create_api.py -q --maxfail=1 --disable-warnings`

------
https://chatgpt.com/codex/tasks/task_e_68bff74b75c48331a0342a295af07a1d