### PR TITLE
fix: guard OneSignal usage without app id

### DIFF
--- a/frontend/src/services/push.ts
+++ b/frontend/src/services/push.ts
@@ -54,10 +54,25 @@ async function initOneSignal() {
   return initPromise;
 }
 
+function ensureAppId(): boolean {
+  if (!import.meta.env.VITE_ONESIGNAL_APP_ID) {
+    logger.warn(
+      'services/push',
+      'VITE_ONESIGNAL_APP_ID is not set; push notifications are disabled',
+    );
+    return false;
+  }
+  return true;
+}
+
 export async function subscribePush(): Promise<string | null> {
+  if (!ensureAppId()) return null;
   const os = await initOneSignal();
   if (!os?.User?.pushSubscription) {
-    logger.error('services/push', 'OneSignal pushSubscription not available');
+    logger.warn(
+      'services/push',
+      'OneSignal pushSubscription not available. Verify VITE_ONESIGNAL_APP_ID and browser push support',
+    );
     return null;
   }
   try {
@@ -72,9 +87,13 @@ export async function subscribePush(): Promise<string | null> {
 }
 
 export async function unsubscribePush(): Promise<void> {
+  if (!ensureAppId()) return;
   const os = await initOneSignal();
   if (!os?.User?.pushSubscription) {
-    logger.error('services/push', 'OneSignal pushSubscription not available');
+    logger.warn(
+      'services/push',
+      'OneSignal pushSubscription not available. Verify VITE_ONESIGNAL_APP_ID and browser push support',
+    );
     return;
   }
   try {
@@ -86,9 +105,13 @@ export async function unsubscribePush(): Promise<void> {
 }
 
 export async function refreshPushToken(): Promise<string | null> {
+  if (!ensureAppId()) return null;
   const os = await initOneSignal();
   if (!os?.User?.pushSubscription) {
-    logger.error('services/push', 'OneSignal pushSubscription not available');
+    logger.warn(
+      'services/push',
+      'OneSignal pushSubscription not available. Verify VITE_ONESIGNAL_APP_ID and browser push support',
+    );
     return null;
   }
   try {


### PR DESCRIPTION
## Summary
- warn instead of error when OneSignal push subscription is unavailable and hint to verify `VITE_ONESIGNAL_APP_ID` and browser support
- add helper to skip push actions when `VITE_ONESIGNAL_APP_ID` is missing

## Testing
- `npm run lint`
- `cd frontend && npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_68c11ac2b1d0833192cc84fcf3d35b16