### PR TITLE
test: mock OneSignal SDK in push toggle

### DIFF
--- a/backend/tests/integration/test_users_me_api.py
+++ b/backend/tests/integration/test_users_me_api.py
@@ -19,6 +19,7 @@ async def test_get_and_update_me(client: AsyncClient, async_session: AsyncSessio
     async_session.add(user)
     await async_session.commit()
     await async_session.refresh(user)
+    assert user.onesignal_player_id is None
 
     token = create_jwt_token(user.id)
     headers = {"Authorization": f"Bearer {token}"}

--- a/frontend/src/components/PushToggle.test.tsx
+++ b/frontend/src/components/PushToggle.test.tsx
@@ -1,16 +1,30 @@
-import { render, screen, waitFor } from '@testing-library/react';
-import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('@/services/push', () => ({
+  subscribePush: vi.fn().mockResolvedValue('player'),
+  unsubscribePush: vi.fn().mockResolvedValue(undefined),
+  refreshPushToken: vi.fn().mockResolvedValue('player'),
+}));
+
 import PushToggle from '@/components/PushToggle';
+import { subscribePush, unsubscribePush } from '@/services/push';
 
 describe('PushToggle', () => {
   const ensureFreshToken = vi.fn().mockResolvedValue('auth');
+  let fetchSpy: ReturnType<typeof vi.spyOn> | null = null;
 
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
+  afterEach(() => {
+    fetchSpy?.mockRestore();
+    fetchSpy = null;
+  });
+
   it('shows unchecked when no subscription', async () => {
-    vi.spyOn(global, 'fetch').mockResolvedValue({
+    fetchSpy = vi.spyOn(global, 'fetch').mockResolvedValue({
       ok: true,
       json: async () => ({ onesignal_player_id: null }),
     } as Response);
@@ -20,12 +34,36 @@ describe('PushToggle', () => {
   });
 
   it('shows checked when subscribed', async () => {
-    vi.spyOn(global, 'fetch').mockResolvedValue({
+    fetchSpy = vi.spyOn(global, 'fetch').mockResolvedValue({
       ok: true,
       json: async () => ({ onesignal_player_id: 'tok' }),
     } as Response);
     render(<PushToggle ensureFreshToken={ensureFreshToken} />);
     const checkbox = await screen.findByRole('switch', { name: /push notifications/i });
     await waitFor(() => expect(checkbox).toBeChecked());
+  });
+
+  it('enables and disables push', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ onesignal_player_id: null }),
+      })
+      .mockResolvedValue({ ok: true, json: async () => ({}) });
+    fetchSpy = vi.spyOn(global, 'fetch').mockImplementation(
+      fetchMock as unknown as typeof fetch,
+    );
+    render(<PushToggle ensureFreshToken={ensureFreshToken} />);
+    const checkbox = await screen.findByRole('switch', { name: /push notifications/i });
+    expect(checkbox).not.toBeChecked();
+
+    await fireEvent.click(checkbox);
+    await waitFor(() => expect(subscribePush).toHaveBeenCalled());
+    await waitFor(() => expect(checkbox).toBeChecked());
+
+    await fireEvent.click(checkbox);
+    await waitFor(() => expect(unsubscribePush).toHaveBeenCalled());
+    await waitFor(() => expect(checkbox).not.toBeChecked());
   });
 });


### PR DESCRIPTION
## Summary
- ensure backend user tests cover `onesignal_player_id`
- mock OneSignal push services in `PushToggle` tests
- verify enabling and disabling push notifications

## Testing
- `npm run lint`
- `cd backend && pytest -q --maxfail=1 --disable-warnings`
- `cd frontend && npx vitest run src/components/PushToggle.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c1048d3ae083319d163480b5c39ca2