### PR TITLE
fix: expose ride tracker as link

### DIFF
--- a/frontend/src/components/BookingWizard/BookingWizard.tsx
+++ b/frontend/src/components/BookingWizard/BookingWizard.tsx
@@ -93,6 +93,7 @@ export default function BookingWizard({
           component={RouterLink}
           to={`/t/${bookingData.public_code}`}
           variant="contained"
+          role="link"
         >
           Track this ride
         </Button>


### PR DESCRIPTION
## Summary
- ensure the booking confirmation call-to-action renders with link semantics for assistive tech

## Testing
- npx vitest run src/pages/Booking/BookingWizardPage.test.tsx


------
https://chatgpt.com/codex/tasks/task_e_68cca0ccc23c833199a43fe539591f7b