### PR TITLE
feat: log FCM config and warn when disabled

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -198,4 +198,13 @@ class Settings(BaseSettings):
 def get_settings() -> Settings:
     """Singleton-style accessor so we don't re-parse env every import."""
     logger.debug("loading settings", extra={"env": _ENV, "env_file": _ENV_FILE})
-    return Settings()
+    settings = Settings()
+    logger.debug(
+        "resolved FCM config",
+        extra={
+            "fcm_project_id": settings.fcm_project_id,
+            "fcm_client_email": settings.fcm_client_email,
+            "has_fcm_private_key": bool(settings.fcm_private_key),
+        },
+    )
+    return settings

--- a/backend/app/services/notifications.py
+++ b/backend/app/services/notifications.py
@@ -7,14 +7,13 @@ from datetime import datetime, timezone
 from typing import Any
 
 import httpx
-from jose import jwt
-from sqlalchemy import select
-from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
-
 from app.core.config import get_settings
 from app.models.notification import Notification, NotificationType
 from app.models.user_v2 import User as UserV2
 from app.models.user_v2 import UserRole
+from jose import jwt
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 logger = logging.getLogger(__name__)
 
@@ -102,6 +101,14 @@ async def _send_fcm(
         and settings.fcm_client_email
         and settings.fcm_private_key
     ):
+        logger.warning(
+            "FCM disabled",
+            extra={
+                "fcm_project_id": settings.fcm_project_id,
+                "fcm_client_email": settings.fcm_client_email,
+                "fcm_private_key_len": len(settings.fcm_private_key or ""),
+            },
+        )
         return
 
     now = int(datetime.now(timezone.utc).timestamp())


### PR DESCRIPTION
## Summary
- log FCM configuration values when settings are loaded
- warn when FCM credentials are missing and include sanitized details

## Testing
- `pytest -q --maxfail=1 --disable-warnings tests/unit/services/test_notifications.py`


------
https://chatgpt.com/codex/tasks/task_e_68c0b4d46a088331bc49866420ad55ea