### PR TITLE
fix: build hourly slots with local dates

### DIFF
--- a/frontend/src/lib/availabilityUtils.ts
+++ b/frontend/src/lib/availabilityUtils.ts
@@ -70,14 +70,15 @@ export function calculateHourlyAvailability(
     : [];
 
   return Array.from({ length: 24 }).map((_, h) => {
-    const startMs = Date.UTC(year, monthIndex, dayOfMonth, h, 0, 0, 0);
+    const start = new Date(year, monthIndex, dayOfMonth, h, 0, 0, 0);
+    const startMs = start.getTime();
     const endMs = startMs + 60 * 60 * 1000;
     const disabled =
       bookingWindows.some((b) => b.startMs < endMs && b.endMs > startMs) ||
       slotWindows.some((s) => s.startMs < endMs && s.endMs > startMs);
     return {
       label: `${String(h).padStart(2, '0')}:00`,
-      iso: new Date(startMs).toISOString(),
+      iso: start.toISOString(),
       disabled,
     };
   });


### PR DESCRIPTION
## Summary
- create hourly slot start times using local Date instances so comparisons match the user's selection
- derive milliseconds and ISO strings from the local start time to preserve user intent

## Testing
- npx vitest run src/__tests__/BookingWizard.test.tsx src/pages/Booking/BookingWizardPage.test.tsx >/tmp/vitest.log 2>&1

------
https://chatgpt.com/codex/tasks/task_e_68cc9915dc308331b4ea9f6eefcb33e4