### PR TITLE
fix: load env for FCM service worker

### DIFF
--- a/frontend/scripts/inject-fcm-sw.js
+++ b/frontend/scripts/inject-fcm-sw.js
@@ -1,8 +1,11 @@
 import { readFileSync, writeFileSync, existsSync } from 'node:fs';
 import { resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { config as loadEnv } from 'dotenv';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
+const env = process.env.ENV || process.env.NODE_ENV || 'development';
+loadEnv({ path: resolve(__dirname, `../.env.${env}`) });
 const templatePath = resolve(__dirname, '../public/firebase-messaging-sw.template.js');
 const targetPath = resolve(__dirname, '../public/firebase-messaging-sw.js');
 
@@ -13,6 +16,8 @@ const replacements = {
   VITE_FCM_SENDER_ID: process.env.VITE_FCM_SENDER_ID || '',
   VITE_FCM_VAPID_KEY: process.env.VITE_FCM_VAPID_KEY || '',
 };
+
+console.log('FCM env variables', replacements);
 
 let content = readFileSync(templatePath, 'utf-8');
 for (const [key, value] of Object.entries(replacements)) {


### PR DESCRIPTION
## Summary
- load environment variables from .env files when injecting Firebase service worker
- log FCM env variables for easier debugging

## Testing
- `npm run lint`
- `cd backend && pytest -q --maxfail=1 --disable-warnings`
- `cd frontend && npx vitest run src/lib/calculateDistance.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c0ab2b1cc483318045e9d3c6258231