### PR TITLE
fix: preserve auth user id type from login responses

### DIFF
--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -264,14 +264,13 @@ useEffect(() => {
       const token = body.access_token ?? body.token ?? null;
       const role: string | null = body.role ?? body.user?.role ?? null;
       const userFromResp: UserShape | null =
-        body.user ||
-        ({
-          id: typeof body.id === "number" ? body.id : Number(body.id),
+        body.user ?? {
+          id: body.id,
           email: body.email ?? email,
           full_name: body.full_name,
           role: role ?? undefined,
           phone: body.phone,
-        } as UserShape);
+        };
       const tokenRes: TokenResponse | null = token
         ? {
             access_token: token,

--- a/frontend/src/types/AuthContextType.tsx
+++ b/frontend/src/types/AuthContextType.tsx
@@ -1,6 +1,6 @@
 // Type definitions for the authentication context values.
 export type UserShape = {
-  id?: number;
+  id?: string | number;
   email?: string;
   full_name?: string;
   role?: string;


### PR DESCRIPTION
## Summary
- stop coercing login response IDs in the auth context so the backend-provided identifier type is preserved
- widen the `UserShape` typing to allow string identifiers
- mock the push service in the auth context tests and add coverage for string IDs

## Testing
- npx vitest run src/contexts/AuthContext.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68ca8ea55ea4833193476b8e6ecae670