### PR TITLE
test: load test env via pytest-dotenv

### DIFF
--- a/backend/pytest.ini
+++ b/backend/pytest.ini
@@ -3,4 +3,5 @@ asyncio_mode = auto
 testpaths = tests
 python_files = test_*.py *_test.py
 pythonpath = .
-env_files = .env.test
+env_files =
+    .env.test

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -33,6 +33,7 @@ python-dotenv
 pytest
 pytest-asyncio
 pytest-mock
+pytest-dotenv
 httpx
 python-multipart
 python-json-logger


### PR DESCRIPTION
## Summary
- add pytest-dotenv to backend dev requirements
- configure pytest to load variables from `.env.test`

## Testing
- `pytest tests/unit -q --maxfail=1 --disable-warnings`

------
https://chatgpt.com/codex/tasks/task_e_68c08d6013548331925c5d8a37531721