### PR TITLE
fix: adjust OneSignal push subscription typing

### DIFF
--- a/frontend/src/services/push.ts
+++ b/frontend/src/services/push.ts
@@ -6,7 +6,7 @@ interface OneSignalSDK {
   init(options: { appId: string; allowLocalhostAsSecureOrigin?: boolean }): Promise<void>;
   User?: {
     pushSubscription: {
-      id: Promise<string | null>;
+      id: string | null | undefined;
       optIn: () => Promise<void>;
       optOut: () => Promise<void>;
     };
@@ -99,7 +99,7 @@ export async function subscribePush(): Promise<string | null> {
     await subscription.optIn();
     logger.debug('services/push', 'pushSubscription.optIn resolved');
 
-    const id = await subscription.id;
+    const id = subscription.id;
     logger.debug('services/push', 'Subscription object', {
       id,
       hasOptIn: typeof subscription.optIn === 'function',
@@ -177,7 +177,7 @@ export async function refreshPushToken(): Promise<string | null> {
     return null;
   }
   try {
-    const id = await subscription.id;
+    const id = subscription.id;
     return id ?? null;
   } catch (err) {
     logger.warn('services/push', 'OneSignal id retrieval failed', err);

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,1 +1,3 @@
 /// <reference types="vite/client" />
+
+declare module 'https://cdn.onesignal.com/sdks/OneSignalSDK.js';


### PR DESCRIPTION
## Summary
- align the OneSignal push subscription type with synchronous `id` access returning `string | null | undefined`
- remove unnecessary awaits when reading the subscription id and declare the CDN module for clean type checking

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68c9275edd408331995f688f3e8d2d55