### PR TITLE
chore: remove legacy onesignal workers

### DIFF
--- a/frontend/public/OneSignalSDKUpdaterWorker.js
+++ b/frontend/public/OneSignalSDKUpdaterWorker.js
@@ -1,1 +1,0 @@
-importScripts('https://cdn.onesignal.com/sdks/OneSignalSDKWorker.js');

--- a/frontend/public/OneSignalSDKWorker.js
+++ b/frontend/public/OneSignalSDKWorker.js
@@ -1,1 +1,0 @@
-importScripts('https://cdn.onesignal.com/sdks/OneSignalSDKWorker.js');


### PR DESCRIPTION
## Summary
- remove the legacy OneSignal worker shims from the frontend public assets so only the v16 service worker remains
- verify the Vite build emits a single OneSignal service worker file at the dist root

## Testing
- npx vite build

------
https://chatgpt.com/codex/tasks/task_e_68c9276cd9c8833189c60eee24106012