### PR TITLE
feat: sync booking wizard with context

### DIFF
--- a/frontend/src/__tests__/BookingWizard.test.tsx
+++ b/frontend/src/__tests__/BookingWizard.test.tsx
@@ -1,0 +1,69 @@
+import { renderWithProviders } from '@/__tests__/setup/renderWithProviders';
+import BookingWizard from '@/components/BookingWizard/BookingWizard';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi, test, expect, afterEach } from 'vitest';
+import React, { useEffect } from 'react';
+
+const createBooking = vi.fn().mockResolvedValue({ booking: { id: '1', public_code: 'code' } });
+const addBooking = vi.fn();
+
+vi.mock('@/hooks/useBooking', () => ({
+  useBooking: () => ({ createBooking, loading: false }),
+}));
+vi.mock('@/hooks/useBookings', () => ({
+  useBookings: () => ({ addBooking }),
+}));
+vi.mock('@/hooks/useSettings', () => ({
+  useSettings: () => ({ data: { flagfall: 0, per_km_rate: 0, per_minute_rate: 0 } }),
+}));
+vi.mock('@/contexts/AuthContext', () => ({
+  useAuth: () => ({ user: null }),
+  AuthProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+vi.mock('@/components/MapProvider', () => ({
+  MapProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+vi.mock('@/components/MapRoute', () => ({
+  MapRoute: () => <div />,
+}));
+vi.mock('@/components/PriceSummary', () => ({
+  PriceSummary: () => <div />,
+}));
+vi.mock('@/components/FareBreakdown', () => ({
+  default: () => <div />,
+}));
+vi.mock('@/components/BookingWizard/TripDetails', () => {
+  function TripDetailsMock({
+    onChange,
+  }: {
+    onChange: (data: Record<string, unknown>) => void;
+  }) {
+    useEffect(() => {
+      onChange({
+        pickup_when: new Date('2025-01-01T10:00').toISOString(),
+        pickup: { address: 'A', lat: 0, lng: 0 },
+        dropoff: { address: 'B', lat: 0, lng: 0 },
+        passengers: 1,
+        notes: '',
+        pickupValid: true,
+        dropoffValid: true,
+      });
+    }, [onChange]);
+    return <div />;
+  }
+  return { default: TripDetailsMock };
+});
+
+afterEach(() => {
+  createBooking.mockClear();
+  addBooking.mockClear();
+});
+
+test('adds new booking to context on confirmation', async () => {
+  renderWithProviders(<BookingWizard />);
+  await userEvent.click(screen.getByRole('button', { name: /confirm booking/i }));
+  await screen.findByRole('link', { name: /track this ride/i });
+  expect(addBooking).toHaveBeenCalledWith({ id: '1', public_code: 'code' });
+});
+

--- a/frontend/src/components/BookingWizard/BookingWizard.tsx
+++ b/frontend/src/components/BookingWizard/BookingWizard.tsx
@@ -17,6 +17,7 @@ import { BookingFormData } from '@/types/BookingFormData';
 import { useBooking } from '@/hooks/useBooking';
 import { useSettings } from '@/hooks/useSettings';
 import { useAuth } from '@/contexts/AuthContext';
+import { useBookings } from '@/hooks/useBookings';
 import * as logger from '@/lib/logger';
 
 interface BookingWizardProps {
@@ -34,6 +35,7 @@ export default function BookingWizard({
   });
   const { user: profile } = useAuth();
   const { createBooking, loading } = useBooking();
+  const { addBooking } = useBookings();
   const [bookingData, setBookingData] = useState<{ public_code: string } | null>(
     null,
   );
@@ -65,6 +67,7 @@ export default function BookingWizard({
           : undefined,
       };
       const res = await createBooking(payload);
+      addBooking(res.booking);
       setBookingData(res.booking);
     } catch (err) {
       logger.error(

--- a/frontend/src/pages/Booking/BookingWizardPage.test.tsx
+++ b/frontend/src/pages/Booking/BookingWizardPage.test.tsx
@@ -21,13 +21,17 @@ import BookingWizardPage from './BookingWizardPage';
 
 const createBooking = vi
   .fn()
-  .mockResolvedValue({ booking: { public_code: 'test' } });
+  .mockResolvedValue({ booking: { id: '1', public_code: 'test' } });
+const addBooking = vi.fn();
 
 vi.mock('@/hooks/useBooking', () => ({
   useBooking: () => ({
     createBooking,
     loading: false,
   }),
+}));
+vi.mock('@/hooks/useBookings', () => ({
+  useBookings: () => ({ addBooking }),
 }));
 vi.mock('@/hooks/useAvailability', () => ({
   default: () => ({ data: { slots: [], bookings: [] } }),
@@ -91,6 +95,7 @@ beforeEach(() => {
 afterEach(() => {
   mockElements.submit.mockClear();
   mockConfirm.mockClear();
+  addBooking.mockClear();
 });
 
 test('creates booking on confirmation and shows tracking link', async () => {
@@ -122,9 +127,10 @@ test('creates booking on confirmation and shows tracking link', async () => {
     customer: {
       name: 'Test User',
       email: 'test@example.com',
-      phone: '123-4567',
+    phone: '123-4567',
     },
   });
+  expect(addBooking).toHaveBeenCalledWith({ id: '1', public_code: 'test' });
 });
 
 test('prompts to add a payment method when missing', async () => {


### PR DESCRIPTION
## Summary
- update BookingWizard to push newly created bookings into the shared context
- cover booking context update with focused tests

## Testing
- `npm run lint`
- `cd frontend && npx vitest run src/__tests__/BookingWizard.test.tsx src/pages/Booking/BookingWizardPage.test.tsx -t "adds new booking|creates booking"`


------
https://chatgpt.com/codex/tasks/task_e_68c0c0d2765c83318bc943bdd8f6b3a7