### PR TITLE
feat: require default payment method for bookings

### DIFF
--- a/backend/app/services/booking_service.py
+++ b/backend/app/services/booking_service.py
@@ -35,6 +35,9 @@ async def create_booking(
 
     customer = user
 
+    if not customer.stripe_payment_method_id:
+        raise ValueError("default payment method required")
+
     settings = (await db.execute(select(AdminConfig))).scalar_one_or_none()
     if settings is None:
         settings = AdminConfig(

--- a/backend/tests/integration/test_booking_create_api.py
+++ b/backend/tests/integration/test_booking_create_api.py
@@ -2,11 +2,12 @@ from datetime import datetime, timedelta, timezone
 
 import pytest
 from _pytest.monkeypatch import MonkeyPatch
+from httpx import AsyncClient
+from sqlalchemy import delete
+
 from app.core.security import create_jwt_token, hash_password
 from app.models.settings import AdminConfig
 from app.models.user_v2 import User, UserRole
-from httpx import AsyncClient
-from sqlalchemy import delete
 
 pytestmark = pytest.mark.asyncio
 
@@ -150,4 +151,4 @@ async def test_create_booking_requires_payment_method(
 
     res = await client.post("/api/v1/bookings", json=payload, headers=headers)
     assert res.status_code == 400
-    assert res.json()["detail"] == "customer has no payment method"
+    assert res.json()["detail"] == "default payment method required"


### PR DESCRIPTION
## Summary
- ensure booking creation requires a default payment method
- update integration test for missing payment method

## Testing
- `npm run lint`
- `cd backend && pytest -q --maxfail=1 --disable-warnings tests/integration/test_booking_create_api.py::test_create_booking_requires_payment_method`


------
https://chatgpt.com/codex/tasks/task_e_68c0836f69e88331a135bfee87314d5f