### PR TITLE
fix: align OneSignal SDK import with service worker

### DIFF
--- a/frontend/src/services/push.ts
+++ b/frontend/src/services/push.ts
@@ -37,7 +37,7 @@ async function initOneSignal() {
     try {
       if (!window.OneSignal) {
         logger.debug('services/push', 'Loading OneSignal SDK');
-        await import('https://cdn.onesignal.com/sdks/OneSignalSDK.js');
+        await import('https://cdn.onesignal.com/sdks/web/v16/OneSignalSDK.js');
         logger.debug('services/push', 'OneSignal SDK loaded');
       }
       if (!initialized) {


### PR DESCRIPTION
## Summary
- update the OneSignal SDK dynamic import to load the web/v16 build so it matches the service worker version

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c9275230748331a0f225129ff04b61