### PR TITLE
test: tidy auth registration tests and mocks

### DIFF
--- a/backend/tests/unit/services/test_auth_service.py
+++ b/backend/tests/unit/services/test_auth_service.py
@@ -1,12 +1,11 @@
 import pytest
-from fastapi import HTTPException
-from sqlalchemy import select
-from sqlalchemy.ext.asyncio import AsyncSession
-
 from app.core.security import hash_password, verify_password
 from app.models.user_v2 import User
 from app.schemas.auth import LoginRequest, RegisterRequest
 from app.services import auth_service
+from fastapi import HTTPException
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 
 
 @pytest.mark.asyncio

--- a/frontend/src/__tests__/setup/msw.handlers.ts
+++ b/frontend/src/__tests__/setup/msw.handlers.ts
@@ -1,4 +1,3 @@
-// frontend/tests/msw/handlers.ts
 import { http, HttpResponse } from "msw";
 import { CONFIG } from "@/config"
 


### PR DESCRIPTION
## Summary
- sort imports in auth service tests
- prune obsolete header comment in msw handlers

## Testing
- `python -m black --check backend/tests/unit/services/test_auth_service.py`
- `isort --check-only backend/tests/unit/services/test_auth_service.py`
- `cd backend && pytest tests/unit/services/test_auth_service.py -q --maxfail=1 --disable-warnings`
- `cd frontend && npx eslint src/__tests__/setup/msw.handlers.ts --fix`
- `npx vitest run src/components/PushToggle.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c09dea0cc083318eef7478fd6e6359