### PR TITLE
fix: integrate react onesignal sdk

### DIFF
--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,3 +1,1 @@
 /// <reference types="vite/client" />
-
-declare module 'https://cdn.onesignal.com/sdks/OneSignalSDK.js';


### PR DESCRIPTION
## Summary
- use the react-onesignal SDK import instead of the CDN shim and keep a module-scoped init promise
- configure service worker paths from environment settings when calling `OneSignal.init`
- update push subscription helpers to rely on `OneSignal.User.PushSubscription` and drop the CDN module declaration

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c9c2b9ccd083318cb906d82349d589