### PR TITLE
fix: handle push toggle bootstrap failures

### DIFF
--- a/frontend/src/components/PushToggle.test.tsx
+++ b/frontend/src/components/PushToggle.test.tsx
@@ -87,6 +87,22 @@ describe('PushToggle', () => {
     await waitFor(() => expect(checkbox).toBeChecked());
   });
 
+  it('leaves the switch unchecked when bootstrap fails', async () => {
+    const consoleErrorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined);
+    try {
+      const { default: PushToggle } = await import('@/components/PushToggle');
+      fetchSpy = vi.spyOn(global, 'fetch').mockRejectedValue(new Error('network oops'));
+      render(<PushToggle ensureFreshToken={ensureFreshToken} />);
+      const checkbox = await screen.findByRole('switch', { name: /push notifications/i });
+      expect(checkbox).not.toBeChecked();
+      await waitFor(() => expect(consoleErrorSpy).toHaveBeenCalled());
+    } finally {
+      consoleErrorSpy.mockRestore();
+    }
+  });
+
   it('enables and disables push', async () => {
     const { default: PushToggle } = await import('@/components/PushToggle');
     const fetchMock = vi

--- a/frontend/src/components/PushToggle.tsx
+++ b/frontend/src/components/PushToggle.tsx
@@ -38,7 +38,8 @@ const PushToggle = ({ ensureFreshToken }: Props) => {
         }
       } catch (err) {
         if (controller.signal.aborted || !isActive) return;
-        throw err;
+        console.error('Failed to bootstrap push toggle', err);
+        return;
       }
     };
 


### PR DESCRIPTION
## Summary
- log and swallow bootstrap errors in the PushToggle bootstrap effect so the control stays usable
- add a unit test that simulates a /users/me failure and asserts the switch remains unchecked

## Testing
- npx vitest run src/components/PushToggle.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68cc88c9efb0833198bb145f01c1a376