### PR TITLE
feat: remove phone and payment method from registration

### DIFF
--- a/backend/app/schemas/auth.py
+++ b/backend/app/schemas/auth.py
@@ -40,8 +40,6 @@ class RegisterRequest(BaseModel):
     email: EmailStr
     full_name: str
     password: str
-    phone: Optional[str] = None
-    stripe_payment_method_id: Optional[str] = None
 
 
 class TokenResponse(BaseModel):

--- a/backend/app/services/auth_service.py
+++ b/backend/app/services/auth_service.py
@@ -54,8 +54,6 @@ async def register_user(db: AsyncSession, data: RegisterRequest) -> UserRead:
         email=data.email,
         full_name=data.full_name,
         hashed_password=hash_password(data.password),
-        phone=data.phone,
-        stripe_payment_method_id=data.stripe_payment_method_id,
     )
 
     # Persist to database

--- a/backend/tests/unit/services/test_auth_service.py
+++ b/backend/tests/unit/services/test_auth_service.py
@@ -62,8 +62,6 @@ async def test_register_user_success(async_session: AsyncSession):
         email="new@async.com",
         full_name="New Async",
         password="newpass",
-        phone="555-1234",
-        stripe_payment_method_id="pm_123",
     )
     result = await auth_service.register_user(async_session, register_req)
     # Should return a UserRead schema for the new user
@@ -83,8 +81,8 @@ async def test_register_user_success(async_session: AsyncSession):
     assert new_user is not None
     # Password should be stored hashed
     assert verify_password("newpass", new_user.hashed_password)
-    assert new_user.phone == "555-1234"
-    assert new_user.stripe_payment_method_id == "pm_123"
+    assert new_user.phone is None
+    assert new_user.stripe_payment_method_id is None
 
 
 @pytest.mark.asyncio

--- a/frontend/src/__tests__/setup/msw.handlers.ts
+++ b/frontend/src/__tests__/setup/msw.handlers.ts
@@ -7,8 +7,6 @@ type RegisterBody = {
   full_name: string;
   email: string;
   password: string;
-  phone?: string;
-  stripe_payment_method_id?: string;
 };
 type SettingsBody = {
   account_mode: boolean;

--- a/frontend/src/api-client/api.ts
+++ b/frontend/src/api-client/api.ts
@@ -147,12 +147,6 @@ export interface BookingCreateResponse {
      * @memberof BookingCreateResponse
      */
     'booking': BookingPublic;
-    /**
-     * 
-     * @type {StripeSetupIntent}
-     * @memberof BookingCreateResponse
-     */
-    'stripe': StripeSetupIntent;
 }
 /**
  * 
@@ -572,18 +566,6 @@ export interface RegisterRequest {
      * @memberof RegisterRequest
      */
     'password': string;
-    /**
-     * 
-     * @type {string}
-     * @memberof RegisterRequest
-     */
-    'phone'?: string | null;
-    /**
-     * 
-     * @type {string}
-     * @memberof RegisterRequest
-     */
-    'stripe_payment_method_id'?: string | null;
 }
 /**
  * 
@@ -714,7 +696,7 @@ export interface StripeSetupIntent {
      * @type {string}
      * @memberof StripeSetupIntent
      */
-    'setup_intent_client_secret': string;
+    'setup_intent_client_secret'?: string | null;
 }
 /**
  * 
@@ -2774,15 +2756,15 @@ export const RouteMetricsApiAxiosParamCreator = function (configuration?: Config
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        apiRouteMetricsRouteMetricsGet: async (pickupLat: number, pickupLon: number, dropoffLat: number, dropoffLon: number, rideTime?: string | null, routeMetricsRequest?: RouteMetricsRequest, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+        apiRouteMetricsRouteMetricsPost: async (pickupLat: number, pickupLon: number, dropoffLat: number, dropoffLon: number, rideTime?: string | null, routeMetricsRequest?: RouteMetricsRequest, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'pickupLat' is not null or undefined
-            assertParamExists('apiRouteMetricsRouteMetricsGet', 'pickupLat', pickupLat)
+            assertParamExists('apiRouteMetricsRouteMetricsPost', 'pickupLat', pickupLat)
             // verify required parameter 'pickupLon' is not null or undefined
-            assertParamExists('apiRouteMetricsRouteMetricsGet', 'pickupLon', pickupLon)
+            assertParamExists('apiRouteMetricsRouteMetricsPost', 'pickupLon', pickupLon)
             // verify required parameter 'dropoffLat' is not null or undefined
-            assertParamExists('apiRouteMetricsRouteMetricsGet', 'dropoffLat', dropoffLat)
+            assertParamExists('apiRouteMetricsRouteMetricsPost', 'dropoffLat', dropoffLat)
             // verify required parameter 'dropoffLon' is not null or undefined
-            assertParamExists('apiRouteMetricsRouteMetricsGet', 'dropoffLon', dropoffLon)
+            assertParamExists('apiRouteMetricsRouteMetricsPost', 'dropoffLon', dropoffLon)
             const localVarPath = `/route-metrics`;
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
@@ -2843,15 +2825,15 @@ export const RouteMetricsApiAxiosParamCreator = function (configuration?: Config
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        apiRouteMetricsRouteMetricsGet_1: async (pickupLat: number, pickupLon: number, dropoffLat: number, dropoffLon: number, rideTime?: string | null, routeMetricsRequest?: RouteMetricsRequest, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+        apiRouteMetricsRouteMetricsPost_1: async (pickupLat: number, pickupLon: number, dropoffLat: number, dropoffLon: number, rideTime?: string | null, routeMetricsRequest?: RouteMetricsRequest, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'pickupLat' is not null or undefined
-            assertParamExists('apiRouteMetricsRouteMetricsGet_1', 'pickupLat', pickupLat)
+            assertParamExists('apiRouteMetricsRouteMetricsPost_1', 'pickupLat', pickupLat)
             // verify required parameter 'pickupLon' is not null or undefined
-            assertParamExists('apiRouteMetricsRouteMetricsGet_1', 'pickupLon', pickupLon)
+            assertParamExists('apiRouteMetricsRouteMetricsPost_1', 'pickupLon', pickupLon)
             // verify required parameter 'dropoffLat' is not null or undefined
-            assertParamExists('apiRouteMetricsRouteMetricsGet_1', 'dropoffLat', dropoffLat)
+            assertParamExists('apiRouteMetricsRouteMetricsPost_1', 'dropoffLat', dropoffLat)
             // verify required parameter 'dropoffLon' is not null or undefined
-            assertParamExists('apiRouteMetricsRouteMetricsGet_1', 'dropoffLon', dropoffLon)
+            assertParamExists('apiRouteMetricsRouteMetricsPost_1', 'dropoffLon', dropoffLon)
             const localVarPath = `/route-metrics`;
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
@@ -2922,10 +2904,10 @@ export const RouteMetricsApiFp = function(configuration?: Configuration) {
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async apiRouteMetricsRouteMetricsGet(pickupLat: number, pickupLon: number, dropoffLat: number, dropoffLon: number, rideTime?: string | null, routeMetricsRequest?: RouteMetricsRequest, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<any>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.apiRouteMetricsRouteMetricsGet(pickupLat, pickupLon, dropoffLat, dropoffLon, rideTime, routeMetricsRequest, options);
+        async apiRouteMetricsRouteMetricsPost(pickupLat: number, pickupLon: number, dropoffLat: number, dropoffLon: number, rideTime?: string | null, routeMetricsRequest?: RouteMetricsRequest, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<any>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.apiRouteMetricsRouteMetricsPost(pickupLat, pickupLon, dropoffLat, dropoffLon, rideTime, routeMetricsRequest, options);
             const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
-            const localVarOperationServerBasePath = operationServerMap['RouteMetricsApi.apiRouteMetricsRouteMetricsGet']?.[localVarOperationServerIndex]?.url;
+            const localVarOperationServerBasePath = operationServerMap['RouteMetricsApi.apiRouteMetricsRouteMetricsPost']?.[localVarOperationServerIndex]?.url;
             return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
         },
         /**
@@ -2940,10 +2922,10 @@ export const RouteMetricsApiFp = function(configuration?: Configuration) {
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async apiRouteMetricsRouteMetricsGet_1(pickupLat: number, pickupLon: number, dropoffLat: number, dropoffLon: number, rideTime?: string | null, routeMetricsRequest?: RouteMetricsRequest, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<any>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.apiRouteMetricsRouteMetricsGet_1(pickupLat, pickupLon, dropoffLat, dropoffLon, rideTime, routeMetricsRequest, options);
+        async apiRouteMetricsRouteMetricsPost_1(pickupLat: number, pickupLon: number, dropoffLat: number, dropoffLon: number, rideTime?: string | null, routeMetricsRequest?: RouteMetricsRequest, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<any>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.apiRouteMetricsRouteMetricsPost_1(pickupLat, pickupLon, dropoffLat, dropoffLon, rideTime, routeMetricsRequest, options);
             const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
-            const localVarOperationServerBasePath = operationServerMap['RouteMetricsApi.apiRouteMetricsRouteMetricsGet_1']?.[localVarOperationServerIndex]?.url;
+            const localVarOperationServerBasePath = operationServerMap['RouteMetricsApi.apiRouteMetricsRouteMetricsPost_1']?.[localVarOperationServerIndex]?.url;
             return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
         },
     }
@@ -2968,8 +2950,8 @@ export const RouteMetricsApiFactory = function (configuration?: Configuration, b
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        apiRouteMetricsRouteMetricsGet(pickupLat: number, pickupLon: number, dropoffLat: number, dropoffLon: number, rideTime?: string | null, routeMetricsRequest?: RouteMetricsRequest, options?: RawAxiosRequestConfig): AxiosPromise<any> {
-            return localVarFp.apiRouteMetricsRouteMetricsGet(pickupLat, pickupLon, dropoffLat, dropoffLon, rideTime, routeMetricsRequest, options).then((request) => request(axios, basePath));
+        apiRouteMetricsRouteMetricsPost(pickupLat: number, pickupLon: number, dropoffLat: number, dropoffLon: number, rideTime?: string | null, routeMetricsRequest?: RouteMetricsRequest, options?: RawAxiosRequestConfig): AxiosPromise<any> {
+            return localVarFp.apiRouteMetricsRouteMetricsPost(pickupLat, pickupLon, dropoffLat, dropoffLon, rideTime, routeMetricsRequest, options).then((request) => request(axios, basePath));
         },
         /**
          * Return travel metrics between pickup and dropoff coordinates.
@@ -2983,8 +2965,8 @@ export const RouteMetricsApiFactory = function (configuration?: Configuration, b
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        apiRouteMetricsRouteMetricsGet_1(pickupLat: number, pickupLon: number, dropoffLat: number, dropoffLon: number, rideTime?: string | null, routeMetricsRequest?: RouteMetricsRequest, options?: RawAxiosRequestConfig): AxiosPromise<any> {
-            return localVarFp.apiRouteMetricsRouteMetricsGet_1(pickupLat, pickupLon, dropoffLat, dropoffLon, rideTime, routeMetricsRequest, options).then((request) => request(axios, basePath));
+        apiRouteMetricsRouteMetricsPost_1(pickupLat: number, pickupLon: number, dropoffLat: number, dropoffLon: number, rideTime?: string | null, routeMetricsRequest?: RouteMetricsRequest, options?: RawAxiosRequestConfig): AxiosPromise<any> {
+            return localVarFp.apiRouteMetricsRouteMetricsPost_1(pickupLat, pickupLon, dropoffLat, dropoffLon, rideTime, routeMetricsRequest, options).then((request) => request(axios, basePath));
         },
     };
 };
@@ -3009,8 +2991,8 @@ export class RouteMetricsApi extends BaseAPI {
      * @throws {RequiredError}
      * @memberof RouteMetricsApi
      */
-    public apiRouteMetricsRouteMetricsGet(pickupLat: number, pickupLon: number, dropoffLat: number, dropoffLon: number, rideTime?: string | null, routeMetricsRequest?: RouteMetricsRequest, options?: RawAxiosRequestConfig) {
-        return RouteMetricsApiFp(this.configuration).apiRouteMetricsRouteMetricsGet(pickupLat, pickupLon, dropoffLat, dropoffLon, rideTime, routeMetricsRequest, options).then((request) => request(this.axios, this.basePath));
+    public apiRouteMetricsRouteMetricsPost(pickupLat: number, pickupLon: number, dropoffLat: number, dropoffLon: number, rideTime?: string | null, routeMetricsRequest?: RouteMetricsRequest, options?: RawAxiosRequestConfig) {
+        return RouteMetricsApiFp(this.configuration).apiRouteMetricsRouteMetricsPost(pickupLat, pickupLon, dropoffLat, dropoffLon, rideTime, routeMetricsRequest, options).then((request) => request(this.axios, this.basePath));
     }
 
     /**
@@ -3026,8 +3008,8 @@ export class RouteMetricsApi extends BaseAPI {
      * @throws {RequiredError}
      * @memberof RouteMetricsApi
      */
-    public apiRouteMetricsRouteMetricsGet_1(pickupLat: number, pickupLon: number, dropoffLat: number, dropoffLon: number, rideTime?: string | null, routeMetricsRequest?: RouteMetricsRequest, options?: RawAxiosRequestConfig) {
-        return RouteMetricsApiFp(this.configuration).apiRouteMetricsRouteMetricsGet_1(pickupLat, pickupLon, dropoffLat, dropoffLon, rideTime, routeMetricsRequest, options).then((request) => request(this.axios, this.basePath));
+    public apiRouteMetricsRouteMetricsPost_1(pickupLat: number, pickupLon: number, dropoffLat: number, dropoffLon: number, rideTime?: string | null, routeMetricsRequest?: RouteMetricsRequest, options?: RawAxiosRequestConfig) {
+        return RouteMetricsApiFp(this.configuration).apiRouteMetricsRouteMetricsPost_1(pickupLat, pickupLon, dropoffLat, dropoffLon, rideTime, routeMetricsRequest, options).then((request) => request(this.axios, this.basePath));
     }
 }
 

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -215,7 +215,8 @@ useEffect(() => {
     }
   }, [state.accessToken]);
 
-  const persist = useCallback((t?: TokenResponse | null, user?: UserShape, role?: string | null) => {
+  const persist = useCallback(
+    (t?: TokenResponse | null, user?: UserShape | null, role?: string | null) => {
     const access_token = t?.access_token ?? null;
     const refresh_token = t?.refresh_token ?? null;
     if (access_token || refresh_token || user) {

--- a/frontend/src/pages/Auth/RegisterPage.tsx
+++ b/frontend/src/pages/Auth/RegisterPage.tsx
@@ -20,8 +20,6 @@ function RegisterPage() {
     const [email, setEmail] = useState("");
     const [full_name, setName] = useState("");
     const [password, setPassword] = useState("");
-    const [phone, setPhone] = useState("");
-    const [paymentMethodId, setPaymentMethodId] = useState("");
     const [error, setError] = useState("");
     const { loginWithPassword } = useAuth();
     const navigate = useNavigate();
@@ -35,9 +33,6 @@ function RegisterPage() {
             full_name,
             password,
         };
-        if (phone) registerRequest.phone = phone;
-        if (paymentMethodId)
-            registerRequest.stripe_payment_method_id = paymentMethodId;
 
         try {
             // Register the user
@@ -113,22 +108,6 @@ function RegisterPage() {
               onChange={(e) => setPassword(e.target.value)}
               fullWidth
               required
-              margin="normal"
-            />
-            <TextField
-              label="Phone"
-              type="tel"
-              value={phone}
-              onChange={(e) => setPhone(e.target.value)}
-              fullWidth
-              margin="normal"
-            />
-            <TextField
-              label="Default Payment Method ID"
-              type="text"
-              value={paymentMethodId}
-              onChange={(e) => setPaymentMethodId(e.target.value)}
-              fullWidth
               margin="normal"
             />
 


### PR DESCRIPTION
## Summary
- strip `phone` and `stripe_payment_method_id` from user registration schema and client
- update registration UI, mocks, and backend logic accordingly
- relax auth context persistence to accept null users

## Testing
- `npm run lint`
- `cd backend && pytest -q --maxfail=1 --disable-warnings`
- `cd frontend && npx vitest run`
- `cd frontend && npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68c097dbc0a08331bcbfbde20edf744e