### PR TITLE
fix: configure Stripe for Australia

### DIFF
--- a/frontend/src/components/BookingWizard/PaymentStep.test.tsx
+++ b/frontend/src/components/BookingWizard/PaymentStep.test.tsx
@@ -128,6 +128,7 @@ test('handles new card flow', async () => {
           name: 'Test User',
           email: 'test@example.com',
           phone: '123',
+          address: { country: 'AU' },
         },
       },
       return_url: window.location.href,
@@ -164,7 +165,9 @@ test('renders google pay button when supported', async () => {
 
   const gpButton = await screen.findByTestId('google-pay');
   expect(gpButton).toBeInTheDocument();
-  expect(mockStripe.paymentRequest).toHaveBeenCalled();
+  expect(mockStripe.paymentRequest).toHaveBeenCalledWith(
+    expect.objectContaining({ country: 'AU', currency: 'aud' })
+  );
 });
 
 test('does not render google pay button when unsupported', async () => {
@@ -221,7 +224,9 @@ test('handles google pay flow', async () => {
   const gpButton = await screen.findByTestId('google-pay');
   await userEvent.click(gpButton);
 
-  expect(mockStripe.paymentRequest).toHaveBeenCalled();
+  expect(mockStripe.paymentRequest).toHaveBeenCalledWith(
+    expect.objectContaining({ country: 'AU', currency: 'aud' })
+  );
   expect(mockCreateBooking).toHaveBeenCalledTimes(1);
   expect(mockShow).toHaveBeenCalled();
   expect(mockConfirm).toHaveBeenCalledWith({

--- a/frontend/src/components/BookingWizard/PaymentStep.tsx
+++ b/frontend/src/components/BookingWizard/PaymentStep.tsx
@@ -158,8 +158,8 @@ function PaymentInner({
     async function initPaymentRequest() {
       if (!stripe || savedPaymentMethod) return;
       const pr = stripe.paymentRequest({
-        country: 'US',
-        currency: 'usd',
+        country: 'AU',
+        currency: 'aud',
         total: { label: 'Deposit', amount: 0 },
         requestPayerName: true,
         requestPayerEmail: true,
@@ -238,7 +238,12 @@ function PaymentInner({
         clientSecret: clientSecret!,
         confirmParams: {
           payment_method_data: {
-            billing_details: { name, email, phone },
+            billing_details: {
+              name,
+              email,
+              phone,
+              address: { country: 'AU' },
+            },
           },
           return_url: window.location.href,
         },
@@ -306,18 +311,20 @@ function PaymentInner({
           Using saved card {savedPaymentMethod.brand} ending in {savedPaymentMethod.last4}
         </Typography>
       ) : (
-        <PaymentElement
-          options={{
-            defaultValues: { billingDetails: { name, email, phone } },
-            fields: {
-              billingDetails: {
-                name: 'never',
-                email: 'never',
-                phone: 'never',
+          <PaymentElement
+            options={{
+              defaultValues: {
+                billingDetails: { name, email, phone, address: { country: 'AU' } },
               },
-            },
-          }}
-        />
+              fields: {
+                billingDetails: {
+                  name: 'never',
+                  email: 'never',
+                  phone: 'never',
+                },
+              },
+            }}
+          />
       )}
       <Stack direction="row" spacing={1}>
         <Button onClick={onBack}>Back</Button>


### PR DESCRIPTION
## Summary
- use Australian country and currency in Stripe payment request
- prefill billing address with Australia and send it to confirmSetup
- adjust tests for new Stripe configuration

## Testing
- `npm run lint`
- `cd frontend && npm test src/components/BookingWizard/PaymentStep.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68bff8ad96088331b0a7c97ef037eac7