### PR TITLE
feat: persist push subscription changes via listener

### DIFF
--- a/frontend/src/services/push.test.ts
+++ b/frontend/src/services/push.test.ts
@@ -1,0 +1,143 @@
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
+
+const apiFetchMock = vi.fn<
+  [input: RequestInfo | URL, init?: RequestInit],
+  Promise<Response>
+>();
+
+vi.mock('@/services/apiFetch', () => ({
+  apiFetch: apiFetchMock,
+}));
+
+const loggerMock = {
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+};
+
+vi.mock('@/lib/logger', () => loggerMock);
+
+describe('services/push subscription change handling', () => {
+  let refreshPushToken: typeof import('./push').refreshPushToken;
+  let onPushSubscriptionChange: typeof import('./push').onPushSubscriptionChange;
+  let resetForTests: typeof import('./push').__resetPushListenersForTests;
+  let teardownPushListeners: typeof import('./push').teardownPushListeners;
+  let changeHandlers: Array<() => Promise<void> | void>;
+  let pushSubscription: {
+    id: string | null;
+    optIn: ReturnType<typeof vi.fn>;
+    optOut: ReturnType<typeof vi.fn>;
+    addEventListener: ReturnType<typeof vi.fn>;
+    removeEventListener: ReturnType<typeof vi.fn>;
+  };
+  let loginMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    apiFetchMock.mockReset();
+    Object.values(loggerMock).forEach((fn) => fn.mockClear());
+    changeHandlers = [];
+    localStorage.clear();
+    import.meta.env.VITE_ONESIGNAL_APP_ID = 'test-app';
+    import.meta.env.VITE_API_BASE_URL = 'https://api.example';
+
+    pushSubscription = {
+      id: 'initial',
+      optIn: vi.fn(),
+      optOut: vi.fn(),
+      addEventListener: vi.fn((event: string, handler: () => Promise<void> | void) => {
+        if (event === 'change') {
+          changeHandlers.push(handler);
+        }
+      }),
+      removeEventListener: vi.fn((event: string, handler: () => Promise<void> | void) => {
+        if (event === 'change') {
+          changeHandlers = changeHandlers.filter((fn) => fn !== handler);
+        }
+      }),
+    };
+
+    loginMock = vi.fn(() => Promise.resolve());
+    const initMock = vi.fn(() => Promise.resolve());
+
+    (window as unknown as { OneSignal?: unknown }).OneSignal = {
+      init: initMock,
+      login: loginMock,
+      User: {
+        PushSubscription: pushSubscription,
+      },
+    };
+    window.__oneSignalInitPromise = undefined;
+
+    const mod = await import('./push');
+    refreshPushToken = mod.refreshPushToken;
+    onPushSubscriptionChange = mod.onPushSubscriptionChange;
+    resetForTests = mod.__resetPushListenersForTests;
+    teardownPushListeners = mod.teardownPushListeners;
+
+    resetForTests();
+    apiFetchMock.mockResolvedValue({ status: 200 } as Response);
+  });
+
+  afterEach(() => {
+    teardownPushListeners();
+    resetForTests();
+    delete (window as unknown as { OneSignal?: unknown }).OneSignal;
+    window.__oneSignalInitPromise = undefined;
+  });
+
+  const getRegisteredHandler = () => {
+    expect(changeHandlers).not.toHaveLength(0);
+    const handler = changeHandlers[0];
+    expect(typeof handler).toBe('function');
+    return handler;
+  };
+
+  it('persists new subscription IDs to the backend', async () => {
+    await refreshPushToken();
+    expect(pushSubscription.addEventListener).toHaveBeenCalledWith(
+      'change',
+      expect.any(Function),
+    );
+
+    const handler = getRegisteredHandler();
+    pushSubscription.id = 'player-123';
+    await handler?.();
+
+    expect(apiFetchMock).toHaveBeenCalledWith(
+      'https://api.example/users/me',
+      expect.objectContaining({
+        method: 'PATCH',
+        body: JSON.stringify({ onesignal_player_id: 'player-123' }),
+      }),
+    );
+    expect(loginMock).not.toHaveBeenCalled();
+  });
+
+  it('re-links the external ID when available', async () => {
+    localStorage.setItem('onesignal_external_id', 'external-42');
+
+    await refreshPushToken();
+    const handler = getRegisteredHandler();
+
+    pushSubscription.id = 'player-999';
+    await handler?.();
+
+    expect(loginMock).toHaveBeenCalledWith('external-42');
+  });
+
+  it('notifies local listeners about subscription changes', async () => {
+    await refreshPushToken();
+
+    const callback = vi.fn();
+    const unsubscribe = onPushSubscriptionChange(callback);
+
+    const handler = getRegisteredHandler();
+    pushSubscription.id = 'player-abc';
+    await handler?.();
+
+    expect(callback).toHaveBeenCalledWith('player-abc');
+    unsubscribe();
+  });
+});

--- a/frontend/src/services/push.ts
+++ b/frontend/src/services/push.ts
@@ -2,14 +2,25 @@ import * as logger from '@/lib/logger';
 import { apiFetch } from '@/services/apiFetch';
 import { CONFIG } from '@/config';
 
+interface OneSignalPushSubscription {
+  id: string | null | undefined;
+  optIn: () => Promise<void>;
+  optOut: () => Promise<void>;
+  addEventListener?: (
+    event: 'change',
+    handler: (event?: unknown) => void | Promise<void>,
+  ) => void;
+  removeEventListener?: (
+    event: 'change',
+    handler: (event?: unknown) => void | Promise<void>,
+  ) => void;
+}
+
 interface OneSignalSDK {
   init(options: { appId: string; allowLocalhostAsSecureOrigin?: boolean }): Promise<void>;
+  login?: (externalId: string) => Promise<void>;
   User?: {
-    pushSubscription: {
-      id: string | null | undefined;
-      optIn: () => Promise<void>;
-      optOut: () => Promise<void>;
-    };
+    PushSubscription?: OneSignalPushSubscription;
   };
 }
 
@@ -23,6 +34,103 @@ declare global {
 let initialized = false;
 let initPromise: Promise<OneSignalSDK | null> | undefined =
   window.__oneSignalInitPromise;
+
+const EXTERNAL_ID_STORAGE_KEYS = ['onesignal_external_id', 'onesignalExternalId'];
+
+type SubscriptionChangeListener = (id: string | null) => void;
+
+let subscriptionListeners: SubscriptionChangeListener[] = [];
+let subscriptionListenerAttached = false;
+let removeSubscriptionChangeHandler: (() => void) | undefined;
+
+function emitSubscriptionChange(id: string | null) {
+  subscriptionListeners.forEach((listener) => {
+    try {
+      listener(id);
+    } catch (err) {
+      logger.error('services/push', 'Push subscription listener failed', err);
+    }
+  });
+}
+
+export function onPushSubscriptionChange(listener: SubscriptionChangeListener) {
+  subscriptionListeners.push(listener);
+  return () => {
+    subscriptionListeners = subscriptionListeners.filter((fn) => fn !== listener);
+  };
+}
+
+function getStoredExternalId(): string | null {
+  if (typeof window === 'undefined' || !window.localStorage) return null;
+
+  for (const key of EXTERNAL_ID_STORAGE_KEYS) {
+    try {
+      const value = window.localStorage.getItem(key);
+      if (value) {
+        return value;
+      }
+    } catch (err) {
+      logger.debug('services/push', 'Reading external ID failed', { key }, err);
+    }
+  }
+  return null;
+}
+
+function registerPushSubscriptionChangeHandler(
+  sdk: OneSignalSDK | null | undefined,
+) {
+  if (!sdk || subscriptionListenerAttached) return;
+
+  const subscription = sdk.User?.PushSubscription;
+  if (!subscription || typeof subscription.addEventListener !== 'function') {
+    logger.debug(
+      'services/push',
+      'OneSignal pushSubscription change events unavailable',
+    );
+    return;
+  }
+
+  const handler = async () => {
+    const currentId = sdk.User?.PushSubscription?.id ?? null;
+    logger.debug('services/push', 'Push subscription changed', { id: currentId });
+
+    const base = CONFIG.API_BASE_URL ?? '';
+    const url = `${base}/users/me`;
+    try {
+      await apiFetch(url, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ onesignal_player_id: currentId }),
+      });
+      logger.debug('services/push', 'Persisted push ID after change', {
+        id: currentId,
+      });
+    } catch (err) {
+      logger.error('services/push', 'Persisting push ID after change failed', err);
+    }
+
+    const externalId = getStoredExternalId();
+    if (externalId && typeof sdk.login === 'function') {
+      try {
+        await sdk.login(externalId);
+        logger.debug('services/push', 'Re-linked external ID after change', {
+          externalId,
+        });
+      } catch (err) {
+        logger.error('services/push', 'Re-linking external ID failed', err);
+      }
+    }
+
+    emitSubscriptionChange(currentId);
+  };
+
+  subscription.addEventListener('change', handler);
+  subscriptionListenerAttached = true;
+  removeSubscriptionChangeHandler = () => {
+    subscription.removeEventListener?.('change', handler);
+    subscriptionListenerAttached = false;
+  };
+}
 
 async function initOneSignal() {
   const appId = import.meta.env.VITE_ONESIGNAL_APP_ID;
@@ -53,6 +161,7 @@ async function initOneSignal() {
       logger.debug('services/push', 'OneSignal resolved', {
         available: !!status,
       });
+      registerPushSubscriptionChangeHandler(status);
       return status;
     } catch (err) {
       logger.error('services/push', 'OneSignal init failed', err);
@@ -78,6 +187,7 @@ function ensureAppId(): boolean {
 export async function subscribePush(): Promise<string | null> {
   if (!ensureAppId()) return null;
   const os = await initOneSignal();
+  registerPushSubscriptionChangeHandler(os);
   const user = os?.User;
   if (!user) {
     logger.warn(
@@ -133,6 +243,7 @@ export async function subscribePush(): Promise<string | null> {
 export async function unsubscribePush(): Promise<void> {
   if (!ensureAppId()) return;
   const os = await initOneSignal();
+  registerPushSubscriptionChangeHandler(os);
   const user = os?.User;
   if (!user) {
     logger.warn(
@@ -160,6 +271,7 @@ export async function unsubscribePush(): Promise<void> {
 export async function refreshPushToken(): Promise<string | null> {
   if (!ensureAppId()) return null;
   const os = await initOneSignal();
+  registerPushSubscriptionChangeHandler(os);
   const user = os?.User;
   if (!user) {
     logger.warn(
@@ -183,4 +295,25 @@ export async function refreshPushToken(): Promise<string | null> {
     logger.warn('services/push', 'OneSignal id retrieval failed', err);
     return null;
   }
+}
+
+export function teardownPushListeners() {
+  if (removeSubscriptionChangeHandler) {
+    try {
+      removeSubscriptionChangeHandler();
+    } catch (err) {
+      logger.warn('services/push', 'Removing push listener failed', err);
+    } finally {
+      removeSubscriptionChangeHandler = undefined;
+    }
+  }
+  subscriptionListenerAttached = false;
+  subscriptionListeners = [];
+}
+
+export function __resetPushListenersForTests() {
+  teardownPushListeners();
+  initialized = false;
+  initPromise = undefined;
+  window.__oneSignalInitPromise = undefined;
 }


### PR DESCRIPTION
## Summary
- register a OneSignal push subscription change handler that patches the user profile and re-links any stored external ID
- expose subscription change notifications with teardown helpers in the push service and wire PushToggle to those events instead of polling
- add focused unit coverage for the push service change handler and update PushToggle tests to cover the new event pathway

## Testing
- npx vitest run src/services/push.test.ts src/components/PushToggle.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68c9f2277edc8331afceda7a3a1f2a81