### PR TITLE
fix: prevent duplicate onesignal login

### DIFF
--- a/frontend/src/services/push.test.ts
+++ b/frontend/src/services/push.test.ts
@@ -178,4 +178,13 @@ describe('services/push subscription change handling', () => {
     expect(addTagMock).toHaveBeenCalledWith('opted_in', 'true');
     expect(addTagMock).not.toHaveBeenCalledWith('empty', expect.anything());
   });
+
+  it('logs in exactly once when subscribing with a new external ID', async () => {
+    await subscribePushFn({
+      externalId: 'fresh-user',
+    });
+
+    expect(loginMock).toHaveBeenCalledTimes(1);
+    expect(loginMock).toHaveBeenCalledWith('fresh-user');
+  });
 });


### PR DESCRIPTION
## Summary
- avoid duplicate OneSignal logins by deferring external ID assignment until after initialization and tracking the last linked ID
- ensure logout and test reset clear OneSignal linking state
- add a unit test covering the single-login subscribe flow

## Testing
- npx vitest run src/services/push.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68cc9c7d3b8483319065171d30204e08