### PR TITLE
fix: streamline registration form

### DIFF
--- a/frontend/src/__tests__/setup/msw.handlers.ts
+++ b/frontend/src/__tests__/setup/msw.handlers.ts
@@ -7,8 +7,6 @@ type RegisterBody = {
   full_name: string;
   email: string;
   password: string;
-  phone?: string;
-  stripe_payment_method_id?: string;
 };
 type SettingsBody = {
   account_mode: boolean;

--- a/frontend/src/api-client/api.ts
+++ b/frontend/src/api-client/api.ts
@@ -572,18 +572,6 @@ export interface RegisterRequest {
      * @memberof RegisterRequest
      */
     'password': string;
-    /**
-     * 
-     * @type {string}
-     * @memberof RegisterRequest
-     */
-    'phone'?: string | null;
-    /**
-     * 
-     * @type {string}
-     * @memberof RegisterRequest
-     */
-    'stripe_payment_method_id'?: string | null;
 }
 /**
  * 

--- a/frontend/src/pages/Auth/RegisterPage.test.tsx
+++ b/frontend/src/pages/Auth/RegisterPage.test.tsx
@@ -10,6 +10,12 @@ import { apiUrl } from '@/__tests__/setup/msw.handlers';
 
 const label = (re: RegExp | string) => screen.getByLabelText(re, { selector: 'input' });
 
+test('does not render phone or payment method fields', () => {
+  renderWithProviders(<RegisterPage />, { initialPath: '/register' });
+  expect(screen.queryByLabelText(/phone/i)).not.toBeInTheDocument();
+  expect(screen.queryByLabelText(/payment method/i)).not.toBeInTheDocument();
+});
+
 test('registers successfully and navigates to /book', async () => {
   renderWithProviders(<RegisterPage />, {
     initialPath: '/register',

--- a/frontend/src/pages/Auth/RegisterPage.tsx
+++ b/frontend/src/pages/Auth/RegisterPage.tsx
@@ -18,26 +18,21 @@ const authApi = new AuthApi(configuration);
 
 function RegisterPage() {
     const [email, setEmail] = useState("");
-    const [full_name, setName] = useState("");
+    const [fullName, setFullName] = useState("");
     const [password, setPassword] = useState("");
-    const [phone, setPhone] = useState("");
-    const [paymentMethodId, setPaymentMethodId] = useState("");
     const [error, setError] = useState("");
     const { loginWithPassword } = useAuth();
     const navigate = useNavigate();
-    
+
     const handleSubmit = async (e: React.FormEvent) => {
         e.preventDefault();
         setError("");
 
         const registerRequest: RegisterRequest = {
             email,
-            full_name,
+            full_name: fullName,
             password,
         };
-        if (phone) registerRequest.phone = phone;
-        if (paymentMethodId)
-            registerRequest.stripe_payment_method_id = paymentMethodId;
 
         try {
             // Register the user
@@ -90,8 +85,8 @@ function RegisterPage() {
             <TextField
               label="Full Name"
               type="text"
-              value={full_name}
-              onChange={(e) => setName(e.target.value)}
+              value={fullName}
+              onChange={(e) => setFullName(e.target.value)}
               fullWidth
               required
               margin="normal"
@@ -113,22 +108,6 @@ function RegisterPage() {
               onChange={(e) => setPassword(e.target.value)}
               fullWidth
               required
-              margin="normal"
-            />
-            <TextField
-              label="Phone"
-              type="tel"
-              value={phone}
-              onChange={(e) => setPhone(e.target.value)}
-              fullWidth
-              margin="normal"
-            />
-            <TextField
-              label="Default Payment Method ID"
-              type="text"
-              value={paymentMethodId}
-              onChange={(e) => setPaymentMethodId(e.target.value)}
-              fullWidth
               margin="normal"
             />
 


### PR DESCRIPTION
## Summary
- remove phone and payment method fields from RegisterPage
- limit RegisterRequest to email, full_name, and password
- test that registration form renders only the required inputs

## Testing
- `npm run lint`
- `npx vitest run src/pages/Auth/RegisterPage.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c097cfe42083319032946b557bbe54