### PR TITLE
fix: memoize booking update handler

### DIFF
--- a/frontend/src/components/BookingWizard/BookingWizard.tsx
+++ b/frontend/src/components/BookingWizard/BookingWizard.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useCallback } from 'react';
 import {
   Box,
   Button,
@@ -35,9 +35,9 @@ export default function BookingWizard({
     null,
   );
   const [error, setError] = useState<string | null>(null);
-  const update = (data: Partial<BookingFormData>) => {
+  const update = useCallback((data: Partial<BookingFormData>) => {
     setForm((f) => ({ ...f, ...data }));
-  };
+  }, []);
   const handleConfirm = async () => {
     if (!form.pickup_when || !form.pickup || !form.dropoff) return;
     setError(null);


### PR DESCRIPTION
## Summary
- memoize booking wizard update handler using `useCallback`

## Testing
- `npm run lint`
- `cd backend && pytest -q --maxfail=1 --disable-warnings`
- `cd frontend && npx vitest run src/pages/Booking/BookingWizardPage.test.tsx -t "creates booking on confirmation and shows tracking link"`


------
https://chatgpt.com/codex/tasks/task_e_68c098715d608331843099f7c440bb45