### PR TITLE
fix: validate FCM service worker injection

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,11 @@ cd frontend
 npm run dev
 ```
 
+> **Note:** Always start the frontend with `npm run dev` rather than invoking
+> `vite` directly. The `predev` script injects the Firebase Cloud Messaging
+> service worker before the dev server boots and is skipped when running `vite`
+> manually.
+
 ## Realtime tracking
 
 Drivers send location updates over `/ws/bookings/{id}` using a JWT token.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -32,6 +32,10 @@ Start the development server:
 npm run dev
 ```
 
+> **Note:** Run the dev server with `npm run dev` so the `predev` hook can
+> inject the Firebase service worker. Starting `vite` directly skips this step
+> and leaves placeholders in the service worker.
+
 ## Testing
 
 Run unit tests with:

--- a/frontend/scripts/inject-fcm-sw.js
+++ b/frontend/scripts/inject-fcm-sw.js
@@ -1,4 +1,4 @@
-import { readFileSync, writeFileSync } from 'node:fs';
+import { readFileSync, writeFileSync, existsSync } from 'node:fs';
 import { resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -20,3 +20,14 @@ for (const [key, value] of Object.entries(replacements)) {
 }
 
 writeFileSync(targetPath, content);
+
+if (!existsSync(targetPath)) {
+  console.error(`Failed to create ${targetPath}`);
+  process.exit(1);
+}
+
+const written = readFileSync(targetPath, 'utf-8');
+if (/\$\{VITE_FCM_[^}]+\}/.test(written)) {
+  console.error(`Unresolved VITE_FCM placeholders remain in ${targetPath}`);
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- ensure Firebase service worker is created without unresolved placeholders
- document that `npm run dev` must be used so the `predev` hook runs

## Testing
- `npm run lint`
- `cd frontend && npx vitest run` *(fails: BookingWizardPage.test.tsx > prompts to add a payment method when missing)*
- `npx vitest run src/lib/formatAddress.test.ts src/lib/datetime.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c0c746d0188331890892e167790ba2