### PR TITLE
fix: include customer when charging deposits

### DIFF
--- a/backend/app/services/stripe_client.py
+++ b/backend/app/services/stripe_client.py
@@ -212,6 +212,7 @@ def charge_deposit(
     dropoff_address: str | None = None,
     pickup_time: datetime | None = None,
     payment_method: str,
+    customer_id: str | None = None,
 ):
     """Charge a deposit using a stored payment method."""
 
@@ -225,6 +226,9 @@ def charge_deposit(
         "confirm": True,
         "payment_method_types": ["card"],
     }
+    if customer_id:
+        params["customer"] = customer_id
+        params["off_session"] = True
 
     metadata = {
         "booking_id": str(booking_id),
@@ -258,6 +262,7 @@ def charge_final(
     dropoff_address: str | None = None,
     pickup_time: datetime | None = None,
     payment_method: str,
+    customer_id: str | None = None,
 ):
     """Charge the remaining fare amount."""
     if not payment_method:
@@ -270,6 +275,9 @@ def charge_final(
         "confirm": True,
         "payment_method_types": ["card"],
     }
+    if customer_id:
+        params["customer"] = customer_id
+        params["off_session"] = True
 
     metadata = {
         "booking_id": str(booking_id),

--- a/backend/tests/integration/test_availability_api.py
+++ b/backend/tests/integration/test_availability_api.py
@@ -83,6 +83,7 @@ async def _create_booking(async_session, when: datetime) -> Booking:
         hashed_password=hash_password("pass"),
         role=UserRole.CUSTOMER,
         stripe_payment_method_id="pm_test",
+        stripe_customer_id="cus_test",
     )
     async_session.add(user)
     await async_session.flush()

--- a/backend/tests/integration/test_driver_booking_actions_api.py
+++ b/backend/tests/integration/test_driver_booking_actions_api.py
@@ -19,6 +19,7 @@ async def _create_booking(async_session) -> Booking:
         hashed_password=hash_password("pass"),
         role=UserRole.CUSTOMER,
         stripe_payment_method_id="pm_test",
+        stripe_customer_id="cus_test",
     )
     async_session.add(user)
     await async_session.flush()

--- a/backend/tests/integration/test_driver_complete_api.py
+++ b/backend/tests/integration/test_driver_complete_api.py
@@ -28,6 +28,7 @@ async def _create_booking(async_session) -> Booking:
         hashed_password=hash_password("pass"),
         role=UserRole.CUSTOMER,
         stripe_payment_method_id="pm_test",
+        stripe_customer_id="cus_test",
     )
     async_session.add(user)
     await async_session.flush()

--- a/backend/tests/integration/test_driver_retry_deposit_api.py
+++ b/backend/tests/integration/test_driver_retry_deposit_api.py
@@ -23,6 +23,7 @@ async def _create_booking(async_session) -> Booking:
         hashed_password=hash_password("pass"),
         role=UserRole.CUSTOMER,
         stripe_payment_method_id="pm_test",
+        stripe_customer_id="cus_test",
     )
     async_session.add(user)
     await async_session.flush()

--- a/backend/tests/unit/services/test_booking_service.py
+++ b/backend/tests/unit/services/test_booking_service.py
@@ -3,14 +3,15 @@ from datetime import datetime, timedelta, timezone
 
 import pytest
 import stripe
+from fastapi import HTTPException
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
 from app.core.security import hash_password
 from app.models.booking import Booking, BookingStatus
 from app.models.user_v2 import User, UserRole
 from app.schemas.api_booking import BookingCreateRequest, Location
 from app.services import booking_service
-from fastapi import HTTPException
-from sqlalchemy import text
-from sqlalchemy.ext.asyncio import AsyncSession
 
 pytestmark = pytest.mark.asyncio
 
@@ -27,6 +28,7 @@ async def test_confirm_booking_handles_stripe_error(
         hashed_password=hash_password("pass"),
         role=UserRole.CUSTOMER,
         stripe_payment_method_id="pm_test",
+        stripe_customer_id="cus_test",
     )
     async_session.add(user)
     await async_session.flush()
@@ -80,6 +82,7 @@ async def test_confirm_booking_handles_card_error(async_session: AsyncSession, m
         hashed_password=hash_password("pass"),
         role=UserRole.CUSTOMER,
         stripe_payment_method_id="pm_test",
+        stripe_customer_id="cus_test",
     )
     async_session.add(user)
     await async_session.flush()

--- a/backend/tests/unit/services/test_stripe_client.py
+++ b/backend/tests/unit/services/test_stripe_client.py
@@ -64,9 +64,12 @@ def test_charge_deposit_with_google_pay_payment_method(mocker):
         amount_cents=5000,
         booking_id=uuid.uuid4(),
         payment_method="pm_gpay",
+        customer_id="cus_test",
     )
 
     assert captured["payment_method"] == "pm_gpay"
+    assert captured["customer"] == "cus_test"
+    assert captured["off_session"] is True
 
 
 def test_charge_final_with_google_pay_payment_method(mocker):
@@ -82,6 +85,9 @@ def test_charge_final_with_google_pay_payment_method(mocker):
         amount_cents=5000,
         booking_id=uuid.uuid4(),
         payment_method="pm_gpay",
+        customer_id="cus_test",
     )
 
     assert captured["payment_method"] == "pm_gpay"
+    assert captured["customer"] == "cus_test"
+    assert captured["off_session"] is True


### PR DESCRIPTION
## Summary
- pass customer ID when charging deposits and final fares
- ensure booking confirmation requires stored customer payment info
- update tests for new payment intent parameters

## Testing
- `npm run lint`
- `pytest tests/unit/services/test_stripe_client.py::test_charge_deposit_with_google_pay_payment_method tests/unit/services/test_stripe_client.py::test_charge_final_with_google_pay_payment_method tests/unit/services/test_booking_service.py::test_confirm_booking_handles_stripe_error tests/unit/services/test_booking_service.py::test_confirm_booking_handles_card_error tests/integration/test_driver_booking_actions_api.py::test_driver_confirm_booking tests/integration/test_availability_api.py::test_double_booking_blocked tests/integration/test_driver_retry_deposit_api.py::test_retry_deposit_creates_new_intent tests/integration/test_driver_complete_api.py::test_driver_complete_booking -q`

------
https://chatgpt.com/codex/tasks/task_e_68c0a4453df4833188f22997af34bd43