### PR TITLE
fix: align OneSignal push subscription casing

### DIFF
--- a/frontend/src/services/push.ts
+++ b/frontend/src/services/push.ts
@@ -5,7 +5,7 @@ import { CONFIG } from '@/config';
 interface OneSignalSDK {
   init(options: { appId: string; allowLocalhostAsSecureOrigin?: boolean }): Promise<void>;
   User?: {
-    pushSubscription: {
+    PushSubscription: {
       id: Promise<string | null>;
       optIn: () => Promise<void>;
       optOut: () => Promise<void>;
@@ -86,7 +86,7 @@ export async function subscribePush(): Promise<string | null> {
     );
     return null;
   }
-  const subscription = user.pushSubscription;
+  const subscription = user.PushSubscription;
   if (!subscription) {
     logger.warn(
       'services/push',
@@ -141,7 +141,7 @@ export async function unsubscribePush(): Promise<void> {
     );
     return;
   }
-  const subscription = user.pushSubscription;
+  const subscription = user.PushSubscription;
   if (!subscription) {
     logger.warn(
       'services/push',
@@ -168,7 +168,7 @@ export async function refreshPushToken(): Promise<string | null> {
     );
     return null;
   }
-  const subscription = user.pushSubscription;
+  const subscription = user.PushSubscription;
   if (!subscription) {
     logger.warn(
       'services/push',


### PR DESCRIPTION
## Summary
- update the OneSignalSDK interface so the User object exposes a PushSubscription property
- use the new PushSubscription accessor when interacting with OneSignal subscriptions

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c9272975508331b589c0a25751c3ef