### PR TITLE
fix: memoize booking form update

### DIFF
--- a/frontend/src/components/BookingWizard/BookingWizard.tsx
+++ b/frontend/src/components/BookingWizard/BookingWizard.tsx
@@ -41,9 +41,10 @@ export default function BookingWizard({
   const [durationMin, setDurationMin] = useState<number | null>(null);
   const [price, setPrice] = useState<number | null>(null);
   const { data: settings } = useSettings();
-  const update = (data: Partial<BookingFormData>) => {
-    setForm((f) => ({ ...f, ...data }));
-  }, []);
+  const update = useCallback(
+    (data: Partial<BookingFormData>) => setForm((f) => ({ ...f, ...data })),
+    [],
+  );
   const handleConfirm = async () => {
     if (!form.pickup_when || !form.pickup || !form.dropoff) return;
     setError(null);


### PR DESCRIPTION
## Summary
- memoize BookingWizard update handler with useCallback

## Testing
- `npm run lint`
- `npx vitest run` *(fails: BookingWizardPage.test.tsx > prompts to add a payment method when missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c09d18bb4c83319c0833a03c7e38ce