### PR TITLE
feat: add OneSignal configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ The application relies on several external services. Set these variables in a `.
 | `LOG_LEVEL` | (backend) Logging verbosity (`DEBUG`, `INFO`, etc.). Defaults to `INFO`. |
 | `GRAYLOG_HOST` / `GRAYLOG_PORT` | (backend) Optional Graylog host and port for log forwarding. Port defaults to `12201`. |
 | `FCM_PROJECT_ID` / `FCM_CLIENT_EMAIL` / `FCM_PRIVATE_KEY` | (backend) Optional Firebase credentials for push notifications. |
+| `ONESIGNAL_APP_ID` / `ONESIGNAL_API_KEY` | (backend) OneSignal credentials for push notifications. |
 | `VITE_FCM_API_KEY` / `VITE_FCM_PROJECT_ID` / `VITE_FCM_APP_ID` / `VITE_FCM_SENDER_ID` / `VITE_FCM_VAPID_KEY` | (frontend) Optional Firebase config for web push. |
 
 ## Logging

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -121,6 +121,8 @@ class Settings(BaseSettings):
     fcm_project_id: Optional[str] = None
     fcm_client_email: Optional[str] = None
     fcm_private_key: Optional[str] = None
+    onesignal_app_id: Optional[str] = None
+    onesignal_api_key: Optional[str] = None
     app_tz: str = "Australia/Brisbane"
     app_base_url: Optional[str] = None
     frontend_base_url: Optional[str] = None
@@ -200,11 +202,13 @@ def get_settings() -> Settings:
     logger.debug("loading settings", extra={"env": _ENV, "env_file": _ENV_FILE})
     settings = Settings()
     logger.debug(
-        "resolved FCM config",
+        "resolved notification config",
         extra={
             "fcm_project_id": settings.fcm_project_id,
             "fcm_client_email": settings.fcm_client_email,
             "has_fcm_private_key": bool(settings.fcm_private_key),
+            "onesignal_app_id": settings.onesignal_app_id,
+            "has_onesignal_api_key": bool(settings.onesignal_api_key),
         },
     )
     return settings


### PR DESCRIPTION
## Summary
- add OneSignal settings for app ID and API key
- mask OneSignal API key in configuration logging
- document OneSignal environment variables

## Testing
- `npm run lint`
- `cd backend && pytest -q --maxfail=1 --disable-warnings`

------
https://chatgpt.com/codex/tasks/task_e_68c0fb7d6f108331946693f0b9cb381c