### PR TITLE
fix: skip redundant OneSignal relink

### DIFF
--- a/frontend/src/services/push.ts
+++ b/frontend/src/services/push.ts
@@ -89,6 +89,12 @@ async function relinkStoredExternalId(
 
   try {
     storedExternalId = externalId;
+    if (externalId === lastLinkedExternalId) {
+      logger.debug('services/push', 'Identity already linked; skipping login', {
+        externalId,
+      });
+      return;
+    }
     await sdk.login(externalId);
     lastLinkedExternalId = externalId;
     logger.debug('services/push', successMessage, { externalId });


### PR DESCRIPTION
## Summary
- avoid re-running OneSignal login when the stored identity is already linked
- log a debug message instead of attempting the login again

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cc9f7be68c8331bf00e11d99517e3d