### PR TITLE
test: default ENV var for tests

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,5 +1,8 @@
-import asyncio
 import os
+
+os.environ.setdefault("ENV", "test")
+
+import asyncio
 import tempfile
 import uuid
 from pathlib import Path


### PR DESCRIPTION
## Summary
- set `ENV=test` in test configuration so backend tests use test settings

## Testing
- `pip show pytest-dotenv`
- `pytest -q --maxfail=1 --disable-warnings` *(fails: UNIQUE constraint failed: users_v2.email)*

------
https://chatgpt.com/codex/tasks/task_e_68c090b9ff0c83318d3cd9d872909787