### PR TITLE
fix: align hourly availability with UTC windows

### DIFF
--- a/frontend/src/__tests__/DayTimeline.test.tsx
+++ b/frontend/src/__tests__/DayTimeline.test.tsx
@@ -3,6 +3,7 @@ import userEvent from '@testing-library/user-event';
 import { describe, it, expect, vi } from 'vitest';
 import { renderWithProviders } from '@/__tests__/setup/renderWithProviders';
 import DayTimeline from '@/components/BookingWizard/DayTimeline';
+import { calculateHourlyAvailability } from '@/lib/availabilityUtils';
 
 describe('DayTimeline', () => {
   it('disables unavailable hours and emits selection', async () => {
@@ -14,8 +15,9 @@ describe('DayTimeline', () => {
       bookings: [{ id: 'b1', pickup_when: '2025-01-01T10:00:00Z' }],
     };
     const onSelect = vi.fn();
+    const slots = calculateHourlyAvailability(availability, '2025-01-01');
     renderWithProviders(
-      <DayTimeline date="2025-01-01" availability={availability} onSelect={onSelect} />,
+      <DayTimeline slots={slots} onSelect={onSelect} />,
     );
     expect(screen.getByRole('button', { name: '05:00' })).toBeDisabled();
     expect(screen.getByRole('button', { name: '10:00' })).toBeDisabled();
@@ -24,10 +26,10 @@ describe('DayTimeline', () => {
     const eleven = screen.getByRole('button', { name: '11:00' });
     expect(eleven).toBeEnabled();
     await userEvent.click(eleven);
-    const expectedIso = new Date(2025, 0, 1, 11, 0, 0, 0).toISOString();
+    const expectedIso = '2025-01-01T11:00:00.000Z';
     expect(onSelect).toHaveBeenCalledWith(expectedIso);
     const [[selectedIso]] = onSelect.mock.calls;
-    expect(new Date(selectedIso).getHours()).toBe(11);
+    expect(selectedIso).toBe(expectedIso);
   });
 });
 

--- a/frontend/src/components/BookingWizard/DayTimeline.tsx
+++ b/frontend/src/components/BookingWizard/DayTimeline.tsx
@@ -1,31 +1,20 @@
-import { useMemo } from 'react';
 import { Button, Stack } from '@mui/material';
-import type { AvailabilityResponse } from '@/api-client';
-import { calculateHourlyAvailability } from '@/lib/availabilityUtils';
+import type { HourlyAvailabilitySlot } from '@/lib/availabilityUtils';
 
 interface DayTimelineProps {
-  date: string;
-  availability: AvailabilityResponse | null;
+  slots: HourlyAvailabilitySlot[];
   value?: string;
   onSelect?: (iso: string) => void;
 }
 
 export default function DayTimeline({
-  date,
-  availability,
+  slots,
   value,
   onSelect,
 }: DayTimelineProps) {
-  const slots = useMemo(
-    () => calculateHourlyAvailability(availability, date),
-    [availability, date],
-  );
-
   return (
     <Stack direction="row" flexWrap="wrap" gap={1}>
-      {slots.map(({ start, disabled }) => {
-        const label = `${String(start.getHours()).padStart(2, '0')}:00`;
-        const iso = start.toISOString();
+      {slots.map(({ label, iso, disabled }) => {
         return (
           <Button
             key={iso}

--- a/frontend/src/components/BookingWizard/TripDetails.test.tsx
+++ b/frontend/src/components/BookingWizard/TripDetails.test.tsx
@@ -1,0 +1,63 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { renderWithProviders } from '@/__tests__/setup/renderWithProviders';
+
+vi.mock('@/hooks/useAvailability', () => ({
+  __esModule: true,
+  default: vi.fn(),
+}));
+
+vi.mock('@/hooks/useAddressAutocomplete', () => ({
+  useAddressAutocomplete: () => ({
+    suggestions: [],
+    loading: false,
+    onFocus: vi.fn(),
+    onBlur: vi.fn(),
+  }),
+}));
+
+vi.mock('./AvailabilityCalendar', () => ({
+  __esModule: true,
+  default: ({ value }: { value?: string }) => (
+    <div data-testid="availability-calendar" data-value={value} />
+  ),
+}));
+
+import type { AvailabilityResponse } from '@/api-client';
+import TripDetails from './TripDetails';
+import type { BookingFormData } from '@/types/BookingFormData';
+import useAvailability from '@/hooks/useAvailability';
+
+describe('TripDetails', () => {
+  const useAvailabilityMock = vi.mocked(useAvailability);
+
+  beforeEach(() => {
+    useAvailabilityMock.mockReset();
+  });
+
+  it('keeps blocked hours disabled with UTC-normalized availability', async () => {
+    const availability: AvailabilityResponse = {
+      slots: [
+        { id: 1, start_dt: '2025-01-01T05:00:00Z', end_dt: '2025-01-01T06:00:00Z' },
+      ],
+      bookings: [{ id: 'b1', pickup_when: '2025-01-01T10:00:00Z' }],
+    };
+    useAvailabilityMock.mockReturnValue({ data: availability });
+
+    const onChange = vi.fn();
+    const data: BookingFormData = {
+      passengers: 1,
+      pickup_when: '2025-01-01T05:00:00.000Z',
+    };
+
+    renderWithProviders(<TripDetails data={data} onChange={onChange} />);
+
+    expect(await screen.findByRole('button', { name: '05:00' })).toBeDisabled();
+    expect(screen.getByText('Time unavailable')).toBeInTheDocument();
+
+    const eleven = screen.getByRole('button', { name: '11:00' });
+    await userEvent.click(eleven);
+    expect(onChange).toHaveBeenCalledWith({ pickup_when: '2025-01-01T11:00:00.000Z' });
+  });
+});

--- a/frontend/src/lib/availabilityUtils.test.ts
+++ b/frontend/src/lib/availabilityUtils.test.ts
@@ -27,4 +27,17 @@ describe('availabilityUtils', () => {
     expect(hours[10].disabled).toBe(true);
     expect(hours[11].disabled).toBe(false);
   });
+
+  it('produces stable UTC labels and iso timestamps', () => {
+    const hours = calculateHourlyAvailability(availability, '2025-01-01');
+    expect(hours[0]).toMatchObject({
+      label: '00:00',
+      iso: '2025-01-01T00:00:00.000Z',
+    });
+    expect(hours[5]).toMatchObject({
+      label: '05:00',
+      iso: '2025-01-01T05:00:00.000Z',
+      disabled: true,
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- compute hourly availability in UTC and expose stable label/ISO pairs for the timeline
- update TripDetails to reuse normalized slots for blocking logic and adjust DayTimeline consumer
- extend unit and booking flow tests to guard against timezone regressions

## Testing
- npx vitest run src/lib/availabilityUtils.test.ts src/__tests__/DayTimeline.test.tsx src/components/BookingWizard/TripDetails.test.tsx
- npm run lint *(fails: existing @typescript-eslint issues in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cc91d357748331b9896d8d2831e59f