### PR TITLE
test: mock AuthContext before BookingWizardPage imports

### DIFF
--- a/frontend/src/pages/Booking/BookingWizardPage.test.tsx
+++ b/frontend/src/pages/Booking/BookingWizardPage.test.tsx
@@ -1,12 +1,6 @@
 import { vi, beforeAll, beforeEach, afterEach, expect, test } from 'vitest';
+
 vi.stubEnv('VITE_API_BASE_URL', '');
-import { renderWithProviders } from '@/__tests__/setup/renderWithProviders';
-import { screen, waitFor } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
-import React from 'react';
-import { server } from '@/__tests__/setup/msw.server';
-import { http, HttpResponse } from 'msw';
-import { apiUrl } from '@/__tests__/setup/msw.handlers';
 
 vi.mock('@/contexts/AuthContext', () => ({
   useAuth: () => ({
@@ -16,6 +10,13 @@ vi.mock('@/contexts/AuthContext', () => ({
   AuthProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }));
 
+import { renderWithProviders } from '@/__tests__/setup/renderWithProviders';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { server } from '@/__tests__/setup/msw.server';
+import { http, HttpResponse } from 'msw';
+import { apiUrl } from '@/__tests__/setup/msw.handlers';
 import BookingWizardPage from './BookingWizardPage';
 
 const createBooking = vi


### PR DESCRIPTION
## Summary
- ensure AuthContext is mocked before importing BookingWizardPage so test components use mocked provider

## Testing
- `npm run lint`
- `npm --prefix frontend test src/pages/Booking/BookingWizardPage.test.tsx` *(fails: process hangs, see logs)*

------
https://chatgpt.com/codex/tasks/task_e_68c0966fc94483318659d0f26ff4b1cc