### PR TITLE
feat: refresh FCM tokens and sync with backend

### DIFF
--- a/frontend/src/components/PushToggle.tsx
+++ b/frontend/src/components/PushToggle.tsx
@@ -1,6 +1,10 @@
 import { useEffect, useState } from 'react';
 import { FormControlLabel, Switch } from '@mui/material';
-import { subscribePush, unsubscribePush } from '@/services/push';
+import {
+  refreshPushToken,
+  subscribePush,
+  unsubscribePush,
+} from '@/services/push';
 import { CONFIG } from '@/config';
 import { apiFetch } from '@/services/apiFetch';
 
@@ -10,6 +14,7 @@ interface Props {
 
 const PushToggle = ({ ensureFreshToken }: Props) => {
   const [enabled, setEnabled] = useState(false);
+  const [token, setToken] = useState<string | null>(null);
 
   useEffect(() => {
     const load = async () => {
@@ -20,6 +25,7 @@ const PushToggle = ({ ensureFreshToken }: Props) => {
       if (res.ok) {
         const data = await res.json();
         setEnabled(!!data.fcm_token);
+        setToken(data.fcm_token ?? null);
       }
     };
     load();
@@ -32,16 +38,17 @@ const PushToggle = ({ ensureFreshToken }: Props) => {
     const auth = await ensureFreshToken();
     if (!auth) return;
     if (checked) {
-      const token = await subscribePush();
-      if (!token) return;
+      const newToken = await subscribePush();
+      if (!newToken) return;
       const base = CONFIG.API_BASE_URL ?? '';
       await apiFetch(`${base}/users/me`, {
         method: 'PATCH',
         headers: {
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify({ fcm_token: token }),
+        body: JSON.stringify({ fcm_token: newToken }),
       });
+      setToken(newToken);
     } else {
       await unsubscribePush();
       const base = CONFIG.API_BASE_URL ?? '';
@@ -52,9 +59,30 @@ const PushToggle = ({ ensureFreshToken }: Props) => {
         },
         body: JSON.stringify({ fcm_token: null }),
       });
+      setToken(null);
     }
     setEnabled(checked);
   };
+
+  useEffect(() => {
+    if (!enabled) return;
+    const interval = setInterval(async () => {
+      const refreshed = await refreshPushToken();
+      if (!refreshed || refreshed === token) return;
+      const auth = await ensureFreshToken();
+      if (!auth) return;
+      const base = CONFIG.API_BASE_URL ?? '';
+      await apiFetch(`${base}/users/me`, {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ fcm_token: refreshed }),
+      });
+      setToken(refreshed);
+    }, 1000 * 60 * 60 * 24);
+    return () => clearInterval(interval);
+  }, [enabled, token, ensureFreshToken]);
 
   return (
     <FormControlLabel

--- a/frontend/src/services/push.ts
+++ b/frontend/src/services/push.ts
@@ -113,3 +113,22 @@ export async function unsubscribePush(): Promise<void> {
     logger.warn('services/push', 'FCM delete failed', err);
   }
 }
+
+export async function refreshPushToken(): Promise<string | null> {
+  const config = getMessagingConfig();
+  if (!config) return null;
+  const { messaging, vapid } = config;
+  try {
+    const registration = await navigator.serviceWorker.ready;
+    const token = await getToken(messaging, {
+      vapidKey: vapid,
+      serviceWorkerRegistration: registration,
+    });
+    console.log('Refreshed FCM token:', token);
+    logger.info('services/push', 'FCM token refreshed', { token });
+    return token;
+  } catch (err) {
+    logger.warn('services/push', 'FCM token refresh failed', err);
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
- refresh Firebase messaging tokens periodically and log new values
- automatically patch backend when FCM token rotates

## Testing
- `npm run lint`
- `npx vitest run src/components/PushToggle.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68c0f04187048331b3bbea4df13c261d