### PR TITLE
feat: log FCM config at startup

### DIFF
--- a/frontend/public/firebase-messaging-sw.js
+++ b/frontend/public/firebase-messaging-sw.js
@@ -1,12 +1,30 @@
 importScripts('https://www.gstatic.com/firebasejs/11.0.2/firebase-app-compat.js');
 importScripts('https://www.gstatic.com/firebasejs/11.0.2/firebase-messaging-compat.js');
 
-firebase.initializeApp({
+function mask(value) {
+  if (!value) return value;
+  return value.length > 8
+    ? value.slice(0, 4) + '...' + value.slice(-4)
+    : value;
+}
+
+const config = {
   apiKey: '${VITE_FCM_API_KEY}',
   projectId: '${VITE_FCM_PROJECT_ID}',
   appId: '${VITE_FCM_APP_ID}',
   messagingSenderId: '${VITE_FCM_SENDER_ID}',
+  vapidKey: '${VITE_FCM_VAPID_KEY}',
+};
+
+console.log('firebase-messaging-sw', 'FCM env variables', {
+  apiKey: mask(config.apiKey),
+  projectId: config.projectId,
+  appId: mask(config.appId),
+  senderId: mask(config.messagingSenderId),
+  vapidKey: mask(config.vapidKey),
 });
+
+firebase.initializeApp(config);
 
 const messaging = firebase.messaging();
 

--- a/frontend/src/services/push.ts
+++ b/frontend/src/services/push.ts
@@ -2,6 +2,27 @@ import { initializeApp } from 'firebase/app';
 import { deleteToken, getMessaging, getToken } from 'firebase/messaging';
 import * as logger from '@/lib/logger';
 
+function mask(value: string | undefined): string | undefined {
+  if (!value) return value;
+  return value.length > 8
+    ? `${value.slice(0, 4)}...${value.slice(-4)}`
+    : value;
+}
+
+const vapidEnv = import.meta.env.VITE_FCM_VAPID_KEY;
+const apiKeyEnv = import.meta.env.VITE_FCM_API_KEY;
+const projectIdEnv = import.meta.env.VITE_FCM_PROJECT_ID;
+const appIdEnv = import.meta.env.VITE_FCM_APP_ID;
+const senderIdEnv = import.meta.env.VITE_FCM_SENDER_ID;
+
+logger.debug('services/push', 'FCM env variables', {
+  VITE_FCM_VAPID_KEY: mask(vapidEnv),
+  VITE_FCM_API_KEY: mask(apiKeyEnv),
+  VITE_FCM_PROJECT_ID: projectIdEnv,
+  VITE_FCM_APP_ID: mask(appIdEnv),
+  VITE_FCM_SENDER_ID: mask(senderIdEnv),
+});
+
 let messaging: ReturnType<typeof getMessaging> | null = null;
 
 function getMessagingConfig() {


### PR DESCRIPTION
## Summary
- log Firebase Cloud Messaging env vars at module load with masked values
- service worker logs its FCM config on initialization

## Testing
- `npm run lint`
- `cd backend && pytest -q --maxfail=1 --disable-warnings`
- `npx vitest run src/pages/PageNotFound.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c0b4e028308331a5cba5b0238754f6