### PR TITLE
test: stabilize tracking page async assertions

### DIFF
--- a/frontend/src/pages/TrackingPage.test.tsx
+++ b/frontend/src/pages/TrackingPage.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { vi } from 'vitest';
 import type { LocationUpdate } from '@/hooks/useBookingChannel';
@@ -200,21 +200,23 @@ describe('TrackingPage', () => {
           ws_url: '',
         }),
     } as Response);
-    render(
-      <MemoryRouter initialEntries={['/t/abc']}>
-        <Routes>
-          <Route path="/t/:code" element={<TrackingPage />} />
-        </Routes>
-      </MemoryRouter>,
-    );
-    await new Promise((r) => setTimeout(r, 0));
-    await waitFor(() =>
-      expect(screen.getByTestId('dropoff-marker')).toBeInTheDocument(),
-    );
+    await act(async () => {
+      render(
+        <MemoryRouter initialEntries={['/t/abc']}>
+          <Routes>
+            <Route path="/t/:code" element={<TrackingPage />} />
+          </Routes>
+        </MemoryRouter>,
+      );
+    });
+    await screen.findByTestId('dropoff-marker');
     expect(screen.getByTestId('dropoff-marker')).toHaveAttribute(
       'data-icon',
       dropoffIcon,
     );
+    await screen.findByText('ETA: 10 min');
+    await screen.findByTestId('route');
+    await waitFor(() => expect(mockMap.fitBounds).toHaveBeenCalled());
   });
 
   it('sets zoom to 12 when distance is greater than 5 km', async () => {


### PR DESCRIPTION
## Summary
- import `act` into the tracking page test and wrap the render to properly flush updates
- wait for the drop-off marker via `findByTestId` and ensure downstream async UI (ETA, route, fitBounds) settles before finishing the test

## Testing
- npx vitest run src/pages/TrackingPage.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68cc95a49b208331b92147254a4fe62f