### PR TITLE
feat: log OneSignal service worker registration status

### DIFF
--- a/frontend/src/services/push.ts
+++ b/frontend/src/services/push.ts
@@ -48,6 +48,38 @@ async function initOneSignal() {
           appId,
           allowLocalhostAsSecureOrigin: true,
         });
+        const registrations = await navigator.serviceWorker.getRegistrations();
+        logger.debug('services/push', 'Service worker registrations', {
+          registrations,
+        });
+        if (registrations.length === 0) {
+          logger.error(
+            'services/push',
+            'OneSignal service worker not registered',
+            {
+              expected: [
+                '/OneSignalSDKWorker.js',
+                '/OneSignalSDKUpdaterWorker.js',
+              ],
+            },
+          );
+          try {
+            const registration = await navigator.serviceWorker.register(
+              '/OneSignalSDKWorker.js',
+            );
+            logger.debug(
+              'services/push',
+              'Manually registered OneSignal service worker',
+              { scope: registration.scope },
+            );
+          } catch (err) {
+            logger.error(
+              'services/push',
+              'Manual OneSignal service worker registration failed',
+              err,
+            );
+          }
+        }
         logger.debug('services/push', 'OneSignal initialization complete');
         initialized = true;
       }


### PR DESCRIPTION
## Summary
- log service worker registrations after OneSignal init
- warn and attempt manual registration if OneSignal worker is missing

## Testing
- `npm run lint`
- `cd backend && pytest -q --maxfail=1 --disable-warnings`
- `cd frontend && npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_68c139c2724c8331b72877f8395c79c0