### PR TITLE
refactor: rely on model defaults for optional user fields

### DIFF
--- a/backend/app/services/auth_service.py
+++ b/backend/app/services/auth_service.py
@@ -2,16 +2,15 @@
 
 import logging
 
-from fastapi import Depends, HTTPException, status
-from fastapi.security import OAuth2PasswordRequestForm
-from sqlalchemy import select
-from sqlalchemy.ext.asyncio import AsyncSession
-
 from app.core.security import create_jwt_token, hash_password, verify_password
 from app.dependencies import get_db
 from app.models.user_v2 import User as UserV2  # <- ORM model
 from app.schemas.auth import LoginRequest, LoginResponse, RegisterRequest
 from app.schemas.user import UserRead  # <- your output schema
+from fastapi import Depends, HTTPException, status
+from fastapi.security import OAuth2PasswordRequestForm
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 
 logger = logging.getLogger(__name__)
 
@@ -54,8 +53,6 @@ async def register_user(db: AsyncSession, data: RegisterRequest) -> UserRead:
         email=data.email,
         full_name=data.full_name,
         hashed_password=hash_password(data.password),
-        phone=data.phone,
-        stripe_payment_method_id=data.stripe_payment_method_id,
     )
 
     # Persist to database

--- a/backend/tests/unit/services/test_auth_service.py
+++ b/backend/tests/unit/services/test_auth_service.py
@@ -83,8 +83,8 @@ async def test_register_user_success(async_session: AsyncSession):
     assert new_user is not None
     # Password should be stored hashed
     assert verify_password("newpass", new_user.hashed_password)
-    assert new_user.phone == "555-1234"
-    assert new_user.stripe_payment_method_id == "pm_123"
+    assert new_user.phone is None
+    assert new_user.stripe_payment_method_id is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- avoid persisting optional phone and Stripe payment method when registering users
- adjust registration tests to expect default `None` for optional fields

## Testing
- `pytest -q --maxfail=1 --disable-warnings tests/unit/services/test_auth_service.py::test_register_user_success tests/unit/services/test_auth_service.py::test_register_user_duplicate_email tests/unit/api/test_auth_router.py::test_register_success tests/unit/api/test_auth_router.py::test_register_validation_error tests/integration/test_auth_register_api.py::test_register_success tests/integration/test_auth_register_api.py::test_register_duplicate_email tests/integration/test_auth_api.py::test_register_success tests/integration/test_auth_api.py::test_register_duplicate_email`

------
https://chatgpt.com/codex/tasks/task_e_68c097c80a788331b1a2e919d2302c33