### PR TITLE
fix: normalize hourly availability labels

### DIFF
--- a/frontend/src/__tests__/DayTimeline.test.tsx
+++ b/frontend/src/__tests__/DayTimeline.test.tsx
@@ -3,7 +3,10 @@ import userEvent from '@testing-library/user-event';
 import { describe, it, expect, vi } from 'vitest';
 import { renderWithProviders } from '@/__tests__/setup/renderWithProviders';
 import DayTimeline from '@/components/BookingWizard/DayTimeline';
-import { calculateHourlyAvailability } from '@/lib/availabilityUtils';
+import {
+  calculateHourlyAvailability,
+  formatSlotLabel,
+} from '@/lib/availabilityUtils';
 
 describe('DayTimeline', () => {
   it('disables unavailable hours and emits selection', async () => {
@@ -19,14 +22,16 @@ describe('DayTimeline', () => {
     renderWithProviders(
       <DayTimeline slots={slots} onSelect={onSelect} />,
     );
-    expect(screen.getByRole('button', { name: '05:00' })).toBeDisabled();
-    expect(screen.getByRole('button', { name: '10:00' })).toBeDisabled();
-    expect(screen.getByRole('button', { name: '15:00' })).toBeDisabled();
-    expect(screen.getByRole('button', { name: '16:00' })).toBeDisabled();
-    const eleven = screen.getByRole('button', { name: '11:00' });
+    const labelForHour = (hour: number) =>
+      formatSlotLabel(new Date(Date.UTC(2025, 0, 1, hour, 0, 0, 0)));
+    expect(screen.getByRole('button', { name: labelForHour(5) })).toBeDisabled();
+    expect(screen.getByRole('button', { name: labelForHour(10) })).toBeDisabled();
+    expect(screen.getByRole('button', { name: labelForHour(15) })).toBeDisabled();
+    expect(screen.getByRole('button', { name: labelForHour(16) })).toBeDisabled();
+    const eleven = screen.getByRole('button', { name: labelForHour(11) });
     expect(eleven).toBeEnabled();
     await userEvent.click(eleven);
-    const expectedIso = '2025-01-01T11:00:00.000Z';
+    const expectedIso = new Date(Date.UTC(2025, 0, 1, 11, 0, 0, 0)).toISOString();
     expect(onSelect).toHaveBeenCalledWith(expectedIso);
     const [[selectedIso]] = onSelect.mock.calls;
     expect(selectedIso).toBe(expectedIso);

--- a/frontend/src/components/BookingWizard/TripDetails.test.tsx
+++ b/frontend/src/components/BookingWizard/TripDetails.test.tsx
@@ -28,6 +28,7 @@ import type { AvailabilityResponse } from '@/api-client';
 import TripDetails from './TripDetails';
 import type { BookingFormData } from '@/types/BookingFormData';
 import useAvailability from '@/hooks/useAvailability';
+import { formatSlotLabel } from '@/lib/availabilityUtils';
 
 describe('TripDetails', () => {
   const useAvailabilityMock = vi.mocked(useAvailability);
@@ -53,11 +54,18 @@ describe('TripDetails', () => {
 
     renderWithProviders(<TripDetails data={data} onChange={onChange} />);
 
-    expect(await screen.findByRole('button', { name: '05:00' })).toBeDisabled();
+    const labelForHour = (hour: number) =>
+      formatSlotLabel(new Date(Date.UTC(2025, 0, 1, hour, 0, 0, 0)));
+
+    expect(
+      await screen.findByRole('button', { name: labelForHour(5) }),
+    ).toBeDisabled();
     expect(screen.getByText('Time unavailable')).toBeInTheDocument();
 
-    const eleven = screen.getByRole('button', { name: '11:00' });
+    const eleven = screen.getByRole('button', { name: labelForHour(11) });
     await userEvent.click(eleven);
-    expect(onChange).toHaveBeenCalledWith({ pickup_when: '2025-01-01T11:00:00.000Z' });
+    expect(onChange).toHaveBeenCalledWith({
+      pickup_when: new Date(Date.UTC(2025, 0, 1, 11, 0, 0, 0)).toISOString(),
+    });
   });
 });

--- a/frontend/src/lib/availabilityUtils.test.ts
+++ b/frontend/src/lib/availabilityUtils.test.ts
@@ -3,6 +3,7 @@ import type { AvailabilityResponse } from '@/api-client';
 import {
   summarizeMonthlyAvailability,
   calculateHourlyAvailability,
+  formatSlotLabel,
 } from './availabilityUtils';
 
 describe('availabilityUtils', () => {
@@ -28,15 +29,20 @@ describe('availabilityUtils', () => {
     expect(hours[11].disabled).toBe(false);
   });
 
-  it('produces stable UTC labels and iso timestamps', () => {
+  const isoForHour = (hour: number) =>
+    new Date(Date.UTC(2025, 0, 1, hour, 0, 0, 0)).toISOString();
+  const labelForHour = (hour: number) =>
+    formatSlotLabel(new Date(isoForHour(hour)));
+
+  it('produces UTC iso timestamps with localized labels', () => {
     const hours = calculateHourlyAvailability(availability, '2025-01-01');
     expect(hours[0]).toMatchObject({
-      label: '00:00',
-      iso: '2025-01-01T00:00:00.000Z',
+      label: labelForHour(0),
+      iso: isoForHour(0),
     });
     expect(hours[5]).toMatchObject({
-      label: '05:00',
-      iso: '2025-01-01T05:00:00.000Z',
+      label: labelForHour(5),
+      iso: isoForHour(5),
       disabled: true,
     });
   });

--- a/frontend/src/lib/availabilityUtils.ts
+++ b/frontend/src/lib/availabilityUtils.ts
@@ -46,6 +46,16 @@ export interface HourlyAvailabilitySlot {
   disabled: boolean;
 }
 
+const slotLabelFormatter = new Intl.DateTimeFormat(undefined, {
+  hour: '2-digit',
+  minute: '2-digit',
+  hour12: false,
+});
+
+export function formatSlotLabel(date: Date): string {
+  return slotLabelFormatter.format(date);
+}
+
 export function calculateHourlyAvailability(
   availability: AvailabilityResponse | null,
   date: string,
@@ -70,14 +80,14 @@ export function calculateHourlyAvailability(
     : [];
 
   return Array.from({ length: 24 }).map((_, h) => {
-    const start = new Date(year, monthIndex, dayOfMonth, h, 0, 0, 0);
-    const startMs = start.getTime();
+    const startMs = Date.UTC(year, monthIndex, dayOfMonth, h, 0, 0, 0);
+    const start = new Date(startMs);
     const endMs = startMs + 60 * 60 * 1000;
     const disabled =
       bookingWindows.some((b) => b.startMs < endMs && b.endMs > startMs) ||
       slotWindows.some((s) => s.startMs < endMs && s.endMs > startMs);
     return {
-      label: `${String(h).padStart(2, '0')}:00`,
+      label: formatSlotLabel(start),
       iso: start.toISOString(),
       disabled,
     };


### PR DESCRIPTION
## Summary
- ensure hourly availability slots use UTC timestamps while formatting labels with Intl
- expose a shared formatter for localized labels and update affected tests to use it
- cover booking flow expectations with updated local labels and UTC payload assertions

## Testing
- npx vitest run src/lib/availabilityUtils.test.ts
- npx vitest run src/__tests__/DayTimeline.test.tsx
- npx vitest run src/components/BookingWizard/TripDetails.test.tsx
- npx vitest run src/pages/Booking/BookingWizardPage.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68cc9d5cbb988331a40eb7605ff0ea81