### PR TITLE
feat: add user update logging and debug SQL echo

### DIFF
--- a/backend/app/api/users.py
+++ b/backend/app/api/users.py
@@ -4,6 +4,10 @@ import logging
 import uuid
 from typing import List, Optional
 
+from fastapi import APIRouter, Depends, status
+from pydantic import BaseModel, Field
+from sqlalchemy.ext.asyncio import AsyncSession
+
 from app.dependencies import get_current_user, get_db
 from app.models.user_v2 import User
 from app.schemas.api_booking import StripePaymentMethod
@@ -19,9 +23,6 @@ from app.services.user_service import (
     save_payment_method,
     update_user,
 )
-from fastapi import APIRouter, Depends, status
-from pydantic import BaseModel, Field
-from sqlalchemy.ext.asyncio import AsyncSession
 
 logger = logging.getLogger(__name__)
 
@@ -59,7 +60,21 @@ async def api_update_me(
     current_user: User = Depends(get_current_user),
 ):
     """Allow the current user to update their profile, including phone."""
+    logger.info(
+        "api_update_me:start",
+        extra={
+            "user_id": current_user.id,
+            "update_fields": data.model_dump(exclude_unset=True),
+        },
+    )
     user = await update_user(db, current_user.id, data)
+    logger.info(
+        "api_update_me:success",
+        extra={
+            "user_id": current_user.id,
+            "onesignal_player_id": user.onesignal_player_id,
+        },
+    )
     return user
 
 

--- a/backend/app/db/database.py
+++ b/backend/app/db/database.py
@@ -56,6 +56,9 @@ engine_kwargs: Dict[str, Union[int, bool, Dict[str, Union[bool, int]]]] = {
     "connect_args": {"timeout": 30}
 }
 
+if settings.debug:
+    engine_kwargs["echo"] = True
+
 if is_sqlite_async:
     engine_kwargs["connect_args"]["check_same_thread"] = False
 else:

--- a/backend/app/services/user_service.py
+++ b/backend/app/services/user_service.py
@@ -84,6 +84,10 @@ async def update_user(
         )
 
     update_data = data.model_dump(exclude_unset=True)
+    logger.info(
+        "update_user:fields",
+        extra={"user_id": user_id, "update_data": update_data},
+    )
 
     # Handle password specially; everything else set directly
     if "password" in update_data:
@@ -95,6 +99,15 @@ async def update_user(
 
     await db.flush()
     await db.refresh(user)
+    for field in update_data.keys():
+        logger.info(
+            "update_user:field_updated",
+            extra={
+                "user_id": user_id,
+                "field": field,
+                "value": getattr(user, field),
+            },
+        )
     return UserRead.model_validate(user)
 
 


### PR DESCRIPTION
## Summary
- log update fields and OneSignal player id in `api_update_me`
- trace user updates before applying and after commit
- enable SQLAlchemy echo logging when running in debug

## Testing
- `npm run lint`
- `cd backend && pytest -q --maxfail=1 --disable-warnings`

------
https://chatgpt.com/codex/tasks/task_e_68c12b866fec833188cfecc3e8a45ac6