### PR TITLE
feat: show fare breakdown in booking wizard

### DIFF
--- a/frontend/src/components/BookingWizard/BookingWizard.tsx
+++ b/frontend/src/components/BookingWizard/BookingWizard.tsx
@@ -12,6 +12,7 @@ import TripDetails from './TripDetails';
 import { MapProvider } from '@/components/MapProvider';
 import { MapRoute } from '@/components/MapRoute';
 import { PriceSummary } from '@/components/PriceSummary';
+import FareBreakdown from '@/components/FareBreakdown';
 import { BookingFormData } from '@/types/BookingFormData';
 import { useBooking } from '@/hooks/useBooking';
 import { useSettings } from '@/hooks/useSettings';
@@ -124,6 +125,14 @@ export default function BookingWizard({
                 distanceKm={distanceKm ?? undefined}
                 durationMin={durationMin ?? undefined}
                 onPrice={setPrice}
+              />
+              <FareBreakdown
+                price={price}
+                flagfall={settings.flagfall}
+                perKm={settings.per_km_rate}
+                perMin={settings.per_minute_rate}
+                distanceKm={distanceKm ?? undefined}
+                durationMin={durationMin ?? undefined}
               />
               {price !== null && (
                 <Typography sx={{ mt: 1 }}>{`Deposit: $${(price / 2).toFixed(2)}`}</Typography>


### PR DESCRIPTION
## Summary
- show detailed fare breakdown in BookingWizard

## Testing
- `npm run lint`
- `npx vitest run src/pages/Booking/BookingWizardPage.test.tsx src/components/FareBreakdown.test.tsx` *(fails: prompts to add a payment method when missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c0a4f9e3e483319a3150596958cf6e