### PR TITLE
feat: switch push notifications to OneSignal

### DIFF
--- a/backend/app/services/notifications.py
+++ b/backend/app/services/notifications.py
@@ -7,49 +7,47 @@ from datetime import datetime, timezone
 from typing import Any
 
 import httpx
-from jose import jwt
-from sqlalchemy import select
-from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
-
 from app.core.config import get_settings
 from app.models.notification import Notification, NotificationType
 from app.models.user_v2 import User as UserV2
 from app.models.user_v2 import UserRole
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 logger = logging.getLogger(__name__)
 
 notification_map: dict[NotificationType, dict[str, str]] = {
     NotificationType.NEW_BOOKING: {
-        "title": "New booking",
-        "body": "You have a new booking",
+        "headings": "New booking",
+        "contents": "You have a new booking",
     },
     NotificationType.CONFIRMATION: {
-        "title": "Booking confirmed",
-        "body": "Your booking has been confirmed",
+        "headings": "Booking confirmed",
+        "contents": "Your booking has been confirmed",
     },
     NotificationType.LEAVE_NOW: {
-        "title": "Time to leave",
-        "body": "Please leave now for your ride",
+        "headings": "Time to leave",
+        "contents": "Please leave now for your ride",
     },
     NotificationType.ON_THE_WAY: {
-        "title": "Driver on the way",
-        "body": "Your driver is on the way",
+        "headings": "Driver on the way",
+        "contents": "Your driver is on the way",
     },
     NotificationType.ARRIVED_PICKUP: {
-        "title": "Driver arrived",
-        "body": "Your driver has arrived at the pickup location",
+        "headings": "Driver arrived",
+        "contents": "Your driver has arrived at the pickup location",
     },
     NotificationType.STARTED: {
-        "title": "Ride started",
-        "body": "Your ride has started",
+        "headings": "Ride started",
+        "contents": "Your ride has started",
     },
     NotificationType.ARRIVED_DROPOFF: {
-        "title": "Arrived at dropoff",
-        "body": "You have arrived at your destination",
+        "headings": "Arrived at dropoff",
+        "contents": "You have arrived at your destination",
     },
     NotificationType.COMPLETED: {
-        "title": "Ride completed",
-        "body": "Your ride is complete",
+        "headings": "Ride completed",
+        "contents": "Your ride is complete",
     },
 }
 
@@ -80,183 +78,80 @@ async def dispatch_notification(
     payload: dict[str, Any] | None = None,
 ) -> None:
     async with db() as session:
-        await _send_fcm(session, to_role, notif_type, payload or {})
+        await _send_onesignal(session, to_role, notif_type, payload or {})
 
 
-async def _send_fcm(
+async def _send_onesignal(
     db: AsyncSession,
     to_role: UserRole,
     notif_type: NotificationType,
     payload: dict[str, Any],
 ) -> None:
-    """Send a Firebase Cloud Messaging push if credentials are configured.
+    """Send a OneSignal push if credentials are configured.
 
-    The function safely no-ops when any required key is missing or when the HTTP
-    request fails. Messages are delivered to a topic matching the target role so
-    that the single driver and any customers can subscribe independently.
+    The function safely no-ops when required settings are missing or when the HTTP
+    request fails. Messages are delivered to each stored player ID for the target
+    role.
     """
 
     settings = get_settings()
-    if not (
-        settings.fcm_project_id
-        and settings.fcm_client_email
-        and settings.fcm_private_key
-    ):
+    if not (settings.onesignal_app_id and settings.onesignal_api_key):
         logger.warning(
-            "FCM disabled",
+            "OneSignal disabled",
             extra={
-                "fcm_project_id": settings.fcm_project_id,
-                "fcm_client_email": settings.fcm_client_email,
-                "fcm_private_key_len": len(settings.fcm_private_key or ""),
+                "onesignal_app_id": settings.onesignal_app_id,
+                "has_onesignal_api_key": bool(settings.onesignal_api_key),
             },
         )
         return
 
-    now = int(datetime.now(timezone.utc).timestamp())
-    claim = {
-        "iss": settings.fcm_client_email,
-        "sub": settings.fcm_client_email,
-        "aud": "https://oauth2.googleapis.com/token",
-        "iat": now,
-        "exp": now + 3600,
-        "scope": "https://www.googleapis.com/auth/firebase.messaging",
-    }
-    assertion = jwt.encode(
-        claim,
-        settings.fcm_private_key.replace("\\n", "\n"),
-        algorithm="RS256",
+    data = {"type": notif_type.value}
+    for k, v in payload.items():
+        data[k] = json.dumps(v) if not isinstance(v, str) else v
+
+    notification = notification_map.get(notif_type)
+
+    result = await db.execute(
+        select(UserV2.onesignal_player_id).where(
+            UserV2.role == to_role, UserV2.onesignal_player_id.is_not(None)
+        )
     )
-    async with httpx.AsyncClient(timeout=10) as client:
-        try:
-            token_resp = await client.post(
-                "https://oauth2.googleapis.com/token",
-                data={
-                    "grant_type": "urn:ietf:params:oauth:grant-type:jwt-bearer",
-                    "assertion": assertion,
+    player_ids = result.scalars().all()
+
+    if not player_ids:
+        logger.info(
+            "No OneSignal player IDs",
+            extra={"role": to_role.value, "payload": data},
+        )
+        return
+
+    message: dict[str, Any] = {
+        "app_id": settings.onesignal_app_id,
+        "include_player_ids": player_ids,
+        "data": data,
+    }
+    if notification:
+        message["headings"] = {"en": str(notification.get("headings", ""))}
+        message["contents"] = {"en": str(notification.get("contents", ""))}
+
+    try:
+        async with httpx.AsyncClient() as client:
+            response = await client.post(
+                "https://onesignal.com/api/v1/notifications",
+                headers={"Authorization": f"Basic {settings.onesignal_api_key}"},
+                json=message,
+            )
+            response.raise_for_status()
+            logger.info(
+                "OneSignal response",
+                extra={
+                    "player_ids": player_ids,
+                    "payload": data,
+                    "response": response.json(),
                 },
             )
-            token_resp.raise_for_status()
-            access_token = token_resp.json().get("access_token")
-            if not access_token:
-                return
-
-            data = {"type": notif_type.value}
-            for k, v in payload.items():
-                data[k] = json.dumps(v) if not isinstance(v, str) else v
-
-            notification = notification_map.get(notif_type)
-            if notification:
-                notification = {k: str(v) for k, v in notification.items()}
-
-            result = await db.execute(
-                select(UserV2.onesignal_player_id).where(
-                    UserV2.role == to_role, UserV2.onesignal_player_id.is_not(None)
-                )
-            )
-            tokens = result.scalars().all()
-
-            if tokens:
-                for token in tokens:
-                    message = {
-                        "message": {
-                            "token": token,
-                            "data": data,
-                            "webpush": {"notification": notification},
-                        }
-                    }
-                    logger.info(
-                        "Sending FCM message",
-                        extra={"token": token, "payload": data},
-                    )
-                    try:
-                        response = await client.post(
-                            f"https://fcm.googleapis.com/v1/projects/{settings.fcm_project_id}/messages:send",
-                            headers={"Authorization": f"Bearer {access_token}"},
-                            json=message,
-                        )
-                        response.raise_for_status()
-                        resp_data = response.json()
-                        logger.info(
-                            "FCM response",
-                            extra={
-                                "token": token,
-                                "payload": data,
-                                "response": resp_data,
-                            },
-                        )
-                        error_msg = (
-                            resp_data.get("error", {}).get("message", "")
-                            if isinstance(resp_data, dict)
-                            else ""
-                        )
-                        if any(
-                            err in error_msg
-                            for err in ["NotRegistered", "InvalidRegistration"]
-                        ):
-                            logger.error(
-                                "FCM token error",
-                                extra={
-                                    "token": token,
-                                    "payload": data,
-                                    "response": resp_data,
-                                },
-                            )
-                    except httpx.HTTPError:
-                        logger.exception(
-                            "FCM send failed",
-                            extra={"token": token, "payload": data},
-                        )
-            else:
-                message = {
-                    "message": {
-                        "topic": to_role.value.lower(),
-                        "data": data,
-                        "webpush": {"notification": notification},
-                    }
-                }
-                logger.info(
-                    "Sending FCM message",
-                    extra={"token": None, "payload": data},
-                )
-                try:
-                    response = await client.post(
-                        f"https://fcm.googleapis.com/v1/projects/{settings.fcm_project_id}/messages:send",
-                        headers={"Authorization": f"Bearer {access_token}"},
-                        json=message,
-                    )
-                    response.raise_for_status()
-                    resp_data = response.json()
-                    logger.info(
-                        "FCM response",
-                        extra={
-                            "token": None,
-                            "payload": data,
-                            "response": resp_data,
-                        },
-                    )
-                    error_msg = (
-                        resp_data.get("error", {}).get("message", "")
-                        if isinstance(resp_data, dict)
-                        else ""
-                    )
-                    if any(
-                        err in error_msg
-                        for err in ["NotRegistered", "InvalidRegistration"]
-                    ):
-                        logger.error(
-                            "FCM token error",
-                            extra={
-                                "token": None,
-                                "payload": data,
-                                "response": resp_data,
-                            },
-                        )
-                except httpx.HTTPError:
-                    logger.exception(
-                        "FCM send failed",
-                        extra={"token": None, "payload": data},
-                    )
-        except httpx.HTTPError:
-            logger.exception("FCM send failed")
-            # Silently ignore push delivery issues to keep core flow resilient
-            return
+    except httpx.HTTPError:
+        logger.exception(
+            "OneSignal send failed",
+            extra={"player_ids": player_ids, "payload": data},
+        )

--- a/backend/tests/unit/services/test_booking_service.py
+++ b/backend/tests/unit/services/test_booking_service.py
@@ -3,15 +3,14 @@ from datetime import datetime, timedelta, timezone
 
 import pytest
 import stripe
-from fastapi import HTTPException
-from sqlalchemy import text
-from sqlalchemy.ext.asyncio import AsyncSession
-
 from app.core.security import hash_password
 from app.models.booking import Booking, BookingStatus
 from app.models.user_v2 import User, UserRole
 from app.schemas.api_booking import BookingCreateRequest, Location
 from app.services import booking_service
+from fastapi import HTTPException
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
 
 pytestmark = pytest.mark.asyncio
 
@@ -140,7 +139,7 @@ async def test_create_booking_commits_once(async_session: AsyncSession, mocker):
     await async_session.commit()
 
     mocker.patch("app.services.routing.estimate_route", return_value=(1.0, 1.0))
-    mocker.patch("app.services.notifications._send_fcm", return_value=None)
+    mocker.patch("app.services.notifications._send_onesignal", return_value=None)
 
     commit_spy = mocker.spy(async_session, "commit")
 

--- a/backend/tests/unit/services/test_scheduler.py
+++ b/backend/tests/unit/services/test_scheduler.py
@@ -2,14 +2,13 @@ import uuid
 from datetime import datetime, timedelta, timezone
 
 import pytest
-from sqlalchemy import select
-from sqlalchemy.ext.asyncio import AsyncSession
-
 from app.core.security import hash_password
 from app.models.booking import Booking, BookingStatus
 from app.models.notification import Notification, NotificationRole, NotificationType
 from app.models.user_v2 import User, UserRole
 from app.services.scheduler import _leave_now_job
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 
 pytestmark = pytest.mark.asyncio
 
@@ -17,7 +16,7 @@ pytestmark = pytest.mark.asyncio
 async def test_leave_now_job_creates_notifications(
     async_session: AsyncSession, mocker
 ) -> None:
-    mocker.patch("app.services.notifications._send_fcm", return_value=None)
+    mocker.patch("app.services.notifications._send_onesignal", return_value=None)
 
     customer = User(
         email=f"test{uuid.uuid4().hex}@example.com",


### PR DESCRIPTION
## Summary
- replace Firebase push integration with OneSignal
- update notification dispatch to target stored OneSignal player IDs
- adjust tests to mock new OneSignal sender

## Testing
- `npm run lint`
- `pytest -q tests/unit/services/test_notifications.py tests/unit/services/test_booking_service.py tests/unit/services/test_scheduler.py --maxfail=1 --disable-warnings`


------
https://chatgpt.com/codex/tasks/task_e_68c0fdb807508331b5677d85c5badf09