### PR TITLE
feat: display push notifications in service worker

### DIFF
--- a/frontend/public/firebase-messaging-sw.template.js
+++ b/frontend/public/firebase-messaging-sw.template.js
@@ -38,3 +38,17 @@ messaging.onBackgroundMessage((payload) => {
       }
     });
 });
+
+self.addEventListener('push', (event) => {
+  const payload = event.data ? event.data.json() : {};
+  console.log('firebase-messaging-sw', 'Push received', payload);
+  const notification = payload.notification || {};
+  const title = notification.title || 'Notification';
+  const options = {
+    body: notification.body,
+    icon: notification.icon || '/logo.svg',
+  };
+  event.waitUntil(
+    self.registration.showNotification(title, options),
+  );
+});


### PR DESCRIPTION
## Summary
- show push notifications from push events in service worker
- log push payload before displaying notification

## Testing
- `npm run lint`
- `cd backend && pytest -q --maxfail=1 --disable-warnings` *(fails: Expected ValueError for invalid token)*
- `cd ../frontend && npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_68c0ee84e74483319b30734f30ca877f