### PR TITLE
feat: sync push user metadata with OneSignal

### DIFF
--- a/frontend/src/components/PushToggle.test.tsx
+++ b/frontend/src/components/PushToggle.test.tsx
@@ -203,7 +203,7 @@ describe('PushToggle OneSignal integration', () => {
 
   it('logs into OneSignal using a stored external id', async () => {
     const pushModule = await import('@/services/push');
-    await pushModule.subscribePush('user-123');
+    await pushModule.subscribePush({ externalId: 'user-123' });
     await waitFor(() => expect(loginMock).toHaveBeenCalledWith('user-123'));
     loginMock.mockClear();
 

--- a/frontend/src/contexts/AuthContext.test.tsx
+++ b/frontend/src/contexts/AuthContext.test.tsx
@@ -111,7 +111,16 @@ describe('AuthContext push integrations', () => {
       await result.current.loginWithPassword('user@example.com', 'password');
     });
 
-    await waitFor(() => expect(subscribePushMock).toHaveBeenCalledWith('123'));
+    await waitFor(() => expect(subscribePushMock).toHaveBeenCalled());
+    const metadata = subscribePushMock.mock.calls.at(-1)?.[0];
+    expect(metadata).toMatchObject({
+      externalId: '123',
+      email: 'test@example.com',
+      fullName: 'Test User',
+      role: 'user',
+    });
+    expect(metadata?.phone).toBeNull();
+    expect(metadata?.tags?.user_id).toBe('123');
 
     await act(async () => {
       result.current.logout();
@@ -142,8 +151,16 @@ describe('AuthContext push integrations', () => {
       await result.current.loginWithPassword('user@example.com', 'password');
     });
 
-    await waitFor(() => expect(subscribePushMock).toHaveBeenCalledWith('user-123'));
-    const externalIds = subscribePushMock.mock.calls.map((call) => call[0]);
+    await waitFor(() => expect(subscribePushMock).toHaveBeenCalled());
+    const metadata = subscribePushMock.mock.calls.at(-1)?.[0];
+    expect(metadata).toMatchObject({
+      externalId: 'user-123',
+      email: 'test@example.com',
+      fullName: 'Test User',
+      role: 'user',
+    });
+    expect(metadata?.tags?.user_id).toBe('user-123');
+    const externalIds = subscribePushMock.mock.calls.map((call) => call[0]?.externalId);
     expect(externalIds).not.toContain('NaN');
   });
 });


### PR DESCRIPTION
## Summary
- update OneSignal service to accept rich metadata, sync email/SMS, and send tags when subscribing
- surface user metadata from AuthContext to the push subscriber, including role, name, and stored IDs
- extend push and AuthContext unit tests to validate metadata handling and adjust PushToggle test for new subscribe signature

## Testing
- `cd frontend && npx vitest run src/services/push.test.ts src/contexts/AuthContext.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68ca9c5c6f4c8331ab3307e233b25253