### PR TITLE
chore(frontend): add react-onesignal package

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -20,6 +20,9 @@ Create a `.env` file or export the following variables:
 - `VITE_GOOGLE_MAPS_API_KEY` – Google Maps key for rendering maps.
 - `VITE_ONESIGNAL_APP_ID` – OneSignal application ID.
 - `VITE_ONESIGNAL_API_KEY` – OneSignal REST API key.
+- `VITE_ONESIGNAL_SERVICE_WORKER_PATH` – Optional relative path to the OneSignal service worker script. Defaults to `OneSignalSDK.sw.js` in `public/`.
+
+The OneSignal web SDK expects a service worker bundle to be served from `public/OneSignalSDK.sw.js`. Update that file with the latest worker from OneSignal and adjust `VITE_ONESIGNAL_SERVICE_WORKER_PATH` if you host it at a different path.
 
 ## Development
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -22,6 +22,7 @@
         "openapi-generator-cli": "^1.0.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
+        "react-onesignal": "^3.3.0",
         "react-router-dom": "^7.7.1"
       },
       "devDependencies": {
@@ -7291,6 +7292,16 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.1.1.tgz",
       "integrity": "sha512-tr41fA15Vn8p4X9ntI+yCyeGSf1TlYaY5vlTZfQmeLBrFo3psOPX6HhTDnFNL9uj3EhP0KAQ80cugCl4b4BERA==",
       "license": "MIT"
+    },
+    "node_modules/react-onesignal": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/react-onesignal/-/react-onesignal-3.3.0.tgz",
+      "integrity": "sha512-br8qs89CgTDifztO5BMPNx0tM+SoG2tQnRo8vCaWjc/qwxyCYs5yujsS4H1UgCyaxBlOm8zjSqjO26rzaDUyaQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6"
+      }
     },
     "node_modules/react-refresh": {
       "version": "0.17.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -32,6 +32,7 @@
     "openapi-generator-cli": "^1.0.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
+    "react-onesignal": "^3.3.0",
     "react-router-dom": "^7.7.1"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- add the react-onesignal dependency so the push notification integration can use the React helper package
- refresh the lock file to record the new dependency and its metadata
- document the optional VITE_ONESIGNAL_SERVICE_WORKER_PATH variable for configuring the service worker path

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c9c0980edc8331af240f13ad10a355