### PR TITLE
feat: target push notifications per recipient

### DIFF
--- a/backend/alembic/versions/bb39b3df88c1_add_notification_recipient.py
+++ b/backend/alembic/versions/bb39b3df88c1_add_notification_recipient.py
@@ -1,0 +1,32 @@
+"""add recipient to notifications
+
+Revision ID: bb39b3df88c1
+Revises: 4d2b4b9da96b
+Create Date: 2024-05-16 00:00:00.000000
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "bb39b3df88c1"
+down_revision = "4d2b4b9da96b"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("notifications") as batch_op:
+        batch_op.add_column(sa.Column("to_user_id", sa.UUID(), nullable=True))
+        batch_op.create_foreign_key(
+            "notifications_to_user_id_fkey",
+            "users_v2",
+            ["to_user_id"],
+            ["id"],
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("notifications") as batch_op:
+        batch_op.drop_constraint("notifications_to_user_id_fkey", type_="foreignkey")
+        batch_op.drop_column("to_user_id")

--- a/backend/app/api/v1/driver_bookings.py
+++ b/backend/app/api/v1/driver_bookings.py
@@ -54,6 +54,7 @@ async def confirm_booking(
         booking.id,
         NotificationType.CONFIRMATION,
         UserRole.CUSTOMER,
+        booking.customer_id,
         {"deposit_required_cents": booking.deposit_required_cents},
     )
     await db.commit()
@@ -98,6 +99,7 @@ async def leave_booking(
         booking.id,
         NotificationType.ON_THE_WAY,
         UserRole.CUSTOMER,
+        booking.customer_id,
         {},
     )
     await db.commit()
@@ -128,6 +130,7 @@ async def start_trip(
         booking.id,
         NotificationType.STARTED,
         UserRole.CUSTOMER,
+        booking.customer_id,
         {},
     )
     await db.commit()
@@ -162,6 +165,7 @@ async def complete_booking(
         booking.id,
         NotificationType.COMPLETED,
         UserRole.CUSTOMER,
+        booking.customer_id,
         {},
     )
     await db.commit()

--- a/backend/app/api/ws.py
+++ b/backend/app/api/ws.py
@@ -109,6 +109,7 @@ async def booking_ws(websocket: WebSocket, booking_id: uuid.UUID):
                                         booking.id,
                                         NotificationType.ARRIVED_PICKUP,
                                         UserRole.CUSTOMER,
+                                        booking.customer_id,
                                         {},
                                     )
                                     await db.commit()
@@ -132,6 +133,7 @@ async def booking_ws(websocket: WebSocket, booking_id: uuid.UUID):
                                         booking.id,
                                         NotificationType.ARRIVED_DROPOFF,
                                         UserRole.CUSTOMER,
+                                        booking.customer_id,
                                         {},
                                     )
                                     await db.commit()

--- a/backend/app/models/notification.py
+++ b/backend/app/models/notification.py
@@ -3,11 +3,10 @@ import uuid
 from datetime import datetime
 from typing import Any, Dict
 
-from sqlalchemy import JSON, UUID, DateTime, Enum, ForeignKey, String
+from app.db.database import Base
+from sqlalchemy import JSON, UUID, DateTime, Enum, ForeignKey
 from sqlalchemy.orm import Mapped, mapped_column
 from sqlalchemy.sql import func
-
-from app.db.database import Base
 
 
 class NotificationType(str, enum.Enum):
@@ -42,6 +41,9 @@ class Notification(Base):
     )
     to_role: Mapped[NotificationRole] = mapped_column(
         Enum(NotificationRole), nullable=False
+    )
+    to_user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("users_v2.id"), nullable=True
     )
     payload: Mapped[Dict[str, Any]] = mapped_column(JSON, default=dict)
     created_at: Mapped[datetime] = mapped_column(

--- a/backend/tests/unit/api/test_driver_bookings_notifications.py
+++ b/backend/tests/unit/api/test_driver_bookings_notifications.py
@@ -1,0 +1,145 @@
+import asyncio
+import uuid
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.v1 import driver_bookings
+from app.core.security import hash_password
+from app.models.booking import Booking, BookingStatus
+from app.models.notification import NotificationType
+from app.models.user_v2 import User, UserRole
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _make_booking(async_session: AsyncSession, status: BookingStatus) -> Booking:
+    customer = User(
+        email=f"customer{uuid.uuid4().hex}@example.com",
+        full_name="Customer",
+        hashed_password=hash_password("pass"),
+        role=UserRole.CUSTOMER,
+    )
+    async_session.add(customer)
+    await async_session.flush()
+    booking = Booking(
+        public_code=uuid.uuid4().hex[:6].upper(),
+        customer_id=customer.id,
+        pickup_address="A",
+        pickup_lat=0.0,
+        pickup_lng=0.0,
+        dropoff_address="B",
+        dropoff_lat=1.0,
+        dropoff_lng=1.0,
+        pickup_when=datetime.now(timezone.utc) + timedelta(hours=1),
+        notes=None,
+        passengers=1,
+        estimated_price_cents=1000,
+        deposit_required_cents=500,
+        status=status,
+    )
+    async_session.add(booking)
+    await async_session.flush()
+    return booking
+
+
+async def test_confirm_booking_dispatch(async_session: AsyncSession, mocker) -> None:
+    booking = await _make_booking(async_session, BookingStatus.PENDING)
+    dispatch = mocker.patch(
+        "app.services.notifications.dispatch_notification",
+        new_callable=AsyncMock,
+    )
+    mocker.patch(
+        "app.services.booking_service.confirm_booking",
+        new_callable=AsyncMock,
+        return_value=booking,
+    )
+    mocker.patch(
+        "app.services.scheduler.schedule_leave_now",
+        new_callable=AsyncMock,
+        return_value=datetime.now(timezone.utc),
+    )
+    mocker.patch(
+        "app.services.booking_updates.send_booking_update",
+        new_callable=AsyncMock,
+    )
+
+    await driver_bookings.confirm_booking(booking.id, db=async_session)
+    await asyncio.sleep(0)
+
+    dispatch.assert_awaited_once()
+    call = dispatch.await_args_list[0]
+    assert call.kwargs["to_user_id"] == booking.customer_id
+    assert call.kwargs["to_role"] is UserRole.CUSTOMER
+    assert call.kwargs["notif_type"] is NotificationType.CONFIRMATION
+
+
+async def test_leave_booking_dispatch(async_session: AsyncSession, mocker) -> None:
+    booking = await _make_booking(async_session, BookingStatus.DRIVER_CONFIRMED)
+    dispatch = mocker.patch(
+        "app.services.notifications.dispatch_notification",
+        new_callable=AsyncMock,
+    )
+    mocker.patch(
+        "app.services.booking_service.leave_booking",
+        new_callable=AsyncMock,
+        return_value=booking,
+    )
+
+    await driver_bookings.leave_booking(booking.id, db=async_session)
+    await asyncio.sleep(0)
+
+    dispatch.assert_awaited_once()
+    call = dispatch.await_args_list[0]
+    assert call.kwargs["to_user_id"] == booking.customer_id
+    assert call.kwargs["to_role"] is UserRole.CUSTOMER
+    assert call.kwargs["notif_type"] is NotificationType.ON_THE_WAY
+
+
+async def test_start_trip_dispatch(async_session: AsyncSession, mocker) -> None:
+    booking = await _make_booking(async_session, BookingStatus.ARRIVED_PICKUP)
+    dispatch = mocker.patch(
+        "app.services.notifications.dispatch_notification",
+        new_callable=AsyncMock,
+    )
+    mocker.patch(
+        "app.services.booking_service.start_trip",
+        new_callable=AsyncMock,
+        return_value=booking,
+    )
+    mocker.patch("app.core.broadcast.broadcast.publish", new_callable=AsyncMock)
+
+    await driver_bookings.start_trip(booking.id, db=async_session)
+    await asyncio.sleep(0)
+
+    dispatch.assert_awaited_once()
+    call = dispatch.await_args_list[0]
+    assert call.kwargs["to_user_id"] == booking.customer_id
+    assert call.kwargs["to_role"] is UserRole.CUSTOMER
+    assert call.kwargs["notif_type"] is NotificationType.STARTED
+
+
+async def test_complete_booking_dispatch(async_session: AsyncSession, mocker) -> None:
+    booking = await _make_booking(async_session, BookingStatus.IN_PROGRESS)
+    booking.final_price_cents = 1000
+    dispatch = mocker.patch(
+        "app.services.notifications.dispatch_notification",
+        new_callable=AsyncMock,
+    )
+    mocker.patch(
+        "app.services.booking_service.complete_booking",
+        new_callable=AsyncMock,
+        return_value=booking,
+    )
+    mocker.patch("app.core.broadcast.broadcast.publish", new_callable=AsyncMock)
+
+    await driver_bookings.complete_booking(booking.id, db=async_session)
+    await asyncio.sleep(0)
+
+    dispatch.assert_awaited_once()
+    call = dispatch.await_args_list[0]
+    assert call.kwargs["to_user_id"] == booking.customer_id
+    assert call.kwargs["to_role"] is UserRole.CUSTOMER
+    assert call.kwargs["notif_type"] is NotificationType.COMPLETED

--- a/backend/tests/unit/services/test_scheduler.py
+++ b/backend/tests/unit/services/test_scheduler.py
@@ -1,14 +1,19 @@
+import asyncio
 import uuid
 from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock
 
 import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
 from app.core.security import hash_password
 from app.models.booking import Booking, BookingStatus
 from app.models.notification import Notification, NotificationRole, NotificationType
+from app.models.settings import AdminConfig
 from app.models.user_v2 import User, UserRole
+from app.services import settings_service
 from app.services.scheduler import _leave_now_job
-from sqlalchemy import select
-from sqlalchemy.ext.asyncio import AsyncSession
 
 pytestmark = pytest.mark.asyncio
 
@@ -16,16 +21,37 @@ pytestmark = pytest.mark.asyncio
 async def test_leave_now_job_creates_notifications(
     async_session: AsyncSession, mocker
 ) -> None:
-    mocker.patch("app.services.notifications._send_onesignal", return_value=None)
+    dispatch = mocker.patch(
+        "app.services.notifications.dispatch_notification",
+        new_callable=AsyncMock,
+    )
 
+    driver = User(
+        email=f"driver{uuid.uuid4().hex}@example.com",
+        full_name="Driver",
+        hashed_password=hash_password("pass"),
+        role=UserRole.DRIVER,
+    )
     customer = User(
         email=f"test{uuid.uuid4().hex}@example.com",
         full_name="Test",
         hashed_password=hash_password("pass"),
         role=UserRole.CUSTOMER,
     )
-    async_session.add(customer)
+    async_session.add_all([driver, customer])
     await async_session.flush()
+    settings_service._cached_admin_user_id = None
+    await async_session.merge(
+        AdminConfig(
+            id=1,
+            account_mode=False,
+            flagfall=0,
+            per_km_rate=0,
+            per_minute_rate=0,
+            admin_user_id=driver.id,
+        )
+    )
+    await async_session.commit()
 
     booking = Booking(
         public_code=uuid.uuid4().hex[:6].upper(),
@@ -47,6 +73,7 @@ async def test_leave_now_job_creates_notifications(
     await async_session.commit()
 
     await _leave_now_job(booking.id)
+    await asyncio.sleep(0)
 
     await async_session.refresh(booking)
     assert booking.status is BookingStatus.ON_THE_WAY
@@ -59,3 +86,20 @@ async def test_leave_now_job_creates_notifications(
     roles_types = {(n.type, n.to_role) for n in notes}
     assert (NotificationType.LEAVE_NOW, NotificationRole.DRIVER) in roles_types
     assert (NotificationType.ON_THE_WAY, NotificationRole.CUSTOMER) in roles_types
+    assert all(n.to_user_id for n in notes)
+
+    assert dispatch.await_count == 2
+    driver_call = next(
+        call
+        for call in dispatch.await_args_list
+        if call.kwargs["to_role"] is UserRole.DRIVER
+        and call.kwargs["notif_type"] is NotificationType.LEAVE_NOW
+    )
+    assert driver_call.kwargs["to_user_id"] == driver.id
+    customer_call = next(
+        call
+        for call in dispatch.await_args_list
+        if call.kwargs["to_role"] is UserRole.CUSTOMER
+        and call.kwargs["notif_type"] is NotificationType.ON_THE_WAY
+    )
+    assert customer_call.kwargs["to_user_id"] == booking.customer_id


### PR DESCRIPTION
## Summary
- add per-recipient notification metadata and migration so rows capture the user id while dispatch waits for the transaction commit
- refactor the notification service to look up each target user's OneSignal player id and invoke delivery, wiring driver, scheduler, and websocket flows to supply the destination id
- expand unit coverage to ensure every notification path schedules dispatch and to exercise the targeted send logic

## Testing
- pytest tests/unit/services/test_notifications.py tests/unit/services/test_scheduler.py tests/unit/api/test_booking_ws.py tests/unit/api/test_driver_bookings_notifications.py -q

------
https://chatgpt.com/codex/tasks/task_e_68cc926759b08331a824c8dffb4c5ee0