### PR TITLE
refactor: extract booking broadcast helper

### DIFF
--- a/backend/app/api/v1/driver_bookings.py
+++ b/backend/app/api/v1/driver_bookings.py
@@ -1,11 +1,6 @@
 import json
 import uuid
 
-from fastapi import APIRouter, Depends, HTTPException
-from sqlalchemy import select
-from sqlalchemy.ext.asyncio import AsyncSession
-
-from app.api.ws import send_booking_update
 from app.core.broadcast import broadcast
 from app.db.database import get_async_session
 from app.dependencies import require_admin
@@ -15,6 +10,10 @@ from app.models.user_v2 import UserRole
 from app.schemas.api_booking import BookingStatusResponse
 from app.schemas.booking import BookingRead
 from app.services import booking_service, notifications, scheduler
+from app.services.booking_updates import send_booking_update
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 
 router = APIRouter(
     prefix="/api/v1/driver/bookings",

--- a/backend/app/api/ws.py
+++ b/backend/app/api/ws.py
@@ -4,8 +4,6 @@ import logging
 import uuid
 from datetime import datetime, timezone
 
-from fastapi import APIRouter, WebSocket, WebSocketDisconnect
-
 from app.core.broadcast import broadcast
 from app.core.security import decode_token
 from app.db.database import AsyncSessionLocal
@@ -15,30 +13,10 @@ from app.models.route_point import RoutePoint
 from app.models.user_v2 import User, UserRole
 from app.services import notifications
 from app.services.settings_service import get_admin_user_id
+from fastapi import APIRouter, WebSocket, WebSocketDisconnect
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
-
-
-async def send_booking_update(booking: Booking, **fields) -> None:
-    """Publish booking updates to the broadcast channel.
-
-    Parameters
-    ----------
-    booking:
-        The updated booking instance.
-    fields:
-        Additional fields to include in the payload.
-    """
-    payload = {"id": str(booking.id), "status": booking.status}
-    if fields:
-        payload.update(fields)
-    if getattr(broadcast, "_listener_task", None) is None:
-        await broadcast.connect()
-    await broadcast.publish(
-        channel=f"booking:{booking.id}",
-        message=json.dumps(payload, default=str),
-    )
 
 
 @router.websocket("/ws/bookings/{booking_id}")

--- a/backend/app/services/booking_service.py
+++ b/backend/app/services/booking_service.py
@@ -7,11 +7,6 @@ from datetime import datetime, timedelta, timezone
 from math import atan2, cos, radians, sin, sqrt
 
 import stripe
-from fastapi import HTTPException
-from sqlalchemy import select
-from sqlalchemy.ext.asyncio import AsyncSession
-
-from app.api.ws import send_booking_update
 from app.db.database import AsyncSessionLocal
 from app.models.availability_slot import AvailabilitySlot
 from app.models.booking import Booking, BookingStatus
@@ -22,6 +17,10 @@ from app.models.trip import Trip
 from app.models.user_v2 import User, UserRole
 from app.schemas.api_booking import BookingCreateRequest
 from app.services import notifications, pricing_service, routing, stripe_client
+from app.services.booking_updates import send_booking_update
+from fastapi import HTTPException
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 
 
 async def create_booking(

--- a/backend/app/services/booking_updates.py
+++ b/backend/app/services/booking_updates.py
@@ -1,0 +1,23 @@
+"""Utilities for broadcasting booking updates to websocket subscribers."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from app.core.broadcast import broadcast
+from app.models.booking import Booking
+
+
+async def send_booking_update(booking: Booking, **fields: Any) -> None:
+    """Publish booking updates to the broadcast channel."""
+
+    payload: dict[str, Any] = {"id": str(booking.id), "status": booking.status}
+    if fields:
+        payload.update(fields)
+    if getattr(broadcast, "_listener_task", None) is None:
+        await broadcast.connect()
+    await broadcast.publish(
+        channel=f"booking:{booking.id}",
+        message=json.dumps(payload, default=str),
+    )


### PR DESCRIPTION
## Summary
- move the `send_booking_update` broadcaster helper into `app/services/booking_updates.py`
- update service and driver booking endpoints to import the shared helper instead of the websocket module
- remove the helper definition from the websocket API module while retaining its existing broadcast logic

## Testing
- pytest -q --maxfail=1 --disable-warnings


------
https://chatgpt.com/codex/tasks/task_e_68cc8c96d4d4833182c242b31c3f7473