### PR TITLE
feat: add OneSignal service worker files

### DIFF
--- a/frontend/public/OneSignalSDKUpdaterWorker.js
+++ b/frontend/public/OneSignalSDKUpdaterWorker.js
@@ -1,0 +1,1 @@
+importScripts('https://cdn.onesignal.com/sdks/OneSignalSDKWorker.js');

--- a/frontend/public/OneSignalSDKWorker.js
+++ b/frontend/public/OneSignalSDKWorker.js
@@ -1,0 +1,1 @@
+importScripts('https://cdn.onesignal.com/sdks/OneSignalSDKWorker.js');


### PR DESCRIPTION
## Summary
- add OneSignal SDK service worker files to public directory
- ensure dev server serves OneSignal SDK worker

## Testing
- `npm run lint`
- `cd backend && pytest -q --maxfail=1 --disable-warnings`
- `cd ../frontend && npx vitest run`
- `curl -I http://localhost:5173/OneSignalSDKWorker.js`


------
https://chatgpt.com/codex/tasks/task_e_68c113b410f483318201183363739bb6