### PR TITLE
feat: replace FCM token with OneSignal player ID

### DIFF
--- a/backend/alembic/versions/4d2b4b9da96b_replace_fcm_token_with_onesignal_player_id.py
+++ b/backend/alembic/versions/4d2b4b9da96b_replace_fcm_token_with_onesignal_player_id.py
@@ -1,0 +1,34 @@
+"""replace fcm_token with onesignal_player_id
+
+Revision ID: 4d2b4b9da96b
+Revises: fa3de645ec11
+Create Date: 2025-09-10 00:00:00.000000
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "4d2b4b9da96b"
+down_revision = "fa3de645ec11"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column("users", sa.Column("onesignal_player_id", sa.Text(), nullable=True))
+    op.drop_column("users", "fcm_token")
+
+    with op.batch_alter_table("users_v2") as batch_op:
+        batch_op.add_column(sa.Column("onesignal_player_id", sa.Text(), nullable=True))
+        batch_op.drop_column("fcm_token")
+
+
+def downgrade():
+    op.add_column("users", sa.Column("fcm_token", sa.Text(), nullable=True))
+    op.drop_column("users", "onesignal_player_id")
+
+    with op.batch_alter_table("users_v2") as batch_op:
+        batch_op.add_column(sa.Column("fcm_token", sa.Text(), nullable=True))
+        batch_op.drop_column("onesignal_player_id")

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -28,8 +28,8 @@ class User(Base):
     default_pickup_address: Mapped[Union[str, None]] = mapped_column(
         Text, nullable=True, default=None
     )
-    # Firebase Cloud Messaging token for push notifications
-    fcm_token: Mapped[Union[str, None]] = mapped_column(
+    # OneSignal player identifier for push notifications
+    onesignal_player_id: Mapped[Union[str, None]] = mapped_column(
         Text, nullable=True, default=None
     )
     # is_approved:     Mapped[bool]   = mapped_column(Boolean, default=False)

--- a/backend/app/models/user_v2.py
+++ b/backend/app/models/user_v2.py
@@ -32,7 +32,7 @@ class User(Base):
         String, nullable=True
     )  # Optional contact number
     role: Mapped[UserRole] = mapped_column(Enum(UserRole), default=UserRole.CUSTOMER)
-    fcm_token: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    onesignal_player_id: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
     stripe_customer_id: Mapped[Optional[str]] = mapped_column(String, nullable=True)
     stripe_payment_method_id: Mapped[Optional[str]] = mapped_column(
         String, nullable=True

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -27,7 +27,7 @@ class UserRead(UserBase):
     id: uuid.UUID
     # role: str
     # is_approved: bool
-    fcm_token: Optional[str] = None
+    onesignal_player_id: Optional[str] = None
     stripe_customer_id: Optional[str] = None
     stripe_payment_method_id: Optional[str] = None
     model_config = ConfigDict(from_attributes=True)
@@ -40,7 +40,7 @@ class UserUpdate(BaseModel):
     full_name: Optional[str] = None
     password: Optional[str] = None
     default_pickup_address: Optional[str] = None
-    fcm_token: Optional[str] = None
+    onesignal_player_id: Optional[str] = None
     stripe_customer_id: Optional[str] = None
     stripe_payment_method_id: Optional[str] = None
     phone: Optional[str] = None

--- a/backend/app/schemas/user_v2.py
+++ b/backend/app/schemas/user_v2.py
@@ -24,6 +24,7 @@ class UserRead(UserBase):
     id: uuid.UUID
     created_at: datetime
     updated_at: datetime
+    onesignal_player_id: Optional[str] = None
 
     class Config:
         from_attributes = True
@@ -35,7 +36,7 @@ class UserUpdate(BaseModel):
     password: Optional[str] = None
     phone: Optional[str] = None
     role: Optional[UserRole] = None
-    fcm_token: Optional[str] = None
+    onesignal_player_id: Optional[str] = None
     stripe_customer_id: Optional[str] = None
     stripe_payment_method_id: Optional[str] = None
 

--- a/backend/app/services/notifications.py
+++ b/backend/app/services/notifications.py
@@ -149,8 +149,8 @@ async def _send_fcm(
                 notification = {k: str(v) for k, v in notification.items()}
 
             result = await db.execute(
-                select(UserV2.fcm_token).where(
-                    UserV2.role == to_role, UserV2.fcm_token.is_not(None)
+                select(UserV2.onesignal_player_id).where(
+                    UserV2.role == to_role, UserV2.onesignal_player_id.is_not(None)
                 )
             )
             tokens = result.scalars().all()

--- a/backend/tests/integration/test_users_me_api.py
+++ b/backend/tests/integration/test_users_me_api.py
@@ -54,14 +54,18 @@ async def test_enable_disable_push(client: AsyncClient, async_session: AsyncSess
     token = create_jwt_token(user.id)
     headers = {"Authorization": f"Bearer {token}"}
 
-    resp = await client.patch("/users/me", json={"fcm_token": "tok"}, headers=headers)
+    resp = await client.patch(
+        "/users/me", json={"onesignal_player_id": "tok"}, headers=headers
+    )
     assert resp.status_code == 200
-    assert resp.json()["fcm_token"] == "tok"
+    assert resp.json()["onesignal_player_id"] == "tok"
     await async_session.refresh(user)
-    assert user.fcm_token == "tok"
+    assert user.onesignal_player_id == "tok"
 
-    resp = await client.patch("/users/me", json={"fcm_token": None}, headers=headers)
+    resp = await client.patch(
+        "/users/me", json={"onesignal_player_id": None}, headers=headers
+    )
     assert resp.status_code == 200
-    assert resp.json()["fcm_token"] is None
+    assert resp.json()["onesignal_player_id"] is None
     await async_session.refresh(user)
-    assert user.fcm_token is None
+    assert user.onesignal_player_id is None


### PR DESCRIPTION
## Summary
- replace deprecated `fcm_token` with nullable `onesignal_player_id` across user models and schemas
- migrate database schema accordingly and update notifications lookup
- adjust tests for new push identifier field

## Testing
- `npm run lint`
- `cd backend && pytest tests/integration/test_users_me_api.py -q --maxfail=1 --disable-warnings`

------
https://chatgpt.com/codex/tasks/task_e_68c0f9b3f5408331b5bf3ccb55f0643d