### PR TITLE
test: verify OneSignal push initialization

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -14,6 +14,12 @@ Install dependencies:
 npm install
 ```
 
+Install the OneSignal Web SDK wrapper that powers push subscriptions:
+
+```bash
+npm install react-onesignal
+```
+
 Create a `.env` file or export the following variables:
 
 - `VITE_API_BASE_URL` – URL of the backend API (e.g. `http://localhost:8000`).
@@ -23,7 +29,37 @@ Create a `.env` file or export the following variables:
 - `VITE_ONESIGNAL_SERVICE_WORKER_PATH` – Optional relative path to the OneSignal service worker script. Defaults to `onesignal/OneSignalSDKWorker.js` served from `public/`.
 - `VITE_ONESIGNAL_SERVICE_WORKER_UPDATER_PATH` – Optional relative path for the updater worker. Defaults to `onesignal/OneSignalSDKUpdaterWorker.js`.
 
-The OneSignal web SDK expects the service worker bundle and wrapper scripts (`OneSignalSDKWorker.js` and `OneSignalSDKUpdaterWorker.js`) to be served from `public/onesignal/`. The `public/OneSignalSDK.sw.js` file now contains the bundled worker from OneSignal v16 so local builds do not reach out to the CDN. Adjust the environment variables above if you move these files.
+Example `.env.local` snippet for local development:
+
+```
+VITE_API_BASE_URL=http://localhost:8000
+VITE_GOOGLE_MAPS_API_KEY=<maps-api-key>
+VITE_ONESIGNAL_APP_ID=<onesignal-app-id>
+VITE_ONESIGNAL_API_KEY=<onesignal-rest-key>
+VITE_ONESIGNAL_SERVICE_WORKER_PATH=onesignal/OneSignalSDKWorker.js
+VITE_ONESIGNAL_SERVICE_WORKER_UPDATER_PATH=onesignal/OneSignalSDKUpdaterWorker.js
+```
+
+### Hosting the OneSignal service worker
+
+- The worker and updater bundles live in `public/onesignal/`. When you run `npm run dev` or `npm run build`, Vite copies that directory to `/onesignal/*` in the dev server or `dist/` output. Ensure your static host serves those files from the same origin so the SDK can register.
+- The wrapper `public/OneSignalSDK.sw.js` must also be deployed at the root of your site (e.g. `/OneSignalSDK.sw.js`). Copy it alongside the `onesignal/` directory when publishing to production.
+- If you move the worker files, update `VITE_ONESIGNAL_SERVICE_WORKER_PATH` and `VITE_ONESIGNAL_SERVICE_WORKER_UPDATER_PATH` to the new **absolute** path (include the leading slash). The frontend automatically normalizes these values when calling `subscribePush()` after authentication.
+- Example Nginx configuration to expose the workers:
+
+  ```nginx
+  location /onesignal/ {
+    alias /usr/share/nginx/html/onesignal/;
+    add_header Service-Worker-Allowed '/';
+  }
+
+  location = /OneSignalSDK.sw.js {
+    try_files $uri =404;
+    add_header Service-Worker-Allowed '/';
+  }
+  ```
+
+Once the environment variables are in place, logging in will trigger `subscribePush()` which initializes the OneSignal SDK and registers the user if push notifications are enabled for the browser.
 
 ## Development
 

--- a/frontend/src/contexts/AuthContext.test.tsx
+++ b/frontend/src/contexts/AuthContext.test.tsx
@@ -1,0 +1,112 @@
+import React, { useEffect } from 'react';
+import { render, waitFor } from '@testing-library/react';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+let subscribePushMock: ReturnType<typeof vi.fn>;
+let loginMock: ReturnType<typeof vi.fn>;
+let apiFetchMock: ReturnType<typeof vi.fn>;
+
+const resetMocks = () => {
+  subscribePushMock = vi.fn().mockResolvedValue('player-id');
+  loginMock = vi.fn().mockResolvedValue({
+    data: {
+      access_token: 'access-token',
+      refresh_token: 'refresh-token',
+      role: 'dispatcher',
+      user: {
+        id: 101,
+        email: 'user@example.com',
+        full_name: 'Test User',
+        role: 'dispatcher',
+        phone: '+15555555555',
+      },
+    },
+  });
+  apiFetchMock = vi.fn().mockResolvedValue({ ok: false } as Response);
+};
+
+describe('AuthProvider push subscription', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    vi.unstubAllEnvs();
+    localStorage.clear();
+    resetMocks();
+
+    vi.doMock('@/services/push', () => ({
+      __esModule: true,
+      subscribePush: subscribePushMock,
+      unsubscribePush: vi.fn(),
+      refreshPushToken: vi.fn(),
+    }));
+
+    vi.doMock('@/components/ApiConfig', () => ({
+      __esModule: true,
+      authApi: { loginAuthLoginPost: loginMock },
+    }));
+
+    vi.doMock('@/services/apiFetch', () => ({
+      __esModule: true,
+      apiFetch: apiFetchMock,
+    }));
+
+    vi.doMock('@/lib/logger', () => ({
+      __esModule: true,
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    }));
+  });
+  it('subscribes to push notifications once authentication succeeds', async () => {
+    vi.stubEnv('VITE_ONESIGNAL_APP_ID', 'app-id');
+
+    const { AuthProvider, useAuth } = await import('./AuthContext');
+
+    const TriggerLogin: React.FC = () => {
+      const { loginWithPassword } = useAuth();
+      useEffect(() => {
+        void loginWithPassword('user@example.com', 'password');
+      }, [loginWithPassword]);
+      return null;
+    };
+
+    render(
+      <AuthProvider>
+        <TriggerLogin />
+      </AuthProvider>,
+    );
+
+    await waitFor(() => {
+      expect(loginMock).toHaveBeenCalledWith({ email: 'user@example.com', password: 'password' });
+    });
+
+    await waitFor(() => {
+      expect(subscribePushMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('does not subscribe when OneSignal is disabled', async () => {
+    const { AuthProvider, useAuth } = await import('./AuthContext');
+
+    const TriggerLogin: React.FC = () => {
+      const { loginWithPassword } = useAuth();
+      useEffect(() => {
+        void loginWithPassword('user@example.com', 'password');
+      }, [loginWithPassword]);
+      return null;
+    };
+
+    render(
+      <AuthProvider>
+        <TriggerLogin />
+      </AuthProvider>,
+    );
+
+    await waitFor(() => {
+      expect(loginMock).toHaveBeenCalledTimes(1);
+    });
+
+    expect(subscribePushMock).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/services/push.test.ts
+++ b/frontend/src/services/push.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const initMock = vi.fn();
+const optInMock = vi.fn();
+const optOutMock = vi.fn();
+const pushSubscription = {
+  id: 'player-id',
+  optIn: optInMock,
+  optOut: optOutMock,
+};
+
+vi.mock('react-onesignal', () => ({
+  __esModule: true,
+  default: {
+    init: initMock,
+    User: {
+      PushSubscription: pushSubscription,
+    },
+  },
+}));
+
+const apiFetchMock = vi.fn();
+vi.mock('@/services/apiFetch', () => ({
+  __esModule: true,
+  apiFetch: apiFetchMock,
+}));
+
+vi.mock('@/lib/logger', () => ({
+  __esModule: true,
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+}));
+
+describe('services/push subscribePush', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    vi.unstubAllEnvs();
+    pushSubscription.id = 'player-id';
+    initMock.mockResolvedValue(undefined);
+    optInMock.mockResolvedValue(undefined);
+    optOutMock.mockResolvedValue(undefined);
+    apiFetchMock.mockResolvedValue({ ok: true, status: 204 } as Response);
+  });
+
+  it('returns null and skips init when app id is missing', async () => {
+    const { subscribePush } = await import('./push');
+
+    const result = await subscribePush();
+
+    expect(result).toBeNull();
+    expect(initMock).not.toHaveBeenCalled();
+    expect(apiFetchMock).not.toHaveBeenCalled();
+  });
+
+  it('initializes OneSignal with default worker paths and persists the player id', async () => {
+    vi.stubEnv('VITE_ONESIGNAL_APP_ID', 'test-app');
+    vi.stubEnv('VITE_API_BASE_URL', 'https://api.example.com');
+    const { subscribePush } = await import('./push');
+
+    const result = await subscribePush();
+
+    expect(initMock).toHaveBeenCalledTimes(1);
+    const options = initMock.mock.calls[0][0] as Record<string, unknown>;
+    expect(options).toMatchObject({
+      appId: 'test-app',
+      allowLocalhostAsSecureOrigin: true,
+      serviceWorkerPath: '/onesignal/OneSignalSDKWorker.js',
+      serviceWorkerUpdaterPath: '/onesignal/OneSignalSDKUpdaterWorker.js',
+      serviceWorkerParam: { scope: '/onesignal/' },
+    });
+    expect(optInMock).toHaveBeenCalledTimes(1);
+    expect(result).toBe('player-id');
+    expect(apiFetchMock).toHaveBeenCalledWith('https://api.example.com/users/me', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ onesignal_player_id: 'player-id' }),
+    });
+  });
+
+  it('uses configured worker paths and scope when provided', async () => {
+    vi.stubEnv('VITE_ONESIGNAL_APP_ID', 'custom-app');
+    vi.stubEnv('VITE_ONESIGNAL_SERVICE_WORKER_PATH', 'custom/sw.js');
+    vi.stubEnv('VITE_ONESIGNAL_SERVICE_WORKER_UPDATER_PATH', '/alt/updater.js');
+    const { subscribePush } = await import('./push');
+
+    await subscribePush();
+
+    const options = initMock.mock.calls[0][0] as Record<string, unknown>;
+    expect(options).toMatchObject({
+      serviceWorkerPath: '/custom/sw.js',
+      serviceWorkerUpdaterPath: '/alt/updater.js',
+      serviceWorkerParam: { scope: '/custom/' },
+    });
+  });
+
+  it('reuses the existing OneSignal instance on subsequent subscriptions', async () => {
+    vi.stubEnv('VITE_ONESIGNAL_APP_ID', 'reuse-app');
+    const { subscribePush } = await import('./push');
+
+    pushSubscription.id = 'first-player';
+    await subscribePush();
+
+    pushSubscription.id = 'second-player';
+    const second = await subscribePush();
+
+    expect(initMock).toHaveBeenCalledTimes(1);
+    expect(optInMock).toHaveBeenCalledTimes(2);
+    expect(second).toBe('second-player');
+  });
+
+  it('attempts re-initialization when OneSignal.init rejects', async () => {
+    vi.stubEnv('VITE_ONESIGNAL_APP_ID', 'retry-app');
+    initMock.mockRejectedValueOnce(new Error('boom'));
+    const { subscribePush } = await import('./push');
+
+    const first = await subscribePush();
+    expect(first).toBeNull();
+    expect(initMock).toHaveBeenCalledTimes(1);
+
+    pushSubscription.id = 'after-retry';
+    const second = await subscribePush();
+    expect(initMock).toHaveBeenCalledTimes(2);
+    expect(second).toBe('after-retry');
+  });
+});


### PR DESCRIPTION
## Summary
- add a dedicated unit test suite for `subscribePush()` that covers initialization paths
- add an AuthProvider test to confirm push subscription runs post-authentication when OneSignal is enabled
- document the OneSignal package install, environment variables, and service worker hosting expectations

## Testing
- npx vitest run src/services/push.test.ts src/contexts/AuthContext.test.tsx


------
https://chatgpt.com/codex/tasks/task_e_68c9cb9c014c8331affc81a2348bce17