### PR TITLE
fix: align booking slots with local time

### DIFF
--- a/frontend/src/__tests__/DayTimeline.test.tsx
+++ b/frontend/src/__tests__/DayTimeline.test.tsx
@@ -24,9 +24,10 @@ describe('DayTimeline', () => {
     const eleven = screen.getByRole('button', { name: '11:00' });
     expect(eleven).toBeEnabled();
     await userEvent.click(eleven);
-    expect(onSelect).toHaveBeenCalledWith(
-      new Date('2025-01-01T11:00:00').toISOString(),
-    );
+    const expectedIso = new Date(2025, 0, 1, 11, 0, 0, 0).toISOString();
+    expect(onSelect).toHaveBeenCalledWith(expectedIso);
+    const [[selectedIso]] = onSelect.mock.calls;
+    expect(new Date(selectedIso).getHours()).toBe(11);
   });
 });
 

--- a/frontend/src/components/BookingWizard/DayTimeline.tsx
+++ b/frontend/src/components/BookingWizard/DayTimeline.tsx
@@ -24,7 +24,7 @@ export default function DayTimeline({
   return (
     <Stack direction="row" flexWrap="wrap" gap={1}>
       {slots.map(({ start, disabled }) => {
-        const label = `${String(start.getUTCHours()).padStart(2, '0')}:00`;
+        const label = `${String(start.getHours()).padStart(2, '0')}:00`;
         const iso = start.toISOString();
         return (
           <Button

--- a/frontend/src/lib/availabilityUtils.ts
+++ b/frontend/src/lib/availabilityUtils.ts
@@ -49,18 +49,23 @@ export function calculateHourlyAvailability(
   const monthIndex = Number(monthString) - 1;
   const dayOfMonth = Number(dayString);
   return Array.from({ length: 24 }).map((_, h) => {
-    const start = new Date(Date.UTC(year, monthIndex, dayOfMonth, h, 0, 0, 0));
+    const start = new Date(year, monthIndex, dayOfMonth, h, 0, 0, 0);
     const end = new Date(start.getTime() + 60 * 60 * 1000);
+    const startMs = start.getTime();
+    const endMs = end.getTime();
     const disabled = availability
       ? availability.bookings.some((b) => {
           const bStart = new Date(b.pickup_when);
-          const bEnd = new Date(bStart.getTime() + 60 * 60 * 1000);
-          return bStart < end && bEnd > start;
+          const bStartMs = bStart.getTime();
+          const bEndMs = bStartMs + 60 * 60 * 1000;
+          return bStartMs < endMs && bEndMs > startMs;
         }) ||
         availability.slots.some((s) => {
           const sStart = new Date(s.start_dt);
           const sEnd = new Date(s.end_dt);
-          return sStart < end && sEnd > start;
+          const sStartMs = sStart.getTime();
+          const sEndMs = sEnd.getTime();
+          return sStartMs < endMs && sEndMs > startMs;
         })
       : false;
     return { start, disabled };

--- a/frontend/src/pages/Booking/BookingWizardPage.test.tsx
+++ b/frontend/src/pages/Booking/BookingWizardPage.test.tsx
@@ -146,7 +146,15 @@ test('creates booking on confirmation and shows tracking link', async () => {
 
   const now = new Date();
   const first = new Date(now.getFullYear(), now.getMonth(), 1);
-  const expectedWhen = new Date(`${first.toISOString().slice(0, 10)}T10:00`).toISOString();
+  const expectedWhen = new Date(
+    first.getFullYear(),
+    first.getMonth(),
+    1,
+    10,
+    0,
+    0,
+    0,
+  ).toISOString();
   expect(createBooking).toHaveBeenCalledWith({
     pickup_when: expectedWhen,
     pickup: { address: '123 A St', lat: 0, lng: 0 },
@@ -160,6 +168,8 @@ test('creates booking on confirmation and shows tracking link', async () => {
     },
   });
   expect(addBooking).toHaveBeenCalledWith({ id: '1', public_code: 'test' });
+  const [[createdBooking]] = createBooking.mock.calls;
+  expect(new Date(createdBooking.pickup_when).getHours()).toBe(10);
 });
 
 test('prompts to add a payment method when missing', async () => {


### PR DESCRIPTION
## Summary
- build booking slots in local time and compare availability using milliseconds for consistent overlaps
- render DayTimeline labels with local hours and forward the local slot ISO string
- refresh the DayTimeline and BookingWizard page tests to assert local hour handling

## Testing
- `npx vitest run --run src/__tests__/DayTimeline.test.tsx src/pages/Booking/BookingWizardPage.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68cc88c3b9b08331899c898828f09977