### PR TITLE
fix: correct OneSignal worker script import

### DIFF
--- a/frontend/public/OneSignalSDKUpdaterWorker.js
+++ b/frontend/public/OneSignalSDKUpdaterWorker.js
@@ -1,3 +1,3 @@
 importScripts(
-  'https://cdn.onesignal.com/sdks/web/v16/OneSignalSDK.worker.js'
+  'https://cdn.onesignal.com/sdks/web/v16/OneSignalSDK.sw.js'
 );

--- a/frontend/public/OneSignalSDKWorker.js
+++ b/frontend/public/OneSignalSDKWorker.js
@@ -1,3 +1,3 @@
 importScripts(
-  'https://cdn.onesignal.com/sdks/web/v16/OneSignalSDK.worker.js'
+  'https://cdn.onesignal.com/sdks/web/v16/OneSignalSDK.sw.js'
 );


### PR DESCRIPTION
## Summary
- load updated OneSignal Web SDK v16 worker script

## Testing
- `npm run lint`
- `pytest -q --maxfail=1 --disable-warnings`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_68c13c6a4f588331abe9428972dbafd6