### PR TITLE
chore: expand env vars in FCM script

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -35,6 +35,7 @@
         "@types/react-dom": "^19.1.6",
         "@vitejs/plugin-react": "^4.6.0",
         "dotenv": "^17.2.1",
+        "dotenv-expand": "^12.0.3",
         "eslint": "^9.30.1",
         "eslint-plugin-react-hooks": "^5.2.0",
         "eslint-plugin-react-refresh": "^0.4.20",
@@ -4976,6 +4977,35 @@
       "version": "17.2.1",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.1.tgz",
       "integrity": "sha512-kQhDYKZecqnM0fCnzI5eIv5L4cAe/iRI+HqMbO/hbRdTAeXDG+M9FjipUxNfbARuEg4iHIbhnhs78BCHNbSxEQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dotenv-expand": {
+      "version": "12.0.3",
+      "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-12.0.3.tgz",
+      "integrity": "sha512-uc47g4b+4k/M/SeaW1y4OApx+mtLWl92l5LMPP0GNXctZqELk+YGgOPIIC5elYmUH4OuoK3JLhuRUYegeySiFA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dotenv": "^16.4.5"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dotenv-expand/node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
       "dev": true,
       "license": "BSD-2-Clause",
       "engines": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -47,6 +47,7 @@
     "@types/react-dom": "^19.1.6",
     "@vitejs/plugin-react": "^4.6.0",
     "dotenv": "^17.2.1",
+    "dotenv-expand": "^12.0.3",
     "eslint": "^9.30.1",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.20",

--- a/frontend/scripts/inject-fcm-sw.js
+++ b/frontend/scripts/inject-fcm-sw.js
@@ -2,10 +2,12 @@ import { readFileSync, writeFileSync, existsSync } from 'node:fs';
 import { resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { config as loadEnv } from 'dotenv';
+import { expand as dotenvExpand } from 'dotenv-expand';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const env = process.env.ENV || process.env.NODE_ENV || 'development';
-loadEnv({ path: resolve(__dirname, `../.env.${env}`) });
+const envConfig = loadEnv({ path: resolve(__dirname, `../.env.${env}`) });
+dotenvExpand(envConfig);
 const templatePath = resolve(__dirname, '../public/firebase-messaging-sw.template.js');
 const targetPath = resolve(__dirname, '../public/firebase-messaging-sw.js');
 


### PR DESCRIPTION
## Summary
- install `dotenv-expand` in frontend workspace
- use `dotenvExpand` in FCM service worker injection script so nested env vars resolve

## Testing
- `npm run lint` *(fails: BookingWizardPage.test.tsx @typescript-eslint/no-unused-vars)*
- `npx eslint scripts/inject-fcm-sw.js`
- `npx vitest run`
- `node scripts/inject-fcm-sw.js`

------
https://chatgpt.com/codex/tasks/task_e_68c0d22f324483319f8532fc209c9d8c