### PR TITLE
fix: display utc hours in day timeline

### DIFF
--- a/frontend/src/components/BookingWizard/DayTimeline.tsx
+++ b/frontend/src/components/BookingWizard/DayTimeline.tsx
@@ -24,7 +24,7 @@ export default function DayTimeline({
   return (
     <Stack direction="row" flexWrap="wrap" gap={1}>
       {slots.map(({ start, disabled }) => {
-        const label = `${String(start.getHours()).padStart(2, '0')}:00`;
+        const label = `${String(start.getUTCHours()).padStart(2, '0')}:00`;
         const iso = start.toISOString();
         return (
           <Button


### PR DESCRIPTION
## Summary
- use UTC hours for DayTimeline button labels to avoid timezone drift while keeping ISO emissions unchanged

## Testing
- npx vitest run src/__tests__/DayTimeline.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68cbe6782d188331873414e9c06e729e